### PR TITLE
Update JMockit to 1.19.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
         <junit-version>4.8.1</junit-version>
         <testng-version>6.9.6</testng-version>
         <scala-test-version>2.1.3</scala-test-version>
-        <jmockit-version>1.18</jmockit-version>
+        <jmockit-version>1.19</jmockit-version>
         <wiremock-version>1.57</wiremock-version>
         <surefire-version>2.18.1</surefire-version>
     </properties>


### PR DESCRIPTION
Analogously to [Pull Request #1161 of swagger-codegen](https://github.com/swagger-api/swagger-codegen/pull/1161), this fixes the build on OpenJDK on Linux.

Compared to [Issue #1160 there](https://github.com/swagger-api/swagger-codegen/issues/1160), here the problem shows by different error messages (because here we use JUnit and not TestNG, I guess).

I see once this:

```
java.lang.IllegalStateException: To run on OpenJDK 64-Bit Server VM use -javaagent:/home/paulo/.m2/repository/org/jmockit/jmockit/1.18/jmockit-1.18.jar
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at org.apache.maven.surefire.common.junit4.JUnit4Reflector.createRequest(JUnit4Reflector.java:63)
        at org.apache.maven.surefire.common.junit4.JUnit4ProviderUtil.createSuiteDescription(JUnit4ProviderUtil.java:113)
        at org.apache.maven.surefire.junit4.JUnit4Provider.createTestsDescription(JUnit4Provider.java:257)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
        at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
```
... and several times this:
```
initializationError(io.swagger.parser.util.RefUtilsTest)  Time elapsed: 0.011 sec  <<< ERROR!
java.lang.Exception: Method testReadExternalRef_UrlFormat_ExceptionThrown should have no parameters
        at org.junit.runners.model.FrameworkMethod.validatePublicVoidNoArg(FrameworkMethod.java:68)
        at org.junit.runners.ParentRunner.validatePublicVoidNoArgMethods(ParentRunner.java:122)
        at org.junit.runners.BlockJUnit4ClassRunner.validateTestMethods(BlockJUnit4ClassRunner.java:193)
        at org.junit.runners.BlockJUnit4ClassRunner.validateInstanceMethods(BlockJUnit4ClassRunner.java:168)
        at org.junit.runners.BlockJUnit4ClassRunner.collectInitializationErrors(BlockJUnit4ClassRunner.java:115)
        at org.junit.runners.ParentRunner.validate(ParentRunner.java:269)
        at org.junit.runners.ParentRunner.<init>(ParentRunner.java:66)
        at org.junit.runners.BlockJUnit4ClassRunner.<init>(BlockJUnit4ClassRunner.java:59)
        at org.junit.internal.builders.JUnit4Builder.runnerForClass(JUnit4Builder.java:13)
        at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:57)
        at org.junit.internal.builders.AllDefaultPossibilitiesBuilder.runnerForClass(AllDefaultPossibilitiesBuilder.java:29)
        at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:57)
        at org.junit.internal.requests.ClassRequest.getRunner(ClassRequest.java:24)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:283)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:173)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:128)
        at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
```

Updating the jmockit version to 1.19 seems to fix it.
**Please try it on other VMs before merging.**