### PR TITLE
Don't require properties attribute on schema definitions

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -662,7 +662,7 @@ public class SwaggerDeserializer {
             ExternalDocs docs = externalDocs(externalDocs, location, result);
             impl.setExternalDocs(docs);
 
-            ObjectNode properties = getObject("properties", node, true, location, result);
+            ObjectNode properties = getObject("properties", node, false, location, result);
             if(properties != null) {
                 Set<String> propertyNames = getKeys(properties);
                 for(String propertyName : propertyNames) {


### PR DESCRIPTION
Currently the following snippet is parsed as invalid with message "attribute definitions.CssColor.properties is missing".
```yaml
definitions:
  CssColor:
    pattern: ^#[0-9A-F]{6}$
    type: string
```

The `properties` attribute is not relevant for schemas that are not of `type: object`, and even for object schemas, the [JSON schema spec](http://json-schema.org/latest/json-schema-validation.html#anchor64) states that it can be missing and the default value is empty object.

This PR removes the requirement for the `properties` attribute.