### PR TITLE
Parent directory fix

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/ResolverCache.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/ResolverCache.java
@@ -6,6 +6,7 @@ import io.swagger.models.auth.AuthorizationValue;
 import io.swagger.models.refs.RefConstants;
 import io.swagger.models.refs.RefFormat;
 import io.swagger.parser.util.DeserializationUtils;
+import io.swagger.parser.util.PathUtils;
 import io.swagger.parser.util.RefUtils;
 
 import java.io.File;
@@ -50,8 +51,7 @@ public class ResolverCache {
             if(parentFileLocation.startsWith("http")) {
                 parentDirectory = null;
             } else {
-                final Path path = Paths.get(parentFileLocation);
-                parentDirectory = path.getParent();
+                parentDirectory = PathUtils.getParentDirectoryOfFile(parentFileLocation);
             }
         } else {
             File file = new File(".");

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/PathUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/PathUtils.java
@@ -1,0 +1,12 @@
+package io.swagger.parser.util;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class PathUtils {
+
+    public static Path getParentDirectoryOfFile(String fileStr) {
+        Path file = Paths.get(fileStr).toAbsolutePath();
+        return file.toAbsolutePath().getParent();
+    }
+}

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/PathUtilTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/PathUtilTest.java
@@ -1,0 +1,20 @@
+package io.swagger.parser.util;
+
+import org.testng.annotations.Test;
+
+import java.nio.file.Paths;
+
+import static org.testng.Assert.assertEquals;
+
+public class PathUtilTest {
+
+    @Test
+    public void testGetParentDirectoryOfFile() throws Exception {
+
+        final String actualResult = PathUtils.getParentDirectoryOfFile("src/test/resources/parent.json").toString();
+
+        final String execptedResult = Paths.get("src/test/resources").toAbsolutePath().toString();
+
+        assertEquals(actualResult, execptedResult);
+    }
+}


### PR DESCRIPTION
When I refactored SwaggerResolver I didn't test the following use case:

```java
new SwaggerParser().read("swagger.yaml");
```

The parsing works just fine but the parent directory was not being computed correctly. This causes problems when you try and reference another file via

```yaml
$ref: ./anotherFile.yaml
```

The resolving code would get a NPE when it tried to resolve the ref.

The fix is to take "swagger.yaml" get the absolute path and then get the parent directory.