### PR TITLE
Support file URL scheme produced by java.io.File et al.

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/Swagger20Parser.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/Swagger20Parser.java
@@ -42,7 +42,7 @@ public class Swagger20Parser implements SwaggerParserExtension {
             if (location.toLowerCase().startsWith("http")) {
                 data = RemoteUrl.urlToString(location, auths);
             } else {
-                final String fileScheme = "file://";
+                final String fileScheme = "file:";
                 Path path;
                 if (location.toLowerCase().startsWith(fileScheme)) {
                     path = Paths.get(URI.create(location));
@@ -80,7 +80,7 @@ public class Swagger20Parser implements SwaggerParserExtension {
             if (location.toLowerCase().startsWith("http")) {
                 data = RemoteUrl.urlToString(location, auths);
             } else {
-                final String fileScheme = "file://";
+                final String fileScheme = "file:";
                 Path path;
                 if (location.toLowerCase().startsWith(fileScheme)) {
                     path = Paths.get(URI.create(location));

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/PathUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/PathUtils.java
@@ -8,7 +8,7 @@ public class PathUtils {
 
 
     public static Path getParentDirectoryOfFile(String fileStr) {
-        final String fileScheme = "file://";
+        final String fileScheme = "file:";
         Path file;
         fileStr = fileStr.replaceAll("\\\\","/");
         if (fileStr.toLowerCase().startsWith(fileScheme)) {

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerReaderTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerReaderTest.java
@@ -38,6 +38,22 @@ public class SwaggerReaderTest {
         assertNotNull(swagger);
     }
 
+    @Test(description = "it should read the uber api from Path URI")
+    public void readUberApiFromPathUri() {
+        final SwaggerParser parser = new SwaggerParser();
+        java.nio.file.Path uberPath = Paths.get("src/test/resources/uber.json");
+        final Swagger swagger = parser.read(uberPath.toUri().toString());
+        assertNotNull(swagger);
+    }
+
+    @Test(description = "it should read the uber api from File URI")
+    public void readUberApiFromFileUri() {
+        final SwaggerParser parser = new SwaggerParser();
+        java.io.File uberFile = new java.io.File("src/test/resources/uber.json");
+        final Swagger swagger = parser.read(uberFile.toURI().toString());
+        assertNotNull(swagger);
+    }
+
     @Test(description = "it should read the uber api with url string without file scheme")
     public void readUberApiFromFileNoScheme() {
         final SwaggerParser parser = new SwaggerParser();


### PR DESCRIPTION
The URLs produced by `java.io.File.toURI()` (and deprecated `.toURL()`) and `java.lang.Class.getResource(String)` contain no additional slashes between `file:` and the path.  This makes using `Swagger20Parser` with files from these methods a bit more painful than it needs to be.  This PR addresses this by recognizing strings starting with `file:` as file URLs and adds tests to cover this case.

I hope you find it useful,
Kevin