### PR TITLE
Fix bug in relative path generation: 

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
@@ -61,7 +61,7 @@ public class RefUtils {
 
 
     public static String readExternalUrlRef(String file, RefFormat refFormat, List<AuthorizationValue> auths,
-                                         String rootPath) {
+                                            String rootPath) {
 
         if (!RefUtils.isAnExternalRefFormat(refFormat)) {
             throw new RuntimeException("Ref is not external");
@@ -114,16 +114,13 @@ public class RefUtils {
             }
             else if ("..".equals(relPathParts[i])) {
                 trimRel += 1;
+                trimRoot += 1;
             }
         }
 
         String [] outputParts = new String[rootPathParts.length + relPathParts.length - trimRoot - trimRel];
         System.arraycopy(rootPathParts, 0, outputParts, 0, rootPathParts.length - trimRoot);
-        System.arraycopy(relPathParts,
-                trimRel,
-                outputParts,
-                rootPathParts.length - trimRoot + trimRel - 1,
-                relPathParts.length - trimRel);
+        System.arraycopy(relPathParts, trimRel, outputParts, rootPathParts.length - trimRoot, relPathParts.length - trimRel);
 
         return StringUtils.join(outputParts, "/");
     }

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
@@ -4,9 +4,10 @@ import io.swagger.models.Model;
 import io.swagger.models.auth.AuthorizationValue;
 import io.swagger.models.refs.RefFormat;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.FileInputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -86,43 +87,20 @@ public class RefUtils {
 
     }
 
-    public static String buildUrl(String rootPath, String relativePath) {
-        String[] rootPathParts = rootPath.split("/");
-        String [] relPathParts = relativePath.split("/");
-
+    public static String buildUrl(String rootPath, String relativePath) throws URISyntaxException {
         if(rootPath == null || relativePath == null) {
             return null;
         }
 
-        int trimRoot = 0;
-        int trimRel = 0;
+        URI uriRootPath = new URI(rootPath);
 
-        if(!"".equals(rootPathParts[rootPathParts.length - 1])) {
-            trimRoot = 1;
-        }
-        for(int i = 0; i < rootPathParts.length; i++) {
-            if("".equals(rootPathParts[i])) {
-                trimRel += 1;
-            }
-            else {
-                break;
-            }
-        }
-        for(int i = 0; i < relPathParts.length; i ++) {
-            if(".".equals(relPathParts[i])) {
-                trimRel += 1;
-            }
-            else if ("..".equals(relPathParts[i])) {
-                trimRel += 1;
-                trimRoot += 1;
-            }
-        }
+        // Cater for filename in URL
+        if(uriRootPath.getPath().length() == 0)
+            relativePath = "/" + relativePath;
+        else if(!uriRootPath.getPath().endsWith("/") && !relativePath.startsWith("."))
+            relativePath = "../" + relativePath;
 
-        String [] outputParts = new String[rootPathParts.length + relPathParts.length - trimRoot - trimRel];
-        System.arraycopy(rootPathParts, 0, outputParts, 0, rootPathParts.length - trimRoot);
-        System.arraycopy(relPathParts, trimRel, outputParts, rootPathParts.length - trimRoot, relPathParts.length - trimRel);
-
-        return StringUtils.join(outputParts, "/");
+        return uriRootPath.resolve(relativePath).normalize().toString();
     }
 
     public static String readExternalRef(String file, RefFormat refFormat, List<AuthorizationValue> auths,

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/RefUtilsTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/RefUtilsTest.java
@@ -13,16 +13,14 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.testng.Assert.*;
 
 public class RefUtilsTest {
 
@@ -172,6 +170,18 @@ public class RefUtilsTest {
 
         String actualResult = RefUtils.readExternalRef(filePath, RefFormat.RELATIVE, auths, parentDirectory);
         assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void testBuildURLRelativePath() throws URISyntaxException {
+        assertEquals(RefUtils.buildUrl("http://foo.bar.com/foo/bar", "/fun"), "http://foo.bar.com/fun");
+        assertEquals(RefUtils.buildUrl("http://foo.bar.com/foo/bar#/baz/bat", "/fun"), "http://foo.bar.com/fun");
+        assertEquals(RefUtils.buildUrl("http://foo.bar.com/foo/bar#/baz/bat", "/fun#for/all"), "http://foo.bar.com/fun#for/all");
+
+        assertEquals(RefUtils.buildUrl("http://foo.bar.com", "./fun"), "http://foo.bar.com/fun");
+        assertEquals(RefUtils.buildUrl("http://foo.bar.com/veryFun", "./fun"), "http://foo.bar.com/fun");
+        assertEquals(RefUtils.buildUrl("http://foo.bar.com/veryFun/", "../fun#nothing"), "http://foo.bar.com/fun#nothing");
+        assertEquals(RefUtils.buildUrl("http://foo.bar.com/veryFun/notFun", "../fun#/it/is/fun"), "http://foo.bar.com/fun#/it/is/fun");
     }
 
     private void setupRelativeFileExpectations(@Mocked final FileInputStream fileInputStream, @Injectable final Path parentDirectory, @Injectable final Path pathToUse, @Injectable final File file, final String filePath) throws Exception {


### PR DESCRIPTION
'./' results in array out of bounds ands '../' results in root component not being truncated properly