### PR TITLE
Generate better error messages

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/Swagger20Parser.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/Swagger20Parser.java
@@ -1,5 +1,6 @@
 package io.swagger.parser;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.models.Swagger;
@@ -55,10 +56,15 @@ public class Swagger20Parser implements SwaggerParserExtension {
                 rootNode = DeserializationUtils.readYamlTree(data);
             }
             return parseContents(rootNode, auths, location, resolve);
+        } catch (JsonParseException e) {
+            SwaggerDeserializationResult result = new SwaggerDeserializationResult();
+            result.message(e.getOriginalMessage());
+            result.message(e.getLocation().toString());
+            return result;
         }
         catch (Exception e) {
             SwaggerDeserializationResult output = new SwaggerDeserializationResult();
-            output.message("unable to read location `" + location + "`");
+            output.message("unable to read location `" + location + "`: " + e.getMessage());
             return output;
         }
     }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerReaderTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerReaderTest.java
@@ -132,6 +132,30 @@ public class SwaggerReaderTest {
         assertTrue(thingSummary instanceof ModelImpl);
     }
 
+    @Test(enabled = false, description = "It should show some context information on failures")
+    public void testIssue250() throws UnparseableContentException {
+        String spec = "{ wrong content }";
+        SwaggerDeserializationResult result = new SwaggerParser().parseContents(spec);
+        assertEquals(result.getMessages().size(), 2);
+        assertTrue(result.getMessages().get(0).contains("Unexpected character"));
+        assertTrue(result.getMessages().get(1).contains("line: 1"));
+    }
+
+    @Test(description = "It should show some context information on failures")
+    public void testIssue250FileNotFound() throws UnparseableContentException {
+        SwaggerDeserializationResult result = new SwaggerParser().parseLocation("issue250NotFound.json");
+        assertEquals(result.getMessages().size(), 1);
+        assertTrue(result.getMessages().get(0).contains("issue250NotFound.json"));
+    }
+
+    @Test(description = "It should show some context information on failures")
+    public void testIssue250Location() throws UnparseableContentException {
+        SwaggerDeserializationResult result = new SwaggerParser().parseLocation("issue250.json");
+        assertEquals(result.getMessages().size(), 2);
+        assertTrue(result.getMessages().get(0).contains("Unexpected character"));
+        assertTrue(result.getMessages().get(1).contains("line: 1"));
+    }
+
     @Test
     public void testIssue207() throws Exception {
         String spec = "{\n" +

--- a/modules/swagger-parser/src/test/resources/issue250.json
+++ b/modules/swagger-parser/src/test/resources/issue250.json
@@ -1,0 +1,3 @@
+ { wrong content }
+
+


### PR DESCRIPTION
SwaggerDeserializationResult now contains the errors generated by jackson if json parsing fails.

There is a disabled test that considers the case when the spec is provide as a string. I'll add a different commit that will change the api of AbstractParser.stringToNode (will throw a Jackson related exception).