### PR TITLE
add vendor extension to SecurityDefinitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 .project
 .settings/
 modules/swagger-parser/src/test/resources/relative-file-references/yaml
+**/test-output/*

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -1143,6 +1143,14 @@ public class SwaggerDeserializer {
             }
         }
 
+            Set<String> keys = getKeys(node);
+            for (String key : keys)
+            {
+                if (key.startsWith("x-"))
+                {
+                    output.setVendorExtension(key, extension(node.get(key)));
+                }
+            }
         return output;
     }
 

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -27,6 +27,7 @@ public class SwaggerDeserializer {
     static Set<String> OPERATION_KEYS = new HashSet<String>(Arrays.asList("scheme", "tags", "summary", "description", "externalDocs", "operationId", "consumes", "produces", "parameters", "responses", "schemes", "deprecated", "security"));
     static Set<String> PARAMETER_KEYS = new HashSet<String>(Arrays.asList("name", "in", "description", "required", "type", "format", "allowEmptyValue", "items", "collectionFormat", "default", "maximum", "exclusiveMaximum", "minimum", "exclusiveMinimum", "maxLength", "minLength", "pattern", "maxItems", "minItems", "uniqueItems", "enum", "multipleOf"));
     static Set<String> BODY_PARAMETER_KEYS = new HashSet<String>(Arrays.asList("name", "in", "description", "required", "schema"));
+    static Set<String> SECURITY_SCHEME_KEYS = new HashSet<String>(Arrays.asList("name", "in", "description", "flow", "authorizationUrl", "tokenUrl" , "scopes"));
 
     public SwaggerDeserializationResult deserialize(JsonNode rootNode) {
         SwaggerDeserializationResult result = new SwaggerDeserializationResult();
@@ -1141,16 +1142,20 @@ public class SwaggerDeserializer {
             else {
                 result.invalidType(location + ".type", "type", "basic|apiKey|oauth2", node);
             }
-        }
-
+            
+            // extra keys
             Set<String> keys = getKeys(node);
-            for (String key : keys)
-            {
-                if (key.startsWith("x-"))
-                {
+            for(String key : keys) {
+                if(key.startsWith("x-")) {
                     output.setVendorExtension(key, extension(node.get(key)));
                 }
+                else if(!SECURITY_SCHEME_KEYS.contains(key)) {
+                    result.extra(location, key, node.get(key));
+                }
             }
+        }
+
+
         return output;
     }
 

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
@@ -183,12 +183,14 @@ public class SwaggerDeserializerTest {
                 "  \"swagger\": \"2.0\",\n" +
                 "  \"securityDefinitions\": {\n" +
                 "    \"basic_auth\": {\n" +
-                "      \"type\": \"basic\"\n" +
+                "      \"type\": \"basic\",\n" +
+                "      \"x-foo\": \"basicBar\"\n" +
                 "    },\n" +
                 "    \"api_key\": {\n" +
                 "      \"type\": \"apiKey\",\n" +
                 "      \"name\": \"api_key\",\n" +
-                "      \"in\": \"header\"\n" +
+                "      \"in\": \"header\",\n" +
+                "      \"x-foo\": \"apiKeyBar\"\n" +
                 "    }\n" +
                 "  },\n" +
                 "  \"paths\": {\n" +
@@ -219,7 +221,7 @@ public class SwaggerDeserializerTest {
         SecuritySchemeDefinition definitionBasic = swagger.getSecurityDefinitions().get("basic_auth");
         assertNotNull(definitionBasic);
         assertTrue(definitionBasic instanceof BasicAuthDefinition);
-
+        assertEquals(definitionBasic.getVendorExtensions().get("x-foo"), "basicBar");
         // API Key Authentication
         SecuritySchemeDefinition definition = swagger.getSecurityDefinitions().get("api_key");
         assertNotNull(definition);
@@ -228,6 +230,7 @@ public class SwaggerDeserializerTest {
         ApiKeyAuthDefinition apiKey = (ApiKeyAuthDefinition) definition;
         assertEquals(apiKey.getName(), "api_key");
         assertEquals(apiKey.getIn(), In.HEADER);
+        assertEquals(apiKey.getVendorExtensions().get("x-foo"), "apiKeyBar");
     }
 
     @Test


### PR DESCRIPTION
#222 

VendorExtensions in SecurityDefinitions are not being deserialized.
Added serialization for vendor extensions to SecuritySchemeDefinition

