### PR TITLE
HTTP 400 when following URLs with path parameters in swagger doc

### DIFF
--- a/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
+++ b/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
@@ -1,5 +1,4 @@
 package io.swagger.parser;
-
 import io.swagger.models.ArrayModel;
 import io.swagger.models.AuthorizationScope;
 import io.swagger.models.Contact;
@@ -467,7 +466,7 @@ public class SwaggerCompatConverter implements SwaggerParserExtension {
         try {
             JsonNode jsonNode = null;
             if (input.startsWith("http")) {
-                String json = RemoteUrl.urlToString(input, auths);
+                String json = RemoteUrl.urlToString( RemoteUrl.encodePathParameters(input), auths);
                 jsonNode = Json.mapper().readTree(json);
             } else {
                 jsonNode = Json.mapper().readTree(new java.io.File(input));

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/RemoteUrlEncodeTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/RemoteUrlEncodeTest.java
@@ -1,0 +1,86 @@
+package io.swagger.parser.util;
+
+import static org.junit.Assert.*;
+import static org.testng.Assert.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+
+import org.junit.Test;
+
+public class RemoteUrlEncodeTest {
+
+    static final String noparams = "http://localhost:8080/v1/api/thing";
+    static final String withparams = "http://localhost:8080/v1/api/{thing}";
+    static final String trailingslash = "http://localhost:8080/v1/api/thing/";
+    static final String nopath = "http://localhost:8080/";
+    static final String nopathnoslash = "http://localhost:8080";
+    static final String noparamswargs = "http://localhost:8080/v1/api/thing?arg=0";
+    static final String withparamswargs = "http://localhost:8080/v1/api/{thing}?arg";
+    static final String withhashpathparam = "http://localhost:8080/v1/api/thing#foo/bar";
+    static final String nopathwargs = "http://localhost:8080/";
+    static final String nopathnoslashwargs = "http://localhost:8080";
+    static final String malformed="http://{localhost}:8080/path/part/{param}/operation";
+    static final String alreadyencoded = "http://localhost:8080/v1/api/%7Bthing%7D";
+
+	@Test(expected = Exception.class)
+	public void testRaisesMalformedURL() throws Exception {
+		RemoteUrl.urlToString(malformed, null);
+	}
+
+	@Test
+	public void testEncode_noparams() throws Exception {
+		assertEquals(RemoteUrl.encodePathParameters(noparams), noparams);
+	}
+
+	@Test
+	public void testEncode_withparams() throws Exception {
+		assertEquals(RemoteUrl.encodePathParameters(withparams), "http://localhost:8080/v1/api/%7Bthing%7D");
+	}
+
+	@Test
+	public void testEncode_trailingslash() throws Exception {
+		assertEquals(RemoteUrl.encodePathParameters(trailingslash), trailingslash);
+	}
+
+	@Test
+	public void testEncode_nopath() throws Exception {
+		assertEquals(RemoteUrl.encodePathParameters(nopath), nopath);
+	}
+
+	@Test
+	public void testEncode_nopathnoslash() throws Exception {
+		assertEquals(RemoteUrl.encodePathParameters(nopathnoslash), nopathnoslash);
+	}
+
+	@Test
+	public void testEncode_noparamswargs() throws Exception {
+		assertEquals(RemoteUrl.encodePathParameters(noparamswargs), noparamswargs);
+	}
+
+	@Test
+	public void testEncode_withparamswargs() throws Exception {
+		assertEquals(RemoteUrl.encodePathParameters(withparamswargs), "http://localhost:8080/v1/api/%7Bthing%7D?arg");
+	}
+
+	@Test
+	public void testEncode_nopathwargs() throws Exception {
+		assertEquals(RemoteUrl.encodePathParameters(nopathwargs), nopathwargs);
+	}
+
+	@Test
+	public void testEncode_alreadyencoded() throws Exception {
+		assertEquals( RemoteUrl.encodePathParameters(alreadyencoded),alreadyencoded);
+	}
+	
+	@Test
+	public void testEncode_nopathnoslashwargs() throws Exception {
+		assertEquals(RemoteUrl.encodePathParameters(nopathnoslashwargs), nopathnoslashwargs);
+	}
+
+	@Test(expected=Exception.class)
+	public void testEncode_malformed() throws Exception {
+		assertEquals(RemoteUrl.encodePathParameters(malformed), "http://{localhost}:8080/path/part/%7Bparam%7D/op" );
+	}    
+
+}

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/RemoteUrlTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/RemoteUrlTest.java
@@ -3,12 +3,11 @@ package io.swagger.parser.util;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import io.swagger.models.auth.AuthorizationValue;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.net.MalformedURLException;
 import java.util.Arrays;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -42,34 +41,47 @@ public class RemoteUrlTest {
 
     @Test
     public void testReadARemoteUrl() throws Exception {
+    	final String path = "/v2/pet/1";
+        final String expectedBody = setupStub(path);
 
-        final String expectedBody = setupStub();
-
-        final String actualBody = RemoteUrl.urlToString(getUrl(), null);
+        final String actualBody = RemoteUrl.urlToString(getUrl(path), null);
         assertEquals(actualBody, expectedBody);
 
-        verify(getRequestedFor(urlEqualTo("/v2/pet/1"))
+        verify(getRequestedFor(urlEqualTo(path))
                 .withHeader("Accept", equalTo(EXPECTED_ACCEPTS_HEADER)));
 
     }
 
-    private String getUrl() {
-        return "http://localhost:" + WIRE_MOCK_PORT + "/v2/pet/1";
+    private String getUrl(String path) {
+        return "http://localhost:" + WIRE_MOCK_PORT + path;
     }
+
+	@Test
+	public void testParameterizedPathDoesNotThrow() throws Exception {
+		final String path= "/v2/pet/1/{param}/2";
+		final String encodedPath =  "/v2/pet/1/%7Bparam%7D/2";
+		final String expectedBody = setupStub( encodedPath );
+		
+		final String actualBody = RemoteUrl.urlToString( getUrl(path), null);
+		assertEquals( actualBody, expectedBody );
+
+		verify(getRequestedFor(urlEqualTo(encodedPath))
+                .withHeader("Accept", equalTo(EXPECTED_ACCEPTS_HEADER)));
+	}
 
     @Test
     public void testAuthorizationHeader() throws Exception {
-
-        final String expectedBody = setupStub();
+        final String path= "/v2/pet/1";
+        final String expectedBody = setupStub(path);
 
         final String headerName = "Authorization";
         final String headerValue = "foobar";
         final AuthorizationValue authorizationValue = new AuthorizationValue(headerName, headerValue, "header");
-        final String actualBody = RemoteUrl.urlToString(getUrl(), Arrays.asList(authorizationValue));
+        final String actualBody = RemoteUrl.urlToString(getUrl(path), Arrays.asList(authorizationValue));
 
         assertEquals(actualBody, expectedBody);
 
-        verify(getRequestedFor(urlEqualTo("/v2/pet/1"))
+        verify(getRequestedFor(urlEqualTo(path))
                         .withHeader("Accept", equalTo(EXPECTED_ACCEPTS_HEADER))
                         .withHeader(headerName, equalTo(headerValue))
         );
@@ -80,8 +92,9 @@ public class RemoteUrlTest {
         final String queryParamName = "Authorization";
         final String queryParamValue = "foobar";
         final String expectedBody = "a really good body";
+        final String path = "/v2/pet/1";
 
-        stubFor(get(urlPathEqualTo("/v2/pet/1"))
+        stubFor(get(urlPathEqualTo(path))
                         .withQueryParam(queryParamName, equalTo(queryParamValue))
                         .willReturn(aResponse()
                                 .withBody(expectedBody)
@@ -90,19 +103,19 @@ public class RemoteUrlTest {
         );
 
         final AuthorizationValue authorizationValue = new AuthorizationValue(queryParamName, queryParamValue, "query");
-        final String actualBody = RemoteUrl.urlToString(getUrl(), Arrays.asList(authorizationValue));
+        final String actualBody = RemoteUrl.urlToString(getUrl(path), Arrays.asList(authorizationValue));
 
         assertEquals(actualBody, expectedBody);
 
-        verify(getRequestedFor(urlPathEqualTo("/v2/pet/1"))
+        verify(getRequestedFor(urlPathEqualTo(path))
                         .withHeader("Accept", equalTo(EXPECTED_ACCEPTS_HEADER))
                         .withQueryParam(queryParamName, equalTo(queryParamValue))
         );
     }
 
-    private String setupStub() {
+    private String setupStub( String path) {
         final String expectedBody = "a really good body";
-        stubFor(get(urlEqualTo("/v2/pet/1"))
+        stubFor(get(urlEqualTo(path))
                 .willReturn(aResponse()
                                 .withBody(expectedBody)
                                 .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
https://github.com/swagger-api/swagger-parser/issues/93

Filters path elements for path parameters and URL encodes the braces.
Each token has to be decoded to avoid re-encoding an already encoded url.
