### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/modules/swagger-compat-spec-parser/src/main/java/io/swagger/models/reader/ApiDeclarationReader.java
+++ b/modules/swagger-compat-spec-parser/src/main/java/io/swagger/models/reader/ApiDeclarationReader.java
@@ -8,6 +8,11 @@ import java.io.IOException;
 import java.net.URL;
 
 public class ApiDeclarationReader {
+
+    private ApiDeclarationReader() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+
     public static void main(String[] args) throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);

--- a/modules/swagger-compat-spec-parser/src/main/java/io/swagger/models/reader/ResourceListingReader.java
+++ b/modules/swagger-compat-spec-parser/src/main/java/io/swagger/models/reader/ResourceListingReader.java
@@ -15,6 +15,11 @@ import java.util.List;
 import java.util.Map;
 
 public class ResourceListingReader {
+
+    private ResourceListingReader() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+
     public static void main(String[] args) throws IOException, URISyntaxException {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);

--- a/modules/swagger-compat-spec-parser/src/main/java/io/swagger/transform/util/SwaggerMigrators.java
+++ b/modules/swagger-compat-spec-parser/src/main/java/io/swagger/transform/util/SwaggerMigrators.java
@@ -12,6 +12,7 @@ import io.swagger.transform.migrate.SwaggerMigrator;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
+
 import java.io.IOException;
 import java.util.Objects;
 import java.util.Set;
@@ -21,6 +22,11 @@ import java.util.Set;
  */
 @ParametersAreNonnullByDefault
 public final class SwaggerMigrators {
+
+    private SwaggerMigrators() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+
     private static final ObjectMapper MAPPER = JacksonUtils.newMapper();
 
     /**

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/ClasspathHelper.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/ClasspathHelper.java
@@ -8,6 +8,10 @@ import java.io.InputStream;
 
 public class ClasspathHelper {
 
+    private ClasspathHelper() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+
     public static String loadFileFromClasspath(String location) {
 
         InputStream inputStream = ClasspathHelper.class.getResourceAsStream(location);

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/DeserializationUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/DeserializationUtils.java
@@ -11,6 +11,11 @@ import java.io.IOException;
  * Created by russellb337 on 7/14/15.
  */
 public class DeserializationUtils {
+
+    private DeserializationUtils() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+
     public static JsonNode deserializeIntoTree(String contents, String fileOrHost) {
         JsonNode result;
 

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/PathUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/PathUtils.java
@@ -6,6 +6,9 @@ import java.nio.file.Paths;
 
 public class PathUtils {
 
+    private PathUtils() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
 
     public static Path getParentDirectoryOfFile(String fileStr) {
         final String fileScheme = "file://";

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
@@ -13,6 +13,10 @@ import java.util.Map;
 
 public class RefUtils {
 
+    private RefUtils() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
+
     public static String computeDefinitionName(String ref) {
 
         final String[] refParts = ref.split("#/");

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RemoteUrl.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RemoteUrl.java
@@ -11,6 +11,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
 import java.util.List;
+
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -19,6 +20,10 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
 public class RemoteUrl {
+
+    private RemoteUrl() {
+        throw new InstantiationError("Must not instantiate this class");
+    }
 
     private static final String ACCEPT_HEADER_VALUE = "application/json, application/yaml, */*";
     private static final String USER_AGENT_HEADER_VALUE = "Apache-HttpClient/Swagger";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
Please let me know if you have any questions.
George Kankava