### PR TITLE
httpclient to 4.5.2 to mitigate CVE threats

### DIFF
--- a/modules/swagger-compat-spec-parser/pom.xml
+++ b/modules/swagger-compat-spec-parser/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.3</version>
+            <version>4.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>


### PR DESCRIPTION
Updating httpclient to 4.5.2 to mitigate CVE-2014-3577 & CVE-2015-5262.  v4.5.2 is not the latest version but chosen for popularity.