### PR TITLE
handle model collisions

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
@@ -43,10 +43,14 @@ public final class ExternalRefProcessor {
 
         final String possiblyConflictingDefinitionName = computeDefinitionName($ref);
 
-        final Model existingModel = definitions.get(possiblyConflictingDefinitionName);
+        Model existingModel = definitions.get(possiblyConflictingDefinitionName);
 
         if (existingModel != null) {
             LOGGER.debug("A model for " + existingModel + " already exists");
+            if(existingModel instanceof RefModel) {
+                // use the new model
+                existingModel = null;
+            }
         }
         newRef = possiblyConflictingDefinitionName;
         cache.putRenamedRef($ref, newRef);

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/FileReferenceTests.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/FileReferenceTests.java
@@ -1,9 +1,6 @@
 package io.swagger.parser;
 
-import io.swagger.models.Model;
-import io.swagger.models.Operation;
-import io.swagger.models.Path;
-import io.swagger.models.Swagger;
+import io.swagger.models.*;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.parser.util.SwaggerDeserializationResult;
@@ -136,5 +133,14 @@ public class FileReferenceTests {
         assertNotNull(result.getSwagger());
 
         Swagger swagger = result.getSwagger();
+    }
+
+    @Test
+    public void testIssue340() {
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("./src/test/resources/nested-file-references/issue-340.json", null, true);
+        assertNotNull(result.getSwagger());
+
+        Swagger swagger = result.getSwagger();
+        assertFalse(swagger.getDefinitions().get("BarData") instanceof RefModel);
     }
 }

--- a/modules/swagger-parser/src/test/resources/nested-file-references/issue-340-Bar.json
+++ b/modules/swagger-parser/src/test/resources/nested-file-references/issue-340-Bar.json
@@ -1,0 +1,64 @@
+{
+  "bar": {
+    "post": {
+      "description": "posts stuff",
+      "deprecated": true,
+      "operationId": "enrollInBar",
+      "produces": [
+        "application/json"
+      ],
+      "parameters": [
+        {
+          "name": "Authorization",
+          "in": "header",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "barRequest",
+          "in": "body",
+          "description": "The request body containing the amount",
+          "required": true,
+          "schema": {
+            "$ref": "#/definitions/BarSettingsRequest"
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "schema": {
+            "$ref": "#/definitions/BarData"
+          }
+        },
+        "default": {}
+      }
+    }
+  },
+  "definitions": {
+    "BarSettingsRequest": {
+      "properties": {
+        "stuff": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "stuff"
+      ]
+    },
+    "BarData": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "BazData": {
+      "properties": {
+        "enabled": {
+          "description": "am i broken",
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/nested-file-references/issue-340.json
+++ b/modules/swagger-parser/src/test/resources/nested-file-references/issue-340.json
@@ -1,0 +1,42 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "FooAPI",
+    "description": "API for all accesses to the Foo server system",
+    "termsOfService": "TBD",
+    "contact": {
+      "name": "Foo API Team"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "api.foo.com",
+  "basePath": "",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/bar": {
+      "$ref": "./issue-340-Bar.json#/bar"
+    }
+  },
+  "definitions": {
+    "BarSettingsRequest": {
+      "$ref": "./issue-340-Bar.json#/definitions/BarSettingsRequest"
+    },
+    "BarData": {
+      "$ref": "./issue-340-Bar.json#/definitions/BarData"
+    },
+    "BazData": {
+      "$ref": "./issue-340-Bar.json#/definitions/BazData"
+    }
+  }
+}


### PR DESCRIPTION
There are cases where there are model name collisions.  There are scenarios where there is a clear priority when this happens, and a model implementation should clobber a model reference

Fixes #340 