### PR TITLE
Read external reference file with UTF-8 encoding

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
@@ -2,7 +2,7 @@ package io.swagger.parser.util;
 
 import io.swagger.models.auth.AuthorizationValue;
 import io.swagger.models.refs.RefFormat;
-import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.FileInputStream;
@@ -130,7 +130,7 @@ public class RefUtils {
                 final Path pathToUse = parentDirectory.resolve(file).normalize();
 
                 if(Files.exists(pathToUse)) {
-                    result = IOUtils.toString(new FileInputStream(pathToUse.toFile()));
+                    result = FileUtils.readFileToString(pathToUse.toFile(), "UTF-8");
                 } else {
                     result = ClasspathHelper.loadFileFromClasspath(file);
                 }

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
@@ -2,7 +2,7 @@ package io.swagger.parser.util;
 
 import io.swagger.models.auth.AuthorizationValue;
 import io.swagger.models.refs.RefFormat;
-import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.FileInputStream;
@@ -130,7 +130,7 @@ public class RefUtils {
                 final Path pathToUse = parentDirectory.resolve(file).normalize();
 
                 if(Files.exists(pathToUse)) {
-                    result = FileUtils.readFileToString(pathToUse.toFile(), "UTF-8");
+                    result = IOUtils.toString(new FileInputStream(pathToUse.toFile()), "UTF-8");
                 } else {
                     result = ClasspathHelper.loadFileFromClasspath(file);
                 }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/RefUtilsTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/RefUtilsTest.java
@@ -7,7 +7,7 @@ import io.swagger.models.refs.RefFormat;
 import mockit.Injectable;
 import mockit.Mocked;
 import mockit.StrictExpectations;
-import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
 import java.io.File;
@@ -139,8 +139,7 @@ public class RefUtilsTest {
 
     @Test
     public void testReadExternalRef_RelativeFileFormat(@Injectable final List<AuthorizationValue> auths,
-                                                       @Mocked IOUtils ioUtils,
-                                                       @Mocked final FileInputStream fileInputStream,
+                                                       @Mocked FileUtils fileUtils,
                                                        @Mocked Files files,
                                                        @Injectable final Path parentDirectory,
                                                        @Injectable final Path pathToUse,
@@ -150,10 +149,10 @@ public class RefUtilsTest {
         final String filePath = "./path/to/file.json";
         final String expectedResult = "really good json";
 
-        setupRelativeFileExpectations(fileInputStream, parentDirectory, pathToUse, file, filePath);
+        setupRelativeFileExpectations(parentDirectory, pathToUse, file, filePath);
 
         new StrictExpectations() {{
-            IOUtils.toString(fileInputStream);
+            FileUtils.readFileToString(file, "UTF-8");
             times = 1;
             result = expectedResult;
         }};
@@ -162,7 +161,7 @@ public class RefUtilsTest {
         assertEquals(expectedResult, actualResult);
     }
 
-    private void setupRelativeFileExpectations(@Mocked final FileInputStream fileInputStream, @Injectable final Path parentDirectory, @Injectable final Path pathToUse, @Injectable final File file, final String filePath) throws Exception {
+    private void setupRelativeFileExpectations(@Injectable final Path parentDirectory, @Injectable final Path pathToUse, @Injectable final File file, final String filePath) throws Exception {
         new StrictExpectations() {{
 
             parentDirectory.resolve(filePath).normalize();
@@ -176,17 +175,12 @@ public class RefUtilsTest {
             pathToUse.toFile();
             times = 1;
             result = file;
-
-            new FileInputStream(file);
-            times = 1;
-            result = fileInputStream;
         }};
     }
 
     @Test
     public void testReadExternalRef_RelativeFileFormat_ExceptionThrown(@Injectable final List<AuthorizationValue> auths,
-                                                                       @Mocked IOUtils ioUtils,
-                                                                       @Mocked final FileInputStream fileInputStream,
+                                                                       @Mocked FileUtils fileUtils,
                                                                        @Mocked Files files,
                                                                        @Injectable final IOException mockedException,
                                                                        @Injectable final Path parentDirectory,
@@ -195,10 +189,10 @@ public class RefUtilsTest {
     ) throws Exception {
         final String filePath = "./path/to/file.json";
 
-        setupRelativeFileExpectations(fileInputStream, parentDirectory, pathToUse, file, filePath);
+        setupRelativeFileExpectations(parentDirectory, pathToUse, file, filePath);
 
         new StrictExpectations() {{
-            IOUtils.toString(fileInputStream);
+            FileUtils.readFileToString(file, "UTF-8");
             times = 1;
             result = mockedException;
         }};

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/RefUtilsTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/RefUtilsTest.java
@@ -7,7 +7,7 @@ import io.swagger.models.refs.RefFormat;
 import mockit.Injectable;
 import mockit.Mocked;
 import mockit.StrictExpectations;
-import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import java.io.File;
@@ -139,7 +139,8 @@ public class RefUtilsTest {
 
     @Test
     public void testReadExternalRef_RelativeFileFormat(@Injectable final List<AuthorizationValue> auths,
-                                                       @Mocked FileUtils fileUtils,
+                                                       @Mocked IOUtils ioUtils,
+                                                       @Mocked final FileInputStream fileInputStream,
                                                        @Mocked Files files,
                                                        @Injectable final Path parentDirectory,
                                                        @Injectable final Path pathToUse,
@@ -149,10 +150,10 @@ public class RefUtilsTest {
         final String filePath = "./path/to/file.json";
         final String expectedResult = "really good json";
 
-        setupRelativeFileExpectations(parentDirectory, pathToUse, file, filePath);
+        setupRelativeFileExpectations(fileInputStream, parentDirectory, pathToUse, file, filePath);
 
         new StrictExpectations() {{
-            FileUtils.readFileToString(file, "UTF-8");
+            IOUtils.toString(fileInputStream, "UTF-8");
             times = 1;
             result = expectedResult;
         }};
@@ -161,7 +162,7 @@ public class RefUtilsTest {
         assertEquals(expectedResult, actualResult);
     }
 
-    private void setupRelativeFileExpectations(@Injectable final Path parentDirectory, @Injectable final Path pathToUse, @Injectable final File file, final String filePath) throws Exception {
+    private void setupRelativeFileExpectations(@Mocked final FileInputStream fileInputStream, @Injectable final Path parentDirectory, @Injectable final Path pathToUse, @Injectable final File file, final String filePath) throws Exception {
         new StrictExpectations() {{
 
             parentDirectory.resolve(filePath).normalize();
@@ -175,12 +176,17 @@ public class RefUtilsTest {
             pathToUse.toFile();
             times = 1;
             result = file;
+
+            new FileInputStream(file);
+            times = 1;
+            result = fileInputStream;
         }};
     }
 
     @Test
     public void testReadExternalRef_RelativeFileFormat_ExceptionThrown(@Injectable final List<AuthorizationValue> auths,
-                                                                       @Mocked FileUtils fileUtils,
+                                                                       @Mocked IOUtils ioUtils,
+                                                                       @Mocked final FileInputStream fileInputStream,
                                                                        @Mocked Files files,
                                                                        @Injectable final IOException mockedException,
                                                                        @Injectable final Path parentDirectory,
@@ -189,10 +195,10 @@ public class RefUtilsTest {
     ) throws Exception {
         final String filePath = "./path/to/file.json";
 
-        setupRelativeFileExpectations(parentDirectory, pathToUse, file, filePath);
+        setupRelativeFileExpectations(fileInputStream, parentDirectory, pathToUse, file, filePath);
 
         new StrictExpectations() {{
-            FileUtils.readFileToString(file, "UTF-8");
+            IOUtils.toString(fileInputStream, "UTF-8");
             times = 1;
             result = mockedException;
         }};


### PR DESCRIPTION
I've noticed that external files referenced by $ref are loaded without specifying character encoding. Because of that, diacritics are parsed incorrectly. This should fix it.
Note that `IOUtils.toString(InputStream input)` is deprecated in the latest version of commons-io in favor of `IOUtils.toString(InputStream, Charset)`