### PR TITLE
to support path reference parameters for multiple verbs

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/PathsProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/PathsProcessor.java
@@ -6,6 +6,7 @@ import io.swagger.models.Path;
 import io.swagger.models.RefPath;
 import io.swagger.models.Swagger;
 import io.swagger.models.parameters.Parameter;
+import io.swagger.models.parameters.RefParameter;
 import io.swagger.parser.ResolverCache;
 
 import java.util.ArrayList;
@@ -49,9 +50,21 @@ public class PathsProcessor {
                         List<Parameter> existingParameters = operation.getParameters();
                         for(Parameter parameterToAdd : parameters) {
                             for(Parameter existingParameter : existingParameters) {
-                                if(parameterToAdd.getIn() != null && parameterToAdd.getIn().equals(existingParameter.getIn()) &&
-                                        parameterToAdd.getName().equals(existingParameter.getName())) {
+                                if(
+                                      parameterToAdd instanceof RefParameter
+                                   && existingParameter instanceof RefParameter
+                                   && ((RefParameter) parameterToAdd).get$ref().equals(((RefParameter) existingParameter).get$ref())
+                                ) {
                                     matched = true;
+                                } else if (
+                                      !(parameterToAdd instanceof RefParameter)
+                                   && !(existingParameter instanceof RefParameter)
+                                ) {
+                                    if (   parameterToAdd.getIn().equals(existingParameter.getIn())
+                                        && parameterToAdd.getName().equals(existingParameter.getName())
+                                    ) {
+                                        matched = true;
+                                    }
                                 }
                             }
                             if(!matched) {


### PR DESCRIPTION
If you got a yaml fine like this one, you would got an exception as getIn() / getName() won't work.
I left in comment the workaround which is to copy path parameters in each verb definition.


```
swagger: '2.0'

info:
  title: test
  version: "1.0.0"
  description: test

host: api.test.com
schemes:
  - https

paths:
  '/buckets/{bucketKey}/details':
    parameters:
      - $ref: '#/parameters/bucketKey'
    get:
      operationId: get_bucket_details
      description: test
#    parameters:
#      - $ref: '#/parameters/bucketKey'
    responses:
        '200': { $ref: '#/responses/OK' }
  '/buckets/{bucketKey}/objects/{objectName}':
    parameters:
      - $ref: '#/parameters/bucketKey'
      - $ref: '#/parameters/objectName'
    put:
      operationId: upload_object
      description: test
#      parameters:
#        - $ref: '#/parameters/bucketKey'
#        - $ref: '#/parameters/objectName'
      responses:
        '200': { $ref: '#/responses/OK' }
    get:
      operationId: get_object
      description: test
#      parameters:
#        - $ref: '#/parameters/bucketKey'
#        - $ref: '#/parameters/objectName'
      responses:
        '200': { $ref: '#/responses/OK' }

parameters:
  bucketKey:
    name: bucketKey
    in: path
    description: URL-encoded bucket key
    required: true
    type: string
  objectName:
    name: objectName
    in: path
    description: URL-encoded object name
    required: true
    type: string

responses:
  OK:
    description: OK, Success
```