### PR TITLE
added check to avoid removing referenced models #278

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/ResolverCache.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/ResolverCache.java
@@ -14,10 +14,7 @@ import io.swagger.parser.util.SwaggerDeserializer;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -41,6 +38,7 @@ public class ResolverCache {
     private final String rootPath;
     private Map<String, Object> resolutionCache = new HashMap<>();
     private Map<String, String> externalFileCache = new HashMap<>();
+    private Set<String> referencedModelKeys = new HashSet<>();
 
     /*
     a map that stores original external references, and their associated renamed references
@@ -171,6 +169,17 @@ public class ResolverCache {
             }
         }
         return null;
+    }
+
+    public boolean hasReferencedKey(String modelKey) {
+        if(referencedModelKeys == null) {
+            return false;
+        }
+        return referencedModelKeys.contains(modelKey);
+    }
+
+    public void addReferencedKey(String modelKey) {
+        referencedModelKeys.add(modelKey);
     }
 
     public String getRenamedRef(String originalRef) {

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/DefinitionsProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/DefinitionsProcessor.java
@@ -53,7 +53,15 @@ public class DefinitionsProcessor {
 
                 if (renamedRef != null) {
                     //we definitely resolved the referenced and shoved it in the definitions map
-                    final Model resolvedModel = definitions.remove(renamedRef);
+                    // because the referenced model may be in the definitions map, we need to remove old instances
+                    final Model resolvedModel = definitions.get(renamedRef);
+
+                    // ensure the reference isn't still in use
+                    if(!cache.hasReferencedKey(renamedRef)) {
+                        definitions.remove(renamedRef);
+                    }
+
+                    // add the new key
                     definitions.put(modelName, resolvedModel);
                 }
             }

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
@@ -54,6 +54,7 @@ public final class ExternalRefProcessor {
         if(existingModel == null) {
             // don't overwrite existing model reference
             swagger.addDefinition(newRef, model);
+            cache.addReferencedKey(newRef);
 
             String file = $ref.split("#/")[0];
             if (model instanceof RefModel) {

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -185,9 +185,10 @@ public class SwaggerParserTest {
     public void testLoadExternalNestedDefinitions() throws Exception {
         SwaggerParser parser = new SwaggerParser();
         final Swagger swagger = parser.read("src/test/resources/nested-references/b.yaml");
+
         Map<String, Model> definitions = swagger.getDefinitions();
         assertTrue(definitions.containsKey("x"));
-        assertTrue(!definitions.containsKey("y"));
+        assertTrue(definitions.containsKey("y"));
         assertTrue(definitions.containsKey("z"));
         assertEquals(((RefModel) definitions.get("i")).get$ref(), "#/definitions/k");
     }
@@ -223,15 +224,15 @@ public class SwaggerParserTest {
         assertNotNull(Yaml.mapper().writeValueAsString(swagger));
     }
 
-    @Test(enabled = false)
+    @Test
     public void testLoadRecursiveExternalDef() throws Exception {
         SwaggerParser parser = new SwaggerParser();
         final Swagger swagger = parser.read("src/test/resources/file-reference-to-recursive-defs/b.yaml");
 
         Map<String, Model> definitions = swagger.getDefinitions();
         assertEquals(((RefProperty) ((ArrayProperty) definitions.get("v").getProperties().get("children")).getItems()).get$ref(), "#/definitions/v");
-        assertTrue(!definitions.containsKey("y"));
-        assertEquals(((RefProperty) ((ArrayProperty) definitions.get("x").getProperties().get("children")).getItems()).get$ref(), "#/definitions/x");
+        assertTrue(definitions.containsKey("y"));
+        assertEquals(((RefProperty) ((ArrayProperty) definitions.get("x").getProperties().get("children")).getItems()).get$ref(), "#/definitions/y");
     }
 
     @Test

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/processors/ExternalRefProcessorTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/processors/ExternalRefProcessorTest.java
@@ -46,6 +46,10 @@ public class ExternalRefProcessorTest {
 
             cache.putRenamedRef(ref, "bar");
             swagger.addDefinition("bar", mockedModel); times=1;
+
+			cache.addReferencedKey("bar");
+			times = 1;
+			result = null;
         }};
 
         String newRef = new ExternalRefProcessor(cache, swagger).processRefToExternalDefinition(ref, refFormat);


### PR DESCRIPTION
Fixes #278 

@diegode this is to fix the issue in #278 but...

I don't necessarily agree with the expectations in a couple tests.  Once I fixed this bug some other test failures appeared.

For example, when we have this:

```yaml
definitions:
  x:
    properties:
      foo:
        $ref: '#/definitions/y'
  y:
    $ref: '#/definitions/z'
  z:
    type: object
```

That the parser should change the definitions to this:

```yaml
definitions:
  x:
    properties:
      foo:
        $ref: '#/definitions/z'
  z:
    type: object
```

Because a model is referencing `y` in this example as a property, there may be intent and _value_ in retaining that name.  So even though `y` absorbs all the properties of `z`, the name `y` may be useful.

So this PR changes the behavior of a couple tests that were previously behaving differently.  Since you put them there, I thought it was only considerate to get your feedback before any merge :)