### PR TITLE
URL encode path segments when getting remote swagger specs

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RemoteUrl.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RemoteUrl.java
@@ -164,13 +164,4 @@ public class RemoteUrl {
     static {
         disableSslVerification();
     }
-
-    public static void main(String[] args) {
-        try {
-            final String s = RemoteUrl.urlToString("https://tfsappqa.corp.intuit.net/creation/api-docs/v1/filingdata/{filingDataId}/taxitemtotals", null);
-            System.out.println(s);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
 }

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RemoteUrl.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RemoteUrl.java
@@ -1,6 +1,8 @@
 package io.swagger.parser.util;
 
 import io.swagger.models.auth.AuthorizationValue;
+import io.swagger.parser.SwaggerParser;
+
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -66,6 +68,30 @@ public class RemoteUrl {
         BufferedReader br = null;
 
         try {
+            final String[] protocolAndPath = url.split("://");
+            final StringBuilder urlEncodedUrl = new StringBuilder(protocolAndPath[0])
+                    .append("://");
+
+            final String[] pathSegments = protocolAndPath[1].split("/");
+
+            for (int i = 0; i < pathSegments.length; i++) {
+
+                String pathSegment = pathSegments[i];
+
+                //skip the hostname + port
+                if(i > 0) {
+                    pathSegment = URLEncoder.encode(pathSegment, "UTF-8");
+                }
+
+                urlEncodedUrl.append(pathSegment);
+
+                if(i < pathSegments.length - 1) {
+                    urlEncodedUrl.append("/");
+                }
+            }
+
+            //= split[0] + "://" + URLEncoder.encode(split[1], "UTF-8");
+
             if (auths != null) {
                 StringBuilder queryString = new StringBuilder();
                 // build a new url if needed
@@ -82,9 +108,9 @@ public class RemoteUrl {
                     }
                 }
                 if (queryString.toString().length() != 0) {
-                    url = url + queryString.toString();
+                    urlEncodedUrl.append(queryString.toString());
                 }
-                conn = new URL(url).openConnection();
+                conn = new URL(urlEncodedUrl.toString()).openConnection();
 
                 for (AuthorizationValue auth : auths) {
                     if ("header".equals(auth.getType())) {
@@ -92,7 +118,7 @@ public class RemoteUrl {
                     }
                 }
             } else {
-                conn = new URL(url).openConnection();
+                conn = new URL(urlEncodedUrl.toString()).openConnection();
             }
 
             conn.setRequestProperty("Accept", ACCEPT_HEADER_VALUE);
@@ -137,5 +163,14 @@ public class RemoteUrl {
 
     static {
         disableSslVerification();
+    }
+
+    public static void main(String[] args) {
+        try {
+            final String s = RemoteUrl.urlToString("https://tfsappqa.corp.intuit.net/creation/api-docs/v1/filingdata/{filingDataId}/taxitemtotals", null);
+            System.out.println(s);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/RemoteUrlTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/RemoteUrlTest.java
@@ -100,6 +100,28 @@ public class RemoteUrlTest {
         );
     }
 
+    @Test
+    public void testGetRemoteUrlWithCharactersInPathThatShouldBeEncoded() throws Exception {
+
+        final String expectedBody = "a really good body";
+
+        stubFor(get(urlPathEqualTo("/v2/pet/%7Bid%7D"))
+
+                        .willReturn(aResponse()
+                                .withBody(expectedBody)
+                                .withHeader("Content-Type", "application/json"))
+        );
+
+        final String actualBody = RemoteUrl.urlToString("http://localhost:" + WIRE_MOCK_PORT + "/v2/pet/{id}", null);
+
+        assertEquals(actualBody, expectedBody);
+
+        verify(getRequestedFor(urlPathEqualTo("/v2/pet/%7Bid%7D"))
+                        .withHeader("Accept", equalTo(EXPECTED_ACCEPTS_HEADER))
+        );
+
+    }
+
     private String setupStub() {
         final String expectedBody = "a really good body";
         stubFor(get(urlEqualTo("/v2/pet/1"))


### PR DESCRIPTION
Today I came across an interesting use case that broke SwaggerParser's RemoteUrl class.

Given this example swagger 1.2 spec:
```
{
"apiVersion": "1.0.0",
"swaggerVersion": "1.2",
"apis": [
  {
    "path": "/v1/things"
  }
  {
    "path": "/v1/things/{thingId}/widgets"
  }]
}
```

RemoteUrl would get a 400 when it tried to get access: http://hostname.com/v1/things/{thingId}/widgets because the "{" and "}" characters were not url encoded. 

If you take the URL and pop it into chrome, Chrome automatically encodes the "{" and "}" characters and goes along its merry way.

I added some logic to RemoteUrl to split apart the url and only encode the path segments (e.g. ignore the  "http://hostname:port" part of the URL. 
