### PR TITLE
Refs #169 - User agent in URLConnection used by Swagger20Parser.

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RemoteUrl.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RemoteUrl.java
@@ -21,6 +21,7 @@ import javax.net.ssl.X509TrustManager;
 public class RemoteUrl {
 
     private static final String ACCEPT_HEADER_VALUE = "application/json, application/yaml, */*";
+    private static final String USER_AGENT_HEADER_VALUE = "Apache-HttpClient/UNAVAILABLE";
 
     private static void disableSslVerification() {
         try {
@@ -96,6 +97,7 @@ public class RemoteUrl {
             }
 
             conn.setRequestProperty("Accept", ACCEPT_HEADER_VALUE);
+            conn.setRequestProperty("User-Agent", USER_AGENT_HEADER_VALUE);
             conn.connect();
             InputStream in = conn.getInputStream();
 

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RemoteUrl.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RemoteUrl.java
@@ -21,7 +21,7 @@ import javax.net.ssl.X509TrustManager;
 public class RemoteUrl {
 
     private static final String ACCEPT_HEADER_VALUE = "application/json, application/yaml, */*";
-    private static final String USER_AGENT_HEADER_VALUE = "Apache-HttpClient/UNAVAILABLE";
+    private static final String USER_AGENT_HEADER_VALUE = "Apache-HttpClient/Swagger";
 
     private static void disableSslVerification() {
         try {

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -74,6 +74,13 @@ public class SwaggerParserTest {
 
         assertNotNull(swagger.getPaths().get("/pets/{petId}").getGet());
     }
+
+    @Test
+    public void testIssue169() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("https://api.rocrooster.net/api-docs.json");
+        assertNotNull(swagger);
+    }
     
     @Test(description="Test (path & form) parameter's required attribute")
     public void testParameterRequired() {

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -75,13 +75,6 @@ public class SwaggerParserTest {
         assertNotNull(swagger.getPaths().get("/pets/{petId}").getGet());
     }
 
-    @Test
-    public void testIssue169() {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("https://api.rocrooster.net/api-docs.json");
-        assertNotNull(swagger);
-    }
-    
     @Test(description="Test (path & form) parameter's required attribute")
     public void testParameterRequired() {
         SwaggerParser parser = new SwaggerParser();


### PR DESCRIPTION
@fehguy 
Alternative approach for #169, possibly limited to the specific or similar issue (call to https://api.rocrooster.net/api-docs.json with server checking user agent) without adding deps; 

adds User-Agent header to RemoteUrl connection

tested with https://api.rocrooster.net/api-docs.json in https://github.com/frantuma/swagger-parser/commit/a4a1e8bb3dea8493a1fcaacaf2d97b590f13a08b, test removed because hitting external URL