### PR TITLE
Transform "void" response types

### DIFF
--- a/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
+++ b/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
@@ -437,15 +437,13 @@ public class SwaggerCompatConverter implements SwaggerParserExtension {
 
         // default response type
         Property responseProperty = propertyFromTypedObject(operation);
-        if (responseProperty != null) {
-            Response response = new Response()
-                    .description("success")
-                    .schema(responseProperty);
-            if (output.getResponses() == null) {
-                output.defaultResponse(response);
-            } else {
-                output.response(200, response);
-            }
+        Response response = new Response()
+                .description("success")
+                .schema(responseProperty);
+        if (output.getResponses() == null) {
+            output.defaultResponse(response);
+        } else {
+            output.response(200, response);
         }
 
         Map<String, List<AuthorizationScope>> auths = operation.getAuthorizations();

--- a/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
+++ b/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
@@ -442,7 +442,7 @@ public class SwaggerCompatConverter implements SwaggerParserExtension {
                 .schema(responseProperty);
         if (output.getResponses() == null) {
             output.defaultResponse(response);
-        } else {
+        } else if (responseProperty != null) {
             output.response(200, response);
         }
 

--- a/modules/swagger-compat-spec-parser/src/test/java/io/swagger/converter/LegacyConverterTest.java
+++ b/modules/swagger-compat-spec-parser/src/test/java/io/swagger/converter/LegacyConverterTest.java
@@ -130,7 +130,10 @@ public class LegacyConverterTest {
         for (Response item : path.getPost().getResponses().values()) {
             assertNull(item.getSchema());
         }
-        assertNull(path.getDelete().getResponses());
+        assertEquals(path.getDelete().getResponses().size(), 1);
+        assertEquals(path.getDelete().getResponses().containsKey("default"), true);
+        assertEquals(path.getDelete().getResponses().get("default").getDescription(), "success");
+
         final PathParameter id = (PathParameter) Iterables.find(path.getPatch().getParameters(),
                 new Predicate<Parameter>() {
 


### PR DESCRIPTION
This fixes #139.  It modifies conversion logic so that void response types will still result in a default response being created when converting to swagger 2.0.  Previously void response types would result in no responses attribute for the given operation and an invalid swagger 2.0.