### PR TITLE
Fix issue that "void" response is treated as model

### DIFF
--- a/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
+++ b/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
@@ -319,10 +319,8 @@ public class SwaggerCompatConverter implements SwaggerParserExtension {
       else {
         if(obj.getRef() != null)
           output = new RefProperty(obj.getRef());
-        else if(type != null)
+        else if(type != null && !type.equals("void"))
           output = new RefProperty(type);
-        else
-          output = new RefProperty("void");
       }
     }
 


### PR DESCRIPTION
Fix issue that "void" response is treated as model when converting spec from v1.2 to v2.0.

See more at swagger-api/swagger-codegen#305