### PR TITLE
If the spec file provides the basePath, use it.

### DIFF
--- a/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
+++ b/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
@@ -57,6 +57,12 @@ public class SwaggerCompatConverter implements SwaggerParserExtension {
     List<ApiDeclaration> apis = new ArrayList<ApiDeclaration>();
 
     if(resourceListing != null) {
+      String basePath = input;
+      JsonNode basePathNode = resourceListing.getExtraFields().get("basePath");
+      if (basePathNode != null)
+      {
+        basePath = basePathNode.textValue();
+      }
       List<ApiListingReference> refs = resourceListing.getApis();
       boolean readAsSingleFile = false;
       if(refs != null) {
@@ -82,9 +88,9 @@ public class SwaggerCompatConverter implements SwaggerParserExtension {
               }
               else {
                 if(pathLocation.startsWith("/"))
-                  location = input + pathLocation;
+                  location = basePath + pathLocation;
                 else
-                  location = input + "/" + pathLocation;
+                  location = basePath + "/" + pathLocation;
               }
             }
             else {


### PR DESCRIPTION
The Swagger spec includes a basePath field:

https://github.com/swagger-api/swagger-core/wiki/API-Declaration/e22da2fb334170c7676cdde6e89b966e7604de13

The basePath could be different than the location of the API spec file, which will cause the parser to fail. This commit fixes that by using the basePath if it is provided and falling back to the spec file location if it is not.