### PR TITLE
Validate path parameters match parameters

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/Swagger20Parser.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/Swagger20Parser.java
@@ -2,6 +2,9 @@ package io.swagger.parser;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.google.common.base.Optional;
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import io.swagger.models.Swagger;
 import io.swagger.models.auth.AuthorizationValue;
 import io.swagger.parser.util.ClasspathHelper;
@@ -9,6 +12,7 @@ import io.swagger.parser.util.DeserializationUtils;
 import io.swagger.parser.util.RemoteUrl;
 import io.swagger.parser.util.SwaggerDeserializationResult;
 import io.swagger.parser.util.SwaggerDeserializer;
+import static io.swagger.parser.util.SwaggerDeserializer.allPathParametersAccountForExtractedPathParameters;
 import io.swagger.util.Json;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.Validate;
@@ -129,6 +133,23 @@ public class Swagger20Parser implements SwaggerParserExtension {
                 SwaggerDeserializationResult result = new SwaggerDeserializer().deserialize(rootNode);
 
                 Swagger convertValue = result.getSwagger();
+
+                if(convertValue.getPaths() == null) {
+                    // no need to validate Path Parameters since there are no paths
+                }
+                else {
+                    final Optional<Boolean> validPaths = allPathParametersAccountForExtractedPathParameters(convertValue);
+                    if(validPaths.isPresent()) {
+                        final Boolean validResult = validPaths.get();
+                        if(validResult.equals(Boolean.FALSE)) {
+                            return null;
+                        }
+                    }
+                    else {
+                        return null;
+                    }
+                }
+
                 if (System.getProperty("debugParser") != null) {
                     LOGGER.info("\n\nSwagger Tree convertValue : \n"
                         + ReflectionToStringBuilder.toString(convertValue, ToStringStyle.MULTI_LINE_STYLE) + "\n\n");

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/PathUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/PathUtils.java
@@ -3,9 +3,10 @@ package io.swagger.parser.util;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PathUtils {
-
 
     public static Path getParentDirectoryOfFile(String fileStr) {
         final String fileScheme = "file://";
@@ -17,5 +18,96 @@ public class PathUtils {
             file = Paths.get(fileStr).toAbsolutePath();
         }
         return file.toAbsolutePath().getParent();
+    }
+
+    public enum ComparisonOp {
+        EQUALS, NOT_EQUALS
+    }
+
+    // breakFn :: (a -> Bool) -> [a] -> ([a], [a])
+    // λ: break (== 2) [1,2,3]
+    // ([1],[2,3])
+    // λ: break (== 5) [1,2,3]
+    // ([1,2,3],[])
+    public static List<String> breakFn(final String xs, final char matcher) {
+        final List<String> result = new ArrayList<>();
+        final String first = takeWhile(xs, matcher, ComparisonOp.NOT_EQUALS);
+        final int firstLen = first.length();
+        final String rest;
+        if(firstLen == xs.length()) {
+            rest = "";
+        }
+        else {
+            rest = xs.substring(firstLen);
+        }
+        result.add(first);
+        result.add(rest);
+        return result;
+    }
+
+    public static String drop(final String x, final int n) {
+        final String result;
+
+        if(x.isEmpty() || n <= 0) {
+            result = x;
+        }
+        else {
+            final String tail = x.substring(1);
+            result = drop(tail, n-1);
+        }
+
+        return result;
+    }
+
+    public static String dropWhile(final String x, final char matcher, final ComparisonOp op) {
+        final String result;
+
+        if(x.isEmpty()) {
+            result = "";
+        }
+        else if(!x.isEmpty() && compare(x.charAt(0), matcher, op)) {
+            final String tail = x.substring(1);
+            result = dropWhile(tail, matcher, op); // drop head
+        }
+        else {
+            // x matches the matcher - no more dropping
+            result = x;
+        }
+        return result;
+    }
+
+
+    public static String takeWhile(final String x, final char matcher, final ComparisonOp op) {
+        return takeWhileHelper(x, matcher, op, "");
+    }
+
+    private static <T> boolean compare(final T x, final T y, final ComparisonOp op) {
+        if (op == ComparisonOp.EQUALS) {
+            return x.equals(y);
+        }
+        else {
+            return !(x.equals(y));
+        }
+    }
+
+    private static String takeWhileHelper(final String x, final char matcher, final ComparisonOp op, final String acc) {
+        final String result;
+
+        if(x.isEmpty()) {
+            result = acc;
+        }
+        else {
+            final char head = x.charAt(0);
+            final String tail = x.substring(1);
+
+            if(compare(head, matcher, op)) {
+                result = takeWhileHelper(tail, matcher, op, acc + head);
+            }
+            else {
+                // x does not match the matcher - no more taking.
+                result = acc;
+            }
+        }
+        return result;
     }
 }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/PathUtilTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/PathUtilTest.java
@@ -3,8 +3,13 @@ package io.swagger.parser.util;
 import org.testng.annotations.Test;
 
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertEqualsNoOrder;
+import static org.testng.Assert.assertTrue;
+import static io.swagger.parser.util.PathUtils.*;
 
 public class PathUtilTest {
 
@@ -13,8 +18,235 @@ public class PathUtilTest {
 
         final String actualResult = PathUtils.getParentDirectoryOfFile("src/test/resources/parent.json").toString();
 
-        final String execptedResult = Paths.get("src/test/resources").toAbsolutePath().toString();
+        final String expectedResult = Paths.get("src/test/resources").toAbsolutePath().toString();
 
-        assertEquals(actualResult, execptedResult);
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void testDropWhileNoneMatch() {
+        final String x              = "abcdefg";
+        final String actualResult   = dropWhile(x, 'z', PathUtils.ComparisonOp.NOT_EQUALS);
+
+        assertTrue(actualResult.isEmpty());
+    }
+
+    @Test
+    public void testDropWhileAllMatch() {
+        final String x              = "ffffffff";
+        final String actualResult   = dropWhile(x, 'f', PathUtils.ComparisonOp.EQUALS);
+
+        assertTrue(actualResult.isEmpty());
+    }
+
+    @Test
+    public void testDropWhileFirstFewMatch() {
+
+        final String x              = "AAAbbbccc";
+        final String actualResult   = dropWhile(x, 'A', PathUtils.ComparisonOp.EQUALS);
+        final String expectedResult = "bbbccc";
+
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void testDropWhilePath() {
+
+        final String x              = "http://foo.bar.com/{id}";
+        final String actualResult   = dropWhile(x, '{', PathUtils.ComparisonOp.NOT_EQUALS);
+        final String expectedResult = "{id}";
+
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void testTakeWhilePath() {
+
+        final String x              = "{id}";
+        final String actualResult   = takeWhile(x, '}', PathUtils.ComparisonOp.NOT_EQUALS);
+        final String expectedResult = "{id";
+
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void testDropWhileEmptyInputEquals() {
+
+        final String x              = "";
+        final String actualResult   = dropWhile(x, 'Z', PathUtils.ComparisonOp.EQUALS);
+
+        assertTrue(actualResult.isEmpty());
+    }
+
+    @Test
+    public void testDropWhileEmptyInputNotEquals() {
+
+        final String x              = "";
+        final String actualResult   = dropWhile(x, 'Z', PathUtils.ComparisonOp.NOT_EQUALS);
+
+        assertTrue(actualResult.isEmpty());
+    }
+
+    @Test
+    public void testTakeWhileTakeAllValuesEquals() {
+
+        final String x            = "zzzzzz";
+        final String actualResult = takeWhile(x, 'z', PathUtils.ComparisonOp.EQUALS);
+
+        assertEquals(actualResult, x);
+    }
+
+    @Test
+    public void testTakeWhileTakeAllValuesNotEquals() {
+
+        final String x            = "zzzzzz";
+        final String actualResult = takeWhile(x, 'z', PathUtils.ComparisonOp.NOT_EQUALS);
+
+        assertTrue(actualResult.isEmpty());
+    }
+
+
+    @Test
+    public void testTakeWhileTakeNoValuesCaseSensitiveEquals() {
+
+        final String x            = "KAJSDLFKJASDKLFJ";
+        final String actualResult = takeWhile(x, 'k', PathUtils.ComparisonOp.EQUALS);
+
+        assertTrue(actualResult.isEmpty());
+    }
+
+    @Test
+    public void testTakeWhileTakeNoValuesCaseSensitiveNotEquals() {
+
+        final String x            = "KAJSDLFKJASDKLFJ";
+        final String actualResult = takeWhile(x, 'k', PathUtils.ComparisonOp.NOT_EQUALS);
+
+        assertEquals(x, actualResult);
+    }
+
+    @Test
+    public void testTakeWhileTakeHeadCaseSensitive() {
+
+        final String x              = "JjJjJ";
+        final String actualResult   = takeWhile(x, 'J', PathUtils.ComparisonOp.EQUALS);
+        final String expectedResult = "J";
+
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void testBreak() {
+        final String x = "123";
+        final char breakAt = '2';
+        final List<String> expectedResult = new ArrayList<>();
+        expectedResult.add("1");
+        expectedResult.add("23");
+        final List<String> actualResult = breakFn(x, breakAt);
+
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void testBreakOnPathParameter() {
+        final String x = "http://foo.bar.com/{id}";
+        final char breakAt = '{';
+        final List<String> expectedResult = new ArrayList<>();
+        expectedResult.add("http://foo.bar.com/");
+        expectedResult.add("{id}");
+        final List<String> actualResult = breakFn(x, breakAt);
+
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void testBreakOnNone() {
+        final String x = "123";
+        final char breakAt = '9';
+        final List<String> expectedResult = new ArrayList<>();
+        expectedResult.add("123");
+        expectedResult.add("");
+        final List<String> actualResult = breakFn(x, breakAt);
+
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void testBreakOnAll() {
+        final String x = "123";
+        final char breakAt = '1';
+        final List<String> expectedResult = new ArrayList<>();
+        expectedResult.add("");
+        expectedResult.add("123");
+        final List<String> actualResult = breakFn(x, breakAt);
+
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void testBreakOnWhitespaceWithNoWhitespaceMarker() {
+        final String x = "           ";
+        final char breakAt = '3';
+        final List<String> expectedResult = new ArrayList<>();
+        expectedResult.add(x);
+        expectedResult.add("");
+        final List<String> actualResult = breakFn(x, breakAt);
+
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void testBreakOnWhitespace() {
+        final String x = "           ";
+        final char breakAt = ' ';
+        final List<String> expectedResult = new ArrayList<>();
+        expectedResult.add("");
+        expectedResult.add("           ");
+        final List<String> actualResult = breakFn(x, breakAt);
+
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void testDrop0() {
+        final String x            = "foobar";
+        final String actualResult = drop(x, 0);
+        assertEquals(actualResult, x);
+    }
+
+    @Test
+    public void testDropNegative() {
+        final String x            = "foobar";
+        final String actualResult = drop(x, -555);
+        assertEquals(actualResult, x);
+    }
+
+    @Test
+    public void testDrop1() {
+        final String x              = "foobar";
+        final String actualResult   = drop(x, 1);
+        final String expectedResult = "oobar";
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void testDrop3() {
+        final String x              = "foobar";
+        final String actualResult   = drop(x, 3);
+        final String expectedResult = "bar";
+        assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void testDropAll() {
+        final String x              = "foobar";
+        final String actualResult   = drop(x, x.length());
+        assertTrue(actualResult.isEmpty());
+    }
+
+    @Test
+    public void testDropMoreThanLengthX() {
+        final String x              = "foobar";
+        final String actualResult   = drop(x, 999);
+        assertTrue(actualResult.isEmpty());
     }
 }

--- a/modules/swagger-parser/src/test/resources/minimal_invalid_path
+++ b/modules/swagger-parser/src/test/resources/minimal_invalid_path
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Pets Store"
+  },
+  "paths": {
+    "/pets/{foo": {
+      "get": {
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Returns all the pets"
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/path_param_test_parameters_in_path_body_only
+++ b/modules/swagger-parser/src/test/resources/path_param_test_parameters_in_path_body_only
@@ -1,0 +1,27 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Pets Store"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "...",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all the pets"
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/path_param_test_params_match
+++ b/modules/swagger-parser/src/test/resources/path_param_test_params_match
@@ -1,0 +1,27 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Pets Store"
+  },
+  "paths": {
+    "/pets/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "...",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all the pets"
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/path_param_test_path_2_operations_matching_params
+++ b/modules/swagger-parser/src/test/resources/path_param_test_path_2_operations_matching_params
@@ -1,0 +1,57 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Pets Store"
+  },
+  "paths": {
+    "/pets/{id}/{foo}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "...",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "foo",
+            "in": "path",
+            "description": "...",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all the pets"
+          }
+        }
+      },
+      "put": {
+        "parameters": [
+          {
+            "name": "foo",
+            "in": "path",
+            "description": "...",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "...",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all the pets"
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/path_param_test_path_2_operations_non_matching_params
+++ b/modules/swagger-parser/src/test/resources/path_param_test_path_2_operations_non_matching_params
@@ -1,0 +1,50 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Pets Store"
+  },
+  "paths": {
+    "/pets/{id}/{foo}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "...",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all the pets"
+          }
+        }
+      },
+      "put": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "...",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "foo",
+            "in": "path",
+            "description": "...",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all the pets"
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/path_param_test_path_2_params_match
+++ b/modules/swagger-parser/src/test/resources/path_param_test_path_2_params_match
@@ -1,0 +1,34 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Pets Store"
+  },
+  "paths": {
+    "/pets/{id}/{foo}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "...",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "foo",
+            "in": "path",
+            "description": "...",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all the pets"
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/path_param_test_path_3_path_params_each_type
+++ b/modules/swagger-parser/src/test/resources/path_param_test_path_3_path_params_each_type
@@ -1,0 +1,45 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Pets Store"
+  },
+  "paths": {
+    "/pets/{id}/{foo}/{bippy}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "...",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all the pets"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "foo",
+          "in": "path",
+          "description": "...",
+          "required": true,
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "parameters": {
+    "bippyField" : {
+      "name": "bippy",
+      "in": "path",
+      "description": "...",
+      "required": true,
+      "type": "string"
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/path_param_test_path_3_path_params_missing_operation_specific
+++ b/modules/swagger-parser/src/test/resources/path_param_test_path_3_path_params_missing_operation_specific
@@ -1,0 +1,37 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Pets Store"
+  },
+  "paths": {
+    "/pets/{id}/{foo}/{bippy}": {
+      "get": {
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Returns all the pets"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "foo",
+          "in": "path",
+          "description": "...",
+          "required": true,
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "parameters": {
+    "bippyField" : {
+      "name": "bippy",
+      "in": "path",
+      "description": "...",
+      "required": true,
+      "type": "string"
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/path_param_test_path_global_params_match
+++ b/modules/swagger-parser/src/test/resources/path_param_test_path_global_params_match
@@ -1,0 +1,27 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Pets Store"
+  },
+  "paths": {
+    "/pets/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Returns all the pets"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "idParam" : {
+      "name": "id",
+      "in": "path",
+      "description": "...",
+      "required": true,
+      "type": "string"
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/path_param_test_path_no_params_with_each_param
+++ b/modules/swagger-parser/src/test/resources/path_param_test_path_no_params_with_each_param
@@ -1,0 +1,45 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Pets Store"
+  },
+  "paths": {
+    "/pets/": {
+      "get": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "...",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all the pets"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "foo",
+          "in": "path",
+          "description": "...",
+          "required": true,
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "parameters": {
+    "bippyField" : {
+      "name": "bippy",
+      "in": "path",
+      "description": "...",
+      "required": true,
+      "type": "string"
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/path_param_test_path_parameter_path_only
+++ b/modules/swagger-parser/src/test/resources/path_param_test_path_parameter_path_only
@@ -1,0 +1,19 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Pets Store"
+  },
+  "paths": {
+    "/pets/{id}": {
+      "get": {
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Returns all the pets"
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/path_param_test_path_path_specific_params_match
+++ b/modules/swagger-parser/src/test/resources/path_param_test_path_path_specific_params_match
@@ -1,0 +1,27 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Pets Store"
+  },
+  "paths": {
+    "/pets/{fizzbuzz}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Returns all the pets"
+          }
+        },
+        "parameters": [
+         {
+           "name": "fizzbuzz",
+           "in": "path",
+           "description": "...",
+           "required": true,
+           "type": "string"
+         }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Addresses https://github.com/swagger-api/swagger-parser/issues/189.

Note - it's a **WIP**. I will `git rebase` when I believe it's ready for review. I'm using the PR to review the work that I've done via the PR "Files Changed" UI.

The intention of this PR is to fail, i.e. return `null` for the parsed `Swagger` object, if any `path`'s value, e.g. `/pets/{id}`, has an unaccounted for path parameter. Note that, for a path parameter of `{id}`, the global, path, and operation-specific path parameters would be retrieved, and then checked whether they, collectively, contain `{id}`.

I've added quite of bit of tests, but I'm going to add more to account for path parameters with global and path-specific path parameters.