### PR TITLE
When loading from the classpath look in more than one place

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/ClasspathHelper.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/ClasspathHelper.java
@@ -10,7 +10,11 @@ public class ClasspathHelper {
 
     public static String loadFileFromClasspath(String location) {
 
-        InputStream inputStream = ClassLoader.getSystemResourceAsStream(location);
+        InputStream inputStream = ClasspathHelper.class.getResourceAsStream(location);
+
+        if(inputStream == null) {
+            inputStream = ClassLoader.getSystemResourceAsStream(location);
+        }
 
         if(inputStream != null) {
             try {


### PR DESCRIPTION
I gave my new classpath loading a whirl when deployed in Tomcat and the ClasspathHelper did not find the swagger.json in WEB-INF/classes inside my war. 

After some googling I ran across this [this](http://stackoverflow.com/questions/7615040/difference-between-classloader-getsystemresourceasstream-and-getclass-getresou) stack overflow article. Where they describe that in a web app world the classloader situation is more complicated.

So my solution is to change the code try looking for the resource in two places.