### PR TITLE
Add configuration for AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+# http://www.appveyor.com/docs/appveyor-yml
+environment:
+  matrix:
+    - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
+    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+install:
+  # Log versions for debugging
+  - java -version
+  - mvn --version
+build_script:
+  - mvn --batch-mode -DskipTests package
+test_script:
+  - mvn --batch-mode test verify install
+cache:
+  - C:\Users\appveyor\.m2


### PR DESCRIPTION
This PR is a follow-up to https://github.com/swagger-api/swagger-parser/pull/374#issuecomment-269657834 which adds the `appveyor.yml` file which I used for CI testing on Windows.  It simply runs the relevant Maven goals for Java 7 and 8.  An example of the output is at https://ci.appveyor.com/project/kevinoid/swagger-parser/build/1.0.9

To setup CI for this repository, you will need to create a free AppVeyor account and add this repository as an AppVeyor project.  The process is described in [the docs](https://www.appveyor.com/docs/) and should take less than 5 minutes.

Thanks!
Kevin