### PR TITLE
Fix parsing of non-string enum values

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -678,7 +678,12 @@ public class SwaggerDeserializer {
                 ArrayNode arrayNode = getArray("enum", node, false, location, result);
                 if(arrayNode != null) {
                     for(JsonNode n : arrayNode) {
-                        impl._enum(n.textValue());
+                        if(n.isValueNode()) {
+                            impl._enum(n.asText());
+                        }
+                        else {
+                            result.invalidType(location, "enum", "value", n);
+                        }
                     }
                 }
             }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
@@ -692,26 +692,67 @@ public class SwaggerDeserializerTest {
                 "        '200':\n" +
                 "          description: Successful response\n" +
                 "          schema:\n" +
-                "            $ref: '#/definitions/ExampleEnum'\n" +
+                "            type: object\n" +
+                "            properties:\n" +
+                "              se:\n" +
+                "                $ref: '#/definitions/StringEnum'\n" +
+                "              ie:\n" +
+                "                $ref: '#/definitions/IntegerEnum'\n" +
+                "              ne:\n" +
+                "                $ref: '#/definitions/NumberEnum'\n" +
                 "definitions:\n" +
-                "  ExampleEnum:\n" +
+                "  StringEnum:\n" +
                 "    type: string\n" +
                 "    default: foo\n" +
                 "    enum:\n" +
                 "      - First\n" +
-                "      - Second";
+                "      - Second\n" +
+                "  IntegerEnum:\n" +
+                "    type: integer\n" +
+                "    default: 1\n" +
+                "    enum:\n" +
+                "      - -1\n" +
+                "      - 0\n" +
+                "      - 1\n" +
+                "  NumberEnum:\n" +
+                "    type: number\n" +
+                "    default: 3.14\n" +
+                "    enum:\n" +
+                "      - -1.151\n" +
+                "      - 0.0\n" +
+                "      - 1.6161\n" +
+                "      - 3.14";
         SwaggerParser parser = new SwaggerParser();
         SwaggerDeserializationResult result = parser.readWithInfo(yaml);
 
         final Swagger resolved = new SwaggerResolver(result.getSwagger(), null).resolve();
 
-        Model model = resolved.getDefinitions().get("ExampleEnum");
-        assertTrue(model instanceof ModelImpl);
-        ModelImpl impl = (ModelImpl) model;
-        List<String> enumValues = impl.getEnum();
-        assertTrue(enumValues.size() == 2);
-        assertEquals(enumValues.get(0), "First");
-        assertEquals(enumValues.get(1), "Second");
+        Model stringModel = resolved.getDefinitions().get("StringEnum");
+        assertTrue(stringModel instanceof ModelImpl);
+        ModelImpl stringImpl = (ModelImpl) stringModel;
+        List<String> stringValues = stringImpl.getEnum();
+        assertEquals(2, stringValues.size());
+        assertEquals("First", stringValues.get(0));
+        assertEquals("Second", stringValues.get(1));
+
+        Model integerModel = resolved.getDefinitions().get("IntegerEnum");
+        assertTrue(integerModel instanceof ModelImpl);
+        ModelImpl integerImpl = (ModelImpl) integerModel;
+        List<String> integerValues = integerImpl.getEnum();
+        assertEquals(3, integerValues.size());
+        assertEquals("-1", integerValues.get(0));
+        assertEquals("0", integerValues.get(1));
+        assertEquals("1", integerValues.get(2));
+
+        Model numberModel = resolved.getDefinitions().get("NumberEnum");
+        assertTrue(numberModel instanceof ModelImpl);
+        ModelImpl numberImpl = (ModelImpl) numberModel;
+        List<String> numberValues = numberImpl.getEnum();
+        assertEquals(4, numberValues.size());
+        assertEquals("-1.151", numberValues.get(0));
+        assertEquals("0.0", numberValues.get(1));
+        assertEquals("1.6161", numberValues.get(2));
+        assertEquals("3.14", numberValues.get(3));
     }
 
     @Test


### PR DESCRIPTION
[JSON Schema v4 allows enum to contain values of any type, explicitly including null](http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.20).  Swagger v2.0 adopts this definition without change (as far as I am aware) but the parser previously parsed any non-string values as `null`.  This PR fixes this to return the string representation of non-string primitive values and to warn about unsupported non-primitive values and add test cases to cover these.

For reference, I discovered this issue when attempting to run swagger-codegen against a Swagger declaration with an integer enumeration, which produced the following error:

    Exception in thread "main" java.lang.RuntimeException: Could not process model 'MyEnum'.Please make sure that your schema is correct!
            at io.swagger.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:290)
            at io.swagger.codegen.DefaultGenerator.generate(DefaultGenerator.java:647)
            at io.swagger.codegen.cmd.Generate.run(Generate.java:223)
            at io.swagger.codegen.SwaggerCodegen.main(SwaggerCodegen.java:41)
    Caused by: java.lang.NullPointerException
            at io.swagger.codegen.DefaultCodegen.postProcessModelsEnum(DefaultCodegen.java:229)
            at io.swagger.codegen.languages.JavaClientCodegen.postProcessModelsEnum(JavaClientCodegen.java:316)
            at io.swagger.codegen.languages.AbstractJavaCodegen.postProcessModels(AbstractJavaCodegen.java:719)
            at io.swagger.codegen.DefaultGenerator.processModels(DefaultGenerator.java:919)
            at io.swagger.codegen.DefaultGenerator.generateModels(DefaultGenerator.java:285)
            ... 3 more
