### PR TITLE
SwaggerDeserializer support for RefResponse

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.NumericNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+
 import io.swagger.models.ArrayModel;
 import io.swagger.models.ComposedModel;
 import io.swagger.models.Contact;
@@ -46,6 +47,7 @@ import io.swagger.models.Operation;
 import io.swagger.models.Path;
 import io.swagger.models.RefModel;
 import io.swagger.models.RefPath;
+import io.swagger.models.RefResponse;
 import io.swagger.models.Response;
 import io.swagger.models.Scheme;
 import io.swagger.models.SecurityRequirement;
@@ -611,6 +613,10 @@ public class SwaggerDeserializer {
     public RefParameter refParameter(TextNode obj, String location, ParseResult result) {
         return new RefParameter(obj.asText());
     }
+    
+    public RefResponse refResponse(TextNode obj, String location, ParseResult result) {
+        return new RefResponse(obj.asText());
+    }
 
     public Path pathRef(TextNode ref, String location, ParseResult result) {
         RefPath output = new RefPath();
@@ -944,6 +950,16 @@ public class SwaggerDeserializer {
             return null;
 
         Response output = new Response();
+        JsonNode ref = node.get("$ref");
+        if(ref != null) {
+            if(ref.getNodeType().equals(JsonNodeType.STRING)) {
+                return refResponse((TextNode) ref, location, result);
+            }
+            else {
+                result.invalidType(location, "$ref", "string", node);
+                return null;
+            }
+        }
 
         String value = getString("description", node, true, location, result);
         output.description(value);

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
@@ -499,6 +499,37 @@ public class SwaggerDeserializerTest {
         assertTrue(scopes.contains("read:pets"));
         assertTrue(scopes.contains("write:pets"));
     }
+    
+    @Test
+    public void testPathsWithRefResponse() {
+        String json = "{\n" +
+                "  \"swagger\": \"2.0\",\n" +
+                "  \"paths\": {\n" +
+                "    \"/pet\": {\n" +
+                "      \"get\": {\n" +
+                "        \"responses\": {\n" +
+                "          \"200\": {\n" +
+                "            \"$ref\": \"#/responses/OK\"" +
+                "          }\n" +
+                "        }\n" +                
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        SwaggerParser parser = new SwaggerParser();
+
+        SwaggerDeserializationResult result = parser.readWithInfo(json);
+        Swagger swagger = result.getSwagger();
+
+        Path path = swagger.getPath("/pet");
+        assertNotNull(path);
+        Operation operation = path.getGet();
+        assertNotNull(operation);
+        assertTrue(operation.getResponses().containsKey("200"));
+        assertEquals(RefResponse.class,operation.getResponses().get("200").getClass());
+        RefResponse refResponse = (RefResponse)operation.getResponses().get("200");
+        assertEquals("#/responses/OK",refResponse.get$ref());
+    }
 
     @Test
     public void testArrayModelDefinition() {


### PR DESCRIPTION
Addresses #122 

Updated SwaggerDeserializer so that a RefResponse is returned when a $ref attribute is present in the Response json.

This follows a similar approach to what is currently implemented for Parameter and RefParameter.