### PR TITLE
multiple code improvements 2

### DIFF
--- a/modules/swagger-compat-spec-parser/src/main/java/io/swagger/io/HttpClient.java
+++ b/modules/swagger-compat-spec-parser/src/main/java/io/swagger/io/HttpClient.java
@@ -5,6 +5,8 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class HttpClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpClient.class);
     private String baseUrl;
     private Map<String, String> queryParams = new HashMap<>();
     private Map<String, String> headers = new HashMap<>();
@@ -54,13 +57,13 @@ public class HttpClient {
         try {
             response.close();
         } catch (IOException | NullPointerException e) {
-            e.printStackTrace();
+            LOGGER.error("Exception while closing resource", e);
         }
 
         try {
             httpClient.close();
         } catch (IOException | NullPointerException e) {
-            e.printStackTrace();
+            LOGGER.error("Exception while closing resource", e);
         }
     }
 }

--- a/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
+++ b/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
@@ -30,7 +30,7 @@ import java.util.Map;
 // legacy models
 
 public class SwaggerCompatConverter implements SwaggerParserExtension {
-    static Logger LOGGER = LoggerFactory.getLogger(SwaggerCompatConverter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SwaggerCompatConverter.class);
 
     @Override
     public SwaggerDeserializationResult readWithInfo(JsonNode node) {
@@ -147,7 +147,7 @@ public class SwaggerCompatConverter implements SwaggerParserExtension {
         } catch (java.lang.IllegalArgumentException e) {
             return null;
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.error("Exception while execution", e);
         }
         return output;
     }
@@ -441,7 +441,7 @@ public class SwaggerCompatConverter implements SwaggerParserExtension {
         } catch (java.lang.IllegalArgumentException e) {
             return null;
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.error("Exception while execution", e);
         }
         return output;
     }

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/Swagger20Parser.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/Swagger20Parser.java
@@ -98,7 +98,7 @@ public class Swagger20Parser implements SwaggerParserExtension {
             return convertToSwagger(data);
         } catch (Exception e) {
             if (System.getProperty("debugParser") != null) {
-                e.printStackTrace();
+                LOGGER.error("Exception while execution", e);
             }
             return null;
         }

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/SwaggerParser.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/SwaggerParser.java
@@ -14,7 +14,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class SwaggerParser {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SwaggerParser.class);
+    private static final String I_O_EXCEPTION_HAS_OCCURRED = "I/O Exception of some sort has occurred";
 
     public SwaggerDeserializationResult readWithInfo(String location, List<AuthorizationValue> auths, boolean resolve) {
         if (location == null) {
@@ -76,7 +81,7 @@ public class SwaggerParser {
                 }
             } catch (IOException e) {
                 if (System.getProperty("debugParser") != null) {
-                    e.printStackTrace();
+                    LOGGER.error(I_O_EXCEPTION_HAS_OCCURRED, e);
                 }
                 // continue to next parser
             }
@@ -158,7 +163,7 @@ public class SwaggerParser {
                 }
             } catch (IOException e) {
                 if (System.getProperty("debugParser") != null) {
-                    e.printStackTrace();
+                    LOGGER.error(I_O_EXCEPTION_HAS_OCCURRED, e);
                 }
                 // continue to next parser
             }

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RemoteUrl.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RemoteUrl.java
@@ -17,9 +17,12 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RemoteUrl {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RemoteUrl.class);
     private static final String ACCEPT_HEADER_VALUE = "application/json, application/yaml, */*";
     private static final String USER_AGENT_HEADER_VALUE = "Apache-HttpClient/Swagger";
 
@@ -55,9 +58,9 @@ public class RemoteUrl {
             // Install the all-trusting host verifier
             HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
         } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
+            LOGGER.error("Cryptographic algorithm is not available", e);
         } catch (KeyManagementException e) {
-            e.printStackTrace();
+            LOGGER.error("Exception dealing with key management", e);
         }
     }
 
@@ -122,10 +125,10 @@ public class RemoteUrl {
         } catch (javax.net.ssl.SSLProtocolException e) {
             System.out.println("there is a problem with the target SSL certificate");
             System.out.println("**** you may want to run with -Djsse.enableSNIExtension=false\n\n");
-            e.printStackTrace();
+            LOGGER.error("Error in the operation of the SSL protocol", e);
             throw e;
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.error("Exception while execution", e);
             throw e;
         } finally {
             if (is != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1148 - Throwable.printStackTrace(...) should not be called.
squid:S1192 - String literals should not be duplicated.
squid:S1312 - Loggers should be "private static final" and should share a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1148
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1312
Please let me know if you have any questions.
George Kankava