### PR TITLE
Use BasicAuthDefinition for basic securityScheme

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -52,6 +52,7 @@ import io.swagger.models.Swagger;
 import io.swagger.models.Tag;
 import io.swagger.models.Xml;
 import io.swagger.models.auth.ApiKeyAuthDefinition;
+import io.swagger.models.auth.BasicAuthDefinition;
 import io.swagger.models.auth.In;
 import io.swagger.models.auth.OAuth2Definition;
 import io.swagger.models.auth.SecuritySchemeDefinition;
@@ -1101,7 +1102,7 @@ public class SwaggerDeserializer {
         if(type != null) {
             if(type.equals("basic")) {
                 // TODO: parse manually for better feedback
-                output = Json.mapper().convertValue(node, ApiKeyAuthDefinition.class);
+                output = Json.mapper().convertValue(node, BasicAuthDefinition.class);
             }
             else if (type.equals("apiKey")) {
                 String position = getString("in", node, true, location, result);

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.models.*;
 import io.swagger.models.auth.ApiKeyAuthDefinition;
+import io.swagger.models.auth.BasicAuthDefinition;
 import io.swagger.models.auth.In;
 import io.swagger.models.auth.SecuritySchemeDefinition;
 import io.swagger.models.properties.*;
@@ -183,6 +184,9 @@ public class SwaggerDeserializerTest {
         String json = "{\n" +
                 "  \"swagger\": \"2.0\",\n" +
                 "  \"securityDefinitions\": {\n" +
+                "    \"basic_auth\": {\n" +
+                "      \"type\": \"basic\"\n" +
+                "    },\n" +
                 "    \"api_key\": {\n" +
                 "      \"type\": \"apiKey\",\n" +
                 "      \"name\": \"api_key\",\n" +
@@ -194,6 +198,7 @@ public class SwaggerDeserializerTest {
                 "      \"get\": {\n" +
                 "        \"security\": [\n" +
                 "          {\n" +
+                "            \"basic_auth\": [],\n" +
                 "            \"api_key\": []\n" +
                 "          }\n" +
                 "        ]\n" +
@@ -210,7 +215,14 @@ public class SwaggerDeserializerTest {
 
         Swagger swagger = result.getSwagger();
         assertNotNull(swagger.getSecurityDefinitions());
-        assertTrue(swagger.getSecurityDefinitions().keySet().size() == 1);
+        assertTrue(swagger.getSecurityDefinitions().keySet().size() == 2);
+
+        // Basic Authentication
+        SecuritySchemeDefinition definitionBasic = swagger.getSecurityDefinitions().get("basic_auth");
+        assertNotNull(definitionBasic);
+        assertTrue(definitionBasic instanceof BasicAuthDefinition);
+
+        // API Key Authentication
         SecuritySchemeDefinition definition = swagger.getSecurityDefinitions().get("api_key");
         assertNotNull(definition);
         assertTrue(definition instanceof ApiKeyAuthDefinition);


### PR DESCRIPTION
The parser was incorrectly mapping a BasicAuthentication SecurityScheme to ApiAuthentication. For instance with this fix proper java client is generated with support for Basic Auth:

`client/src/main/java/com/example/service/ApiClient.java`:
```java
  public ApiClient() {
    // Use ISO 8601 format for date and datetime.
    // See https://en.wikipedia.org/wiki/ISO_8601
    this.dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");

    // Use UTC as the default time zone.
    this.dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));

    // Set default User-Agent.
    setUserAgent("Java-Swagger");

    // Setup authentications (key: authentication name, value: authentication).
    authentications = new HashMap<String, Authentication>();
    authentications.put("hallo", new HttpBasicAuth());
    // Prevent the authentications from being modified.
    authentications = Collections.unmodifiableMap(authentications);
  }

```