### PR TITLE
Fix NPE for the operations, which accept all methods

### DIFF
--- a/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
+++ b/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
@@ -478,7 +478,9 @@ public class SwaggerCompatConverter implements SwaggerParserExtension {
         }
         for(io.swagger.models.apideclaration.Operation op : ops) {
           Operation operation = convertOperation(tag, op);
-          path.set(op.getMethod().toString().toLowerCase(), operation);
+          String method = (op.getMethod() != null ?
+              op.getMethod().toString().toLowerCase() : "*");
+          path.set(method, operation);
         }
       }
 


### PR DESCRIPTION
In my REST application I have mapping, which serves as 404 page and it accepts all HTTP methods:
@RequestMapping(value=MISSING_CALL, produces=MediaType.APPLICATION_JSON_VALUE)

Parser cannot handle it properly:
Exception in thread "main" java.lang.NullPointerException
	at io.swagger.parser.SwaggerCompatConverter.convert(SwaggerCompatConverter.java:481)
	at io.swagger.parser.SwaggerCompatConverter.read(SwaggerCompatConverter.java:111)
	at io.swagger.parser.SwaggerParser.read(SwaggerParser.java:34)
	at com.wordnik.swagger.codegen.cmd.Generate.run(Generate.java:87)
	at com.wordnik.swagger.codegen.SwaggerCodegen.main(SwaggerCodegen.java:33)