### PR TITLE
Parse external references inside vendor extensions

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
@@ -23,10 +23,12 @@ public final class ExternalRefProcessor {
 
     private final ResolverCache cache;
     private final Swagger swagger;
+    private VendorExtensionProcessor vendorExtensionProcessor;
 
     public ExternalRefProcessor(ResolverCache cache, Swagger swagger) {
         this.cache = cache;
         this.swagger = swagger;
+        this.vendorExtensionProcessor = new VendorExtensionProcessor(cache, this);
     }
 
     public String processRefToExternalDefinition(String $ref, RefFormat refFormat) {
@@ -88,6 +90,7 @@ public final class ExternalRefProcessor {
             if (model instanceof ArrayModel && ((ArrayModel) model).getItems() instanceof RefProperty) {
                 processRefProperty((RefProperty) ((ArrayModel) model).getItems(), file);
             }
+            vendorExtensionProcessor.processRefsFromVendorExtensions(model, file);
         }
 
         return newRef;

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ModelProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ModelProcessor.java
@@ -18,10 +18,12 @@ import static io.swagger.parser.util.RefUtils.isAnExternalRefFormat;
 public class ModelProcessor {
     private final PropertyProcessor propertyProcessor;
     private final ExternalRefProcessor externalRefProcessor;
+    private final VendorExtensionProcessor vendorExtensionProcessor;
 
     public ModelProcessor(ResolverCache cache, Swagger swagger) {
         this.propertyProcessor = new PropertyProcessor(cache, swagger);
         this.externalRefProcessor = new ExternalRefProcessor(cache, swagger);
+        this.vendorExtensionProcessor = new VendorExtensionProcessor(cache, externalRefProcessor);
     }
 
     public void processModel(Model model) {
@@ -44,15 +46,14 @@ public class ModelProcessor {
 
         final Map<String, Property> properties = modelImpl.getProperties();
 
-        if (properties == null) {
-            return;
+        if (properties != null) {
+            for (Map.Entry<String, Property> propertyEntry : properties.entrySet()) {
+                final Property property = propertyEntry.getValue();
+                propertyProcessor.processProperty(property);
+            }
         }
 
-        for (Map.Entry<String, Property> propertyEntry : properties.entrySet()) {
-            final Property property = propertyEntry.getValue();
-            propertyProcessor.processProperty(property);
-        }
-
+        vendorExtensionProcessor.processRefsFromVendorExtensions(modelImpl, null);
     }
 
     private void processComposedModel(ComposedModel composedModel) {

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/VendorExtensionProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/VendorExtensionProcessor.java
@@ -1,0 +1,77 @@
+package io.swagger.parser.processors;
+
+import static io.swagger.parser.util.RefUtils.isAnExternalRefFormat;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.swagger.models.Model;
+import io.swagger.models.refs.RefFormat;
+import io.swagger.parser.ResolverCache;
+
+public class VendorExtensionProcessor {
+	
+	private final ExternalRefProcessor externalRefProcessor;
+	private final ResolverCache cache;
+	
+	public VendorExtensionProcessor(ResolverCache cache, ExternalRefProcessor externalRefProcessor) {
+		this.externalRefProcessor = externalRefProcessor;
+		this.cache = cache;
+	}
+
+    // Copied from GenericRef::computeRefFormat
+    private static RefFormat computeRefFormat(String ref) {
+        RefFormat result = RefFormat.INTERNAL;
+        if (ref.startsWith("http")) {
+            result = RefFormat.URL;
+        } else if (ref.startsWith("#/")) {
+            result = RefFormat.INTERNAL;
+        } else if (ref.startsWith(".") || ref.startsWith("/")) {
+            result = RefFormat.RELATIVE;
+        }
+
+        return result;
+    }
+
+    private void processRefsRecursively(Object node, String externalFile) {
+	    if (node != null && node instanceof ObjectNode) {
+	        ObjectNode objectNode = (ObjectNode) node;
+            if (objectNode.has("$ref")) {
+                String ref = objectNode.get("$ref").asText();
+                RefFormat refFormat = computeRefFormat(ref);
+                if (isAnExternalRefFormat(refFormat)) {
+                    Pattern pattern = Pattern.compile("(#/[^/]+/)");
+                    Matcher matcher = pattern.matcher(ref);
+                    if (!matcher.find()) {
+                        throw new RuntimeException("Unable to infer ref type: " + ref);
+                    }
+                    String refType = matcher.group(0);
+                    objectNode.put("$ref", refType + externalRefProcessor.processRefToExternalDefinition(ref, refFormat));
+                } else if (externalFile != null) {
+                    externalRefProcessor.processRefToExternalDefinition(externalFile + ref, RefFormat.RELATIVE);
+                }
+            } else {
+                Iterator<JsonNode> it = objectNode.elements();
+                while (it.hasNext()) {
+                    processRefsRecursively(it.next(), externalFile);
+                }
+            }
+        }
+    }
+
+	public void processRefsFromVendorExtensions(Model model, String externalFile) {
+        Map<String, Object> vendorExtensions = model.getVendorExtensions();
+        if (vendorExtensions != null) {
+            for (Map.Entry<String, Object> entry : vendorExtensions.entrySet()) {
+                processRefsRecursively(entry.getValue(), externalFile);
+            }
+        }
+    }
+
+}
+

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -236,6 +236,35 @@ public class SwaggerParserTest {
     }
 
     @Test
+    public void testLoadExternalVendorExtensions() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        Swagger swagger = parser.read("src/test/resources/vendor-extensions-references/b.yaml");
+        Map<String, Model> definitions = swagger.getDefinitions();
+        assertTrue(definitions.containsKey("x"));
+        assertTrue(!definitions.containsKey("y"));
+        assertTrue(definitions.containsKey("z"));
+        assertEquals(((ObjectNode) definitions.get("u").getVendorExtensions().get("x-collection")).get("schema").get("$ref").asText(), "#/definitions/t");
+
+        assertTrue(definitions.containsKey("n"));
+        assertTrue(!definitions.containsKey("m"));
+        assertTrue(definitions.containsKey("p"));
+        assertTrue(definitions.containsKey("r"));
+        assertEquals(((ObjectNode) definitions.get("n").getVendorExtensions().get("x-links")).get("q").get("schema").get("$ref").asText(), "#/definitions/r");
+    }
+
+    @Test
+    public void testLoadVendorExtensionsToExternalDef() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/vendor-extensions-references/a.yaml");
+        Map<String, Model> definitions = swagger.getDefinitions();
+        assertTrue(definitions.containsKey("t"));
+        assertEquals(((ObjectNode) definitions.get("s").getVendorExtensions().get("x-collection")).get("schema").get("$ref").asText(), "#/definitions/t");
+
+        assertTrue(definitions.containsKey("r"));
+        assertEquals(((ObjectNode) definitions.get("m").getVendorExtensions().get("x-links")).get("q").get("schema").get("$ref").asText(), "#/definitions/r");
+    }
+
+    @Test
     public void testLoadNestedItemsReferences() {
         SwaggerParser parser = new SwaggerParser();
         SwaggerDeserializationResult result = parser.readWithInfo("src/test/resources/nested-items-references/b.yaml", null, true);

--- a/modules/swagger-parser/src/test/resources/vendor-extensions-references/a.yaml
+++ b/modules/swagger-parser/src/test/resources/vendor-extensions-references/a.yaml
@@ -1,0 +1,36 @@
+---
+swagger: "2.0"
+info:
+  title: test
+  version: '0.0.0'
+paths: {}
+definitions:
+  y:
+    type: object
+    x-collection:
+      schema: 
+        $ref: "#/definitions/z"
+  z:
+    type: object
+    properties:
+      name:
+        type: string
+  m:
+    type: object
+    x-links:
+      o:
+        schema: 
+          $ref: "#/definitions/p"
+      q:
+        schema:
+          $ref: "./b.yaml#/definitions/r"
+  p:
+    type: object
+    properties:
+      name:
+        type: string
+  s:
+    type: object
+    x-collection:
+      schema: 
+        $ref: "./b.yaml#/definitions/t"

--- a/modules/swagger-parser/src/test/resources/vendor-extensions-references/b.yaml
+++ b/modules/swagger-parser/src/test/resources/vendor-extensions-references/b.yaml
@@ -1,0 +1,23 @@
+---
+swagger: "2.0"
+info:
+  title: test
+  version: '0.0.0'
+paths: {}
+definitions:
+  x:
+    $ref: "./a.yaml#/definitions/y"
+  n:
+    $ref: "./a.yaml#/definitions/m"
+  r:
+    type: object
+    properties:
+      name:
+        type: string
+  t:
+    type: object
+    properties:
+      name:
+        type: string
+  u:
+    $ref: "./a.yaml#/definitions/s"


### PR DESCRIPTION
This adds support for parsing external references inside vendor extensions, i.e: whenever a $ref is found inside a vendor extension that points to another file, the referenced definition/parameter/response is added to the swagger object.

I'm not sure if this is the intended behavior by the Swagger spec, but it is useful for adding complex behavior in vendor extensions without forking the swagger-parser.
