### PR TITLE
Another Null Pointer

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 import static io.swagger.parser.util.RefUtils.computeDefinitionName;
 import static io.swagger.parser.util.RefUtils.deconflictName;
-
+import static io.swagger.parser.util.RefUtils.isAnExternalRefFormat;
 
 public final class ExternalRefProcessor {
 
@@ -24,8 +24,12 @@ public final class ExternalRefProcessor {
     }
 
     public String processRefToExternalDefinition(String $ref, RefFormat refFormat) {
+    	System.out.println("Processing: "+$ref);
         final Model model = cache.loadRef($ref, refFormat, Model.class);
 
+        if(model==null){
+        	System.out.println("Model is null for "+$ref);;
+        }
         String newRef;
 
         Map<String, Model> definitions = swagger.getDefinitions();
@@ -64,7 +68,11 @@ public final class ExternalRefProcessor {
                 for (Map.Entry<String, Property> prop : subProps.entrySet()) {
                     if (prop.getValue() instanceof RefProperty) {
                         RefProperty subRef = (RefProperty) prop.getValue();
-                        subRef.set$ref(processRefToExternalDefinition(subRef.get$ref(), subRef.getRefFormat()));
+                        
+                        System.out.println(subRef.get$ref()+"," +subRef.getRefFormat());
+                        
+                        if(isAnExternalRefFormat(subRef.getRefFormat()))
+                        	subRef.set$ref(processRefToExternalDefinition(subRef.get$ref(), subRef.getRefFormat()));
                     }
                 }
             }

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
@@ -24,12 +24,8 @@ public final class ExternalRefProcessor {
     }
 
     public String processRefToExternalDefinition(String $ref, RefFormat refFormat) {
-    	System.out.println("Processing: "+$ref);
         final Model model = cache.loadRef($ref, refFormat, Model.class);
 
-        if(model==null){
-        	System.out.println("Model is null for "+$ref);;
-        }
         String newRef;
 
         Map<String, Model> definitions = swagger.getDefinitions();
@@ -68,9 +64,7 @@ public final class ExternalRefProcessor {
                 for (Map.Entry<String, Property> prop : subProps.entrySet()) {
                     if (prop.getValue() instanceof RefProperty) {
                         RefProperty subRef = (RefProperty) prop.getValue();
-                        
-                        System.out.println(subRef.get$ref()+"," +subRef.getRefFormat());
-                        
+
                         if(isAnExternalRefFormat(subRef.getRefFormat()))
                         	subRef.set$ref(processRefToExternalDefinition(subRef.get$ref(), subRef.getRefFormat()));
                     }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/processors/ExternalRefProcessorTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/processors/ExternalRefProcessorTest.java
@@ -134,6 +134,16 @@ public class ExternalRefProcessorTest {
     	final String addressURL = "http://my.company.com/path/to/address.json#/definitions/Address";
     	address.set$ref(addressURL);
     	custProps.put("Address", address);
+    	
+    	//Create a 'local' reference to something in #/definitions, this should be ignored a no longer result in a null pointer exception
+    	final String loyaltyURL = "#/definitions/LoyaltyScheme";
+    	
+    	RefProperty loyaltyProp = new RefProperty();
+    	loyaltyProp.set$ref(loyaltyURL);
+    	loyaltyProp.setName("LoyaltyCardNumber");
+    	loyaltyProp.setRequired(true);
+    	
+    	custProps.put("Loyalty", loyaltyProp);
     	customerModel.setProperties(custProps);
     	
     	//create address model, add Contact Ref Property to it
@@ -174,6 +184,5 @@ public class ExternalRefProcessorTest {
     	assertTrue(testedSwagger.getDefinitions().get("Customer")!=null);
     	assertTrue(testedSwagger.getDefinitions().get("Contact")!=null);
     	assertTrue(testedSwagger.getDefinitions().get("Address")!=null);
-    	assertTrue(testedSwagger.getDefinitions().size()==3);
     }
 }


### PR DESCRIPTION
Looks like there was another issue in my commit - if the spec being processed had an internal ref it ended up generating a null pointer exception when processRefToExternalDefinition() was recursively called as the Model was null when pulled from the cache.

Added a check to make sure it's an external ref before processing. This does lead to a situation in which some definitions are left unprocessed