### PR TITLE
Refs #146 - Yaml anchor refs parsing. Direct usage of snakeyaml

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/Swagger20Parser.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/Swagger20Parser.java
@@ -5,11 +5,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.models.Swagger;
 import io.swagger.models.auth.AuthorizationValue;
 import io.swagger.parser.util.ClasspathHelper;
+import io.swagger.parser.util.DeserializationUtils;
 import io.swagger.parser.util.RemoteUrl;
 import io.swagger.parser.util.SwaggerDeserializationResult;
 import io.swagger.parser.util.SwaggerDeserializer;
 import io.swagger.util.Json;
-import io.swagger.util.Yaml;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
@@ -56,13 +56,13 @@ public class Swagger20Parser implements SwaggerParserExtension {
                     data = ClasspathHelper.loadFileFromClasspath(location);
                 }
             }
-            ObjectMapper mapper;
+            JsonNode rootNode;
             if (data.trim().startsWith("{")) {
-                mapper = Json.mapper();
+                ObjectMapper mapper = Json.mapper();
+                rootNode = mapper.readTree(data);
             } else {
-                mapper = Yaml.mapper();
+                rootNode = DeserializationUtils.readYamlTree(data);
             }
-            JsonNode rootNode = mapper.readTree(data);
             return readWithInfo(rootNode);
         }
         catch (Exception e) {
@@ -106,13 +106,14 @@ public class Swagger20Parser implements SwaggerParserExtension {
 
     private Swagger convertToSwagger(String data) throws IOException {
         if (data != null) {
-            ObjectMapper mapper;
+            JsonNode rootNode;
             if (data.trim().startsWith("{")) {
-                mapper = Json.mapper();
+                ObjectMapper mapper = Json.mapper();
+                rootNode = mapper.readTree(data);
             } else {
-                mapper = Yaml.mapper();
+                rootNode = DeserializationUtils.readYamlTree(data);
             }
-            JsonNode rootNode = mapper.readTree(data);
+
             if (System.getProperty("debugParser") != null) {
                 LOGGER.info("\n\nSwagger Tree: \n"
                     + ReflectionToStringBuilder.toString(rootNode, ToStringStyle.MULTI_LINE_STYLE) + "\n\n");

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/SwaggerParser.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/SwaggerParser.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.models.Swagger;
 import io.swagger.models.auth.AuthorizationValue;
+import io.swagger.parser.util.DeserializationUtils;
 import io.swagger.parser.util.SwaggerDeserializationResult;
 import io.swagger.util.Json;
-import io.swagger.util.Yaml;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -88,15 +88,14 @@ public class SwaggerParser {
         if(swaggerAsString == null) {
             return new SwaggerDeserializationResult().message("empty or null swagger supplied");
         }
-        ObjectMapper mapper = null;
-        if(swaggerAsString.trim().startsWith("{")) {
-            mapper = Json.mapper();
-        }
-        else {
-            mapper = Yaml.mapper();
-        }
         try {
-            JsonNode node = mapper.readTree(swaggerAsString);
+            JsonNode node;
+            if (swaggerAsString.trim().startsWith("{")) {
+                ObjectMapper mapper = Json.mapper();
+                node = mapper.readTree(swaggerAsString);
+            } else {
+                node = DeserializationUtils.readYamlTree(swaggerAsString);
+            }
 
             SwaggerDeserializationResult result = new Swagger20Parser().readWithInfo(node);
             if (result != null) {

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/DeserializationUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/DeserializationUtils.java
@@ -16,7 +16,7 @@ public class DeserializationUtils {
 
         try {
             if (fileOrHost.endsWith(".yaml")) {
-                result = Yaml.mapper().readTree(contents);
+                result = readYamlTree(contents);
             } else {
                 result = Json.mapper().readTree(contents);
             }
@@ -31,16 +31,22 @@ public class DeserializationUtils {
         T result;
 
         ObjectMapper mapper;
+        boolean isYaml = false;
 
         if(fileOrHost.endsWith(".yaml")) {
             mapper = Yaml.mapper();
+            isYaml = true;
         } else {
             mapper = Json.mapper();
         }
 
         try {
             if (contents instanceof String) {
-                result = mapper.readValue((String) contents, expectedType);
+                if (isYaml) {
+                    result = readYamlValue((String) contents, expectedType);
+                } else {
+                    result = mapper.readValue((String) contents, expectedType);
+                }
             } else {
                 result = mapper.convertValue(contents, expectedType);
             }
@@ -49,5 +55,15 @@ public class DeserializationUtils {
         }
 
         return result;
+    }
+
+    public static JsonNode readYamlTree(String contents) {
+        org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml();
+        return Json.mapper().convertValue(yaml.load(contents), JsonNode.class);
+    }
+
+    public static <T> T readYamlValue(String contents, Class<T> expectedType) {
+        org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml();
+        return Json.mapper().convertValue(yaml.load(contents), expectedType);
     }
 }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -6,6 +6,7 @@ import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.ByteArrayProperty;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
 import io.swagger.parser.util.SwaggerDeserializationResult;
 import io.swagger.util.Json;
 import io.swagger.util.Yaml;
@@ -73,6 +74,16 @@ public class SwaggerParserTest {
         final Swagger swagger = parser.read("https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/fixtures/v2.0/json/resources/resourceWithLinkedDefinitions.json");
 
         assertNotNull(swagger.getPaths().get("/pets/{petId}").getGet());
+    }
+
+    @Test
+    public void testIssue146() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/issue_146.yaml");
+        assertNotNull(swagger);
+        QueryParameter p = ((QueryParameter)swagger.getPaths().get("/checker").getGet().getParameters().get(0));
+        StringProperty pp = (StringProperty)p.getItems();
+        assertTrue("registration".equalsIgnoreCase(pp.getEnum().get(0)));
     }
 
     @Test(description="Test (path & form) parameter's required attribute")

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/DeserializationUtilsTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/DeserializationUtilsTest.java
@@ -23,7 +23,7 @@ public class DeserializationUtilsTest {
 
 
     @Test
-    public void testDeserializeYamlIntoObject(@Mocked Yaml yaml,
+    public void testDeserializeYamlIntoObject(@Mocked Yaml yaml, @Mocked final org.yaml.snakeyaml.Yaml snakeYaml,
                                               @Injectable final ObjectMapper objectMapper,
                                               @Injectable final Model model) throws Exception {
 
@@ -34,7 +34,7 @@ public class DeserializationUtilsTest {
             Yaml.mapper();
             result = objectMapper;
             times = 1;
-            objectMapper.readValue(anyString, withAny(Object.class));
+            snakeYaml.load(anyString);
             times = 1;
             result = model;
         }};
@@ -111,17 +111,14 @@ public class DeserializationUtilsTest {
     }
 
     @Test
-    public void testDeserializeYamlIntoTree(@Mocked Yaml yaml,
+    public void testDeserializeYamlIntoTree(@Mocked Yaml yaml, @Mocked final org.yaml.snakeyaml.Yaml snakeYaml,
                                             @Injectable final ObjectMapper objectMapper,
                                             @Injectable final JsonNode jsonNode) throws Exception {
 
         String jsonStr = "really good yaml";
 
         new Expectations() {{
-            Yaml.mapper();
-            result = objectMapper;
-            times = 1;
-            objectMapper.readTree(anyString);
+            snakeYaml.load(anyString);
             result = jsonNode;
             times = 1;
         }};

--- a/modules/swagger-parser/src/test/resources/issue_146.yaml
+++ b/modules/swagger-parser/src/test/resources/issue_146.yaml
@@ -1,0 +1,32 @@
+swagger: '2.0'
+
+info:
+  version: "0.0.1"
+  title: API
+
+x-types:
+  OperationType: &OperationType
+    - registration
+
+# Describe your paths here
+paths:
+  /checker:
+    get:
+      parameters:
+        - name: operations
+          in: query
+          type: array
+          items:
+            type: string
+            enum: *OperationType
+          default: [registration]
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/OperationType'
+
+definitions:
+  OperationType:
+    type: string
+    enum: *OperationType


### PR DESCRIPTION
@fehguy refs #146, also related to https://github.com/swagger-api/swagger-codegen/issues/1662 and https://github.com/swagger-api/swagger-editor/issues/609

This solution introduces "direct" usage of snakeyaml, which handles correctly scenarios as in #146  example.

It updates YAML "data as string" reading, replacing jackson-dataformat-yaml custom streaming solution with a snakeyaml load of Object, then converted/read by Jackson into JSON, probably at the expenses of performance. 
