### PR TITLE
A couple of security improvements

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/HostAuthorizationValue.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/HostAuthorizationValue.java
@@ -1,0 +1,59 @@
+package io.swagger.parser.util;
+
+import io.swagger.models.auth.AuthorizationValue;
+
+import java.net.URL;
+import java.util.regex.Pattern;
+
+public class HostAuthorizationValue extends AuthorizationValue implements ManagedValue {
+    private final HostMatcher matcher;
+
+    public HostAuthorizationValue(String host, String name, String value, String type) {
+        this(new ExactHostMatcher(host), name, value, type);
+    }
+
+    public HostAuthorizationValue(Pattern host, String name, String value, String type) {
+        this(new RxHostMatcher(host), name, value, type);
+    }
+
+    protected HostAuthorizationValue(HostMatcher matcher, String name, String value, String type) {
+        super(name, value, type);
+        this.matcher = matcher;
+    }
+
+    @Override
+    public boolean process(URL url) {
+        return matcher.match(url.getHost());
+    }
+
+    protected interface HostMatcher {
+
+        boolean match(String host);
+    }
+
+    protected static class ExactHostMatcher implements HostMatcher {
+        private final String host;
+
+        public ExactHostMatcher(String host) {
+            this.host = host;
+        }
+
+        @Override
+        public boolean match(String host) {
+            return this.host.equalsIgnoreCase(host);
+        }
+    }
+
+    protected static class RxHostMatcher implements HostMatcher {
+        private final Pattern rx;
+
+        public RxHostMatcher(Pattern rx) {
+            this.rx = rx;
+        }
+
+        @Override
+        public boolean match(String host) {
+            return rx.matcher(host).matches();
+        }
+    }
+}

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/ManagedValue.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/ManagedValue.java
@@ -1,0 +1,8 @@
+package io.swagger.parser.util;
+
+import java.net.URL;
+
+public interface ManagedValue {
+
+    boolean process(URL url);
+}

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/HostAuthorizationValueTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/HostAuthorizationValueTest.java
@@ -1,0 +1,44 @@
+package io.swagger.parser.util;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class HostAuthorizationValueTest {
+
+    @Test
+    public void testExactMatcher() throws MalformedURLException {
+        final HostAuthorizationValue value = new HostAuthorizationValue("swagger.io", "k", "v",
+                "header");
+        final Map<String, Boolean> urls = ImmutableMap.<String, Boolean> builder()
+                .put("http://swagger.io", true).put("http://swagger.io/swagger.json", true)
+                .put("http://SwAgGeR.iO/swagger.yaml", true).put("http://petstore.swagger.io", false)
+                .build();
+        for (Map.Entry<String, Boolean> url : urls.entrySet()) {
+            Assert.assertEquals(value.process(new URL(url.getKey())), (boolean) url.getValue(),
+                    url.getKey());
+        }
+    }
+
+    @Test
+    public void testPatternMatcher() throws MalformedURLException {
+        final HostAuthorizationValue value = new HostAuthorizationValue(
+                Pattern.compile("([^.]+\\.)*swagger.io", Pattern.CASE_INSENSITIVE), "k", "v",
+                "header");
+
+        final Map<String, Boolean> urls = ImmutableMap.<String, Boolean> builder()
+                .put("http://swagger.io", true).put("http://a.b.c.swagger.io", true)
+                .put("http://json.swagger.io/swagger.json", true)
+                .put("http://yaml.SwAgGeR.iO/swagger.yaml", true)
+                .put("http://not-swagger.io", false).put("http://petstore", false).build();
+        for (Map.Entry<String, Boolean> url : urls.entrySet()) {
+            Assert.assertEquals(value.process(new URL(url.getKey())), (boolean) url.getValue(),
+                    url.getKey());
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,39 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.5.201505241946</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration></configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <rules>
+                        <rule>
+                            <element>BUNDLE</element>
+                        </rule>
+                    </rules>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencyManagement>


### PR DESCRIPTION
The `io.swagger.parser.util.RemoteUrl` changes default SSL settings as follows:

- default socket factory is configured to trust any certificates
- default host name validator is configured to validate any hosts

So, projects which use our parser implicitly get insecure SSL configuration.
This PR eliminates this flaw but preserve the ability to turn on 'trust all' configuration for parser connections only via the `-Dio.swagger.parser.util.RemoteUrl.trastAll=true` system property.

The second issue relates to inability to control sending of authorization values to remote hosts. When we parse a specification which references remote locations and provide a set of `AuthorizationValue` instances these values will be send to all those locations regardless of the fact whether a remote host requires them or not.

This PR adds a support of managed values (`io.swagger.parser.util.ManagedValue`) to link a particular authorization value to its hosts.