### PR TITLE
Fix/misc

### DIFF
--- a/modules/swagger-parser/pom.xml
+++ b/modules/swagger-parser/pom.xml
@@ -74,6 +74,12 @@
             <version>${commons-io-version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
             <version>${wiremock-version}</version>

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/ResolverCache.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/ResolverCache.java
@@ -36,14 +36,14 @@ public class ResolverCache {
     private final List<AuthorizationValue> auths;
     private final Path parentDirectory;
     private final String rootPath;
-    private Map<String, Object> resolutionCache = new HashMap<>();
-    private Map<String, String> externalFileCache = new HashMap<>();
-    private Set<String> referencedModelKeys = new HashSet<>();
+    private Map<String, Object> resolutionCache = new LinkedHashMap<>();
+    private Map<String, String> externalFileCache = new LinkedHashMap<>();
+    private Set<String> referencedModelKeys = new LinkedHashSet<>();
 
     /*
     a map that stores original external references, and their associated renamed references
      */
-    private Map<String, String> renameCache = new HashMap<>();
+    private Map<String, String> renameCache = new LinkedHashMap<>();
 
     public ResolverCache(Swagger swagger, List<AuthorizationValue> auths, String parentFileLocation) {
         this.swagger = swagger;

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/ResolverCache.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/ResolverCache.java
@@ -14,7 +14,12 @@ import io.swagger.parser.util.SwaggerDeserializer;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -36,14 +41,14 @@ public class ResolverCache {
     private final List<AuthorizationValue> auths;
     private final Path parentDirectory;
     private final String rootPath;
-    private Map<String, Object> resolutionCache = new LinkedHashMap<>();
-    private Map<String, String> externalFileCache = new LinkedHashMap<>();
-    private Set<String> referencedModelKeys = new LinkedHashSet<>();
+    private Map<String, Object> resolutionCache = new HashMap<>();
+    private Map<String, String> externalFileCache = new HashMap<>();
+    private Set<String> referencedModelKeys = new HashSet<>();
 
     /*
     a map that stores original external references, and their associated renamed references
      */
-    private Map<String, String> renameCache = new LinkedHashMap<>();
+    private Map<String, String> renameCache = new HashMap<>();
 
     public ResolverCache(Swagger swagger, List<AuthorizationValue> auths, String parentFileLocation) {
         this.swagger = swagger;

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/SwaggerParser.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/SwaggerParser.java
@@ -59,7 +59,6 @@ public class SwaggerParser {
             return null;
         }
         location = location.replaceAll("\\\\","/");
-        List<SwaggerParserExtension> parserExtensions = getExtensions();
         Swagger output;
 
         try {
@@ -69,6 +68,8 @@ public class SwaggerParser {
             }
         } catch (IOException e) {
         }
+
+        List<SwaggerParserExtension> parserExtensions = getExtensions();
         for (SwaggerParserExtension extension : parserExtensions) {
             try {
                 output = extension.read(location, auths);

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/SwaggerResolver.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/SwaggerResolver.java
@@ -19,17 +19,27 @@ public class SwaggerResolver {
     private final PathsProcessor pathProcessor;
     private final DefinitionsProcessor definitionsProcessor;
     private final OperationProcessor operationsProcessor;
+    private Settings settings = new Settings();
 
-    public SwaggerResolver(Swagger swagger, List<AuthorizationValue> auths, String parentFileLocation) {
-        this.swagger = swagger;
-        this.cache = new ResolverCache(swagger, auths, parentFileLocation);
-        definitionsProcessor = new DefinitionsProcessor(cache, swagger);
-        pathProcessor = new PathsProcessor(cache, swagger);
-        operationsProcessor = new OperationProcessor(cache, swagger);
+    public SwaggerResolver(Swagger swagger) {
+        this(swagger, null, null, null);
     }
 
     public SwaggerResolver(Swagger swagger,  List<AuthorizationValue> auths) {
-        this(swagger, auths, null);
+        this(swagger, auths, null, null);
+    }
+
+    public SwaggerResolver(Swagger swagger, List<AuthorizationValue> auths, String parentFileLocation) {
+        this(swagger, auths, parentFileLocation, null);
+    }
+
+    public SwaggerResolver(Swagger swagger, List<AuthorizationValue> auths, String parentFileLocation, Settings settings) {
+        this.swagger = swagger;
+        this.settings = settings != null ? settings : new Settings();
+        this.cache = new ResolverCache(swagger, auths, parentFileLocation);
+        definitionsProcessor = new DefinitionsProcessor(cache, swagger);
+        pathProcessor = new PathsProcessor(cache, swagger, this.settings);
+        operationsProcessor = new OperationProcessor(cache, swagger);
     }
 
     public Swagger resolve() {
@@ -52,5 +62,27 @@ public class SwaggerResolver {
         }
 
         return swagger;
+    }
+
+    public static class Settings {
+
+        private boolean addParametersToEachOperation = true;
+
+        /**
+         * If true, resource parameters are added to each operation
+         */
+        public boolean addParametersToEachOperation() {
+            return this.addParametersToEachOperation;
+        }
+
+        /**
+         * If true, resource parameters are added to each operation
+         */
+        public Settings addParametersToEachOperation(final boolean addParametersToEachOperation) {
+            this.addParametersToEachOperation = addParametersToEachOperation;
+            return this;
+        }
+
+
     }
 }

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/DefinitionsProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/DefinitionsProcessor.java
@@ -5,7 +5,7 @@ import io.swagger.models.RefModel;
 import io.swagger.models.Swagger;
 import io.swagger.parser.ResolverCache;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,7 +29,7 @@ public class DefinitionsProcessor {
             return;
         }
 
-        Set<String> keySet = new HashSet<>();
+        Set<String> keySet = new LinkedHashSet<>();
 
         // the definitions can grow as we resolve references
         while(definitions.keySet().size() > keySet.size()) {

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
@@ -13,7 +13,7 @@ import io.swagger.parser.ResolverCache;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static io.swagger.parser.util.RefUtils.computeDefinitionName;
@@ -38,7 +38,7 @@ public final class ExternalRefProcessor {
         Map<String, Model> definitions = swagger.getDefinitions();
 
         if (definitions == null) {
-            definitions = new HashMap<>();
+            definitions = new LinkedHashMap<>();
         }
 
         final String possiblyConflictingDefinitionName = computeDefinitionName($ref);

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/DeserializationUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/DeserializationUtils.java
@@ -14,10 +14,10 @@ public class DeserializationUtils {
         JsonNode result;
 
         try {
-            if (fileOrHost.endsWith(".yaml")) {
-                result = readYamlTree(contents);
-            } else {
+            if (isJson(contents)) {
                 result = Json.mapper().readTree(contents);
+            } else {
+                result = readYamlTree(contents);
             }
         } catch (IOException e) {
             throw new RuntimeException("An exception was thrown while trying to deserialize the contents of " + fileOrHost + " into a JsonNode tree", e);
@@ -31,7 +31,7 @@ public class DeserializationUtils {
 
         boolean isJson = false;
 
-        if(contents instanceof String && contents.toString().trim().startsWith("{")) {
+        if(contents instanceof String && isJson((String)contents)) {
             isJson = true;
         }
 
@@ -50,6 +50,10 @@ public class DeserializationUtils {
         }
 
         return result;
+    }
+
+    private static boolean isJson(String contents) {
+        return contents.toString().trim().startsWith("{");
     }
 
     public static JsonNode readYamlTree(String contents) {

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -15,20 +15,20 @@ import java.util.*;
 import static io.swagger.models.properties.PropertyBuilder.PropertyId.*;
 
 public class SwaggerDeserializer {
-    static Set<String> ROOT_KEYS = new HashSet<String>(Arrays.asList("swagger", "info", "host", "basePath", "schemes", "consumes", "produces", "paths", "definitions", "parameters", "responses", "securityDefinitions", "security", "tags", "externalDocs"));
-    static Set<String> EXTERNAL_DOCS_KEYS = new HashSet<String>(Arrays.asList("description", "url"));
-    static Set<String> SCHEMA_KEYS = new HashSet<String>(Arrays.asList("discriminator", "example", "$ref", "format", "title", "description", "default", "multipleOf", "maximum", "exclusiveMaximum", "minimum", "exclusiveMinimum", "maxLength", "minLength", "pattern", "maxItems", "minItems", "uniqueItems", "maxProperties", "minProperties", "required", "enum", "type", "items", "allOf", "properties", "additionalProperties", "xml", "readOnly", "allowEmptyValue"));
-    static Set<String> INFO_KEYS = new HashSet<String>(Arrays.asList("title", "description", "termsOfService", "contact", "license", "version"));
-    static Set<String> TAG_KEYS = new HashSet<String>(Arrays.asList("description", "name", "externalDocs"));
-    static Set<String> RESPONSE_KEYS = new HashSet<String>(Arrays.asList("description", "schema", "headers", "examples"));
-    static Set<String> CONTACT_KEYS = new HashSet<String>(Arrays.asList("name", "url", "email"));
-    static Set<String> LICENSE_KEYS = new HashSet<String>(Arrays.asList("name", "url"));
-    static Set<String> REF_MODEL_KEYS = new HashSet<String>(Arrays.asList("$ref"));
-    static Set<String> PATH_KEYS = new HashSet<String>(Arrays.asList("$ref", "get", "put", "post", "delete", "head", "patch", "options", "parameters"));
-    static Set<String> OPERATION_KEYS = new HashSet<String>(Arrays.asList("scheme", "tags", "summary", "description", "externalDocs", "operationId", "consumes", "produces", "parameters", "responses", "schemes", "deprecated", "security"));
-    static Set<String> PARAMETER_KEYS = new HashSet<String>(Arrays.asList("name", "in", "description", "required", "type", "format", "allowEmptyValue", "items", "collectionFormat", "default", "maximum", "exclusiveMaximum", "minimum", "exclusiveMinimum", "maxLength", "minLength", "pattern", "maxItems", "minItems", "uniqueItems", "enum", "multipleOf", "readOnly", "allowEmptyValue"));
-    static Set<String> BODY_PARAMETER_KEYS = new HashSet<String>(Arrays.asList("name", "in", "description", "required", "schema"));
-    static Set<String> SECURITY_SCHEME_KEYS = new HashSet<String>(Arrays.asList("type", "name", "in", "description", "flow", "authorizationUrl", "tokenUrl" , "scopes"));
+    static Set<String> ROOT_KEYS = new LinkedHashSet<String>(Arrays.asList("swagger", "info", "host", "basePath", "schemes", "consumes", "produces", "paths", "definitions", "parameters", "responses", "securityDefinitions", "security", "tags", "externalDocs"));
+    static Set<String> EXTERNAL_DOCS_KEYS = new LinkedHashSet<String>(Arrays.asList("description", "url"));
+    static Set<String> SCHEMA_KEYS = new LinkedHashSet<String>(Arrays.asList("discriminator", "example", "$ref", "format", "title", "description", "default", "multipleOf", "maximum", "exclusiveMaximum", "minimum", "exclusiveMinimum", "maxLength", "minLength", "pattern", "maxItems", "minItems", "uniqueItems", "maxProperties", "minProperties", "required", "enum", "type", "items", "allOf", "properties", "additionalProperties", "xml", "readOnly", "allowEmptyValue"));
+    static Set<String> INFO_KEYS = new LinkedHashSet<String>(Arrays.asList("title", "description", "termsOfService", "contact", "license", "version"));
+    static Set<String> TAG_KEYS = new LinkedHashSet<String>(Arrays.asList("description", "name", "externalDocs"));
+    static Set<String> RESPONSE_KEYS = new LinkedHashSet<String>(Arrays.asList("description", "schema", "headers", "examples"));
+    static Set<String> CONTACT_KEYS = new LinkedHashSet<String>(Arrays.asList("name", "url", "email"));
+    static Set<String> LICENSE_KEYS = new LinkedHashSet<String>(Arrays.asList("name", "url"));
+    static Set<String> REF_MODEL_KEYS = new LinkedHashSet<String>(Arrays.asList("$ref"));
+    static Set<String> PATH_KEYS = new LinkedHashSet<String>(Arrays.asList("$ref", "get", "put", "post", "delete", "head", "patch", "options", "parameters"));
+    static Set<String> OPERATION_KEYS = new LinkedHashSet<String>(Arrays.asList("scheme", "tags", "summary", "description", "externalDocs", "operationId", "consumes", "produces", "parameters", "responses", "schemes", "deprecated", "security"));
+    static Set<String> PARAMETER_KEYS = new LinkedHashSet<String>(Arrays.asList("name", "in", "description", "required", "type", "format", "allowEmptyValue", "items", "collectionFormat", "default", "maximum", "exclusiveMaximum", "minimum", "exclusiveMinimum", "maxLength", "minLength", "pattern", "maxItems", "minItems", "uniqueItems", "enum", "multipleOf", "readOnly", "allowEmptyValue"));
+    static Set<String> BODY_PARAMETER_KEYS = new LinkedHashSet<String>(Arrays.asList("name", "in", "description", "required", "schema"));
+    static Set<String> SECURITY_SCHEME_KEYS = new LinkedHashSet<String>(Arrays.asList("type", "name", "in", "description", "flow", "authorizationUrl", "tokenUrl" , "scopes"));
 
     public SwaggerDeserializationResult deserialize(JsonNode rootNode) {
         SwaggerDeserializationResult result = new SwaggerDeserializationResult();
@@ -115,7 +115,7 @@ public class SwaggerDeserializer {
             // TODO: parse
 
             if(obj != null) {
-                Map<String, Parameter> parameters = new HashMap<>();
+                Map<String, Parameter> parameters = new LinkedHashMap<>();
                 Set<String> keys = getKeys(obj);
                 for(String key : keys) {
                     JsonNode paramNode = obj.get(key);
@@ -472,7 +472,7 @@ public class SwaggerDeserializer {
             if(sp != null) {
                 // type is mandatory when sp != null
                 getString("type", obj, true, location, result);
-                Map<PropertyBuilder.PropertyId, Object> map = new HashMap<PropertyBuilder.PropertyId, Object>();
+                Map<PropertyBuilder.PropertyId, Object> map = new LinkedHashMap<PropertyBuilder.PropertyId, Object>();
 
                 map.put(TYPE, type);
                 map.put(FORMAT, format);
@@ -1221,7 +1221,7 @@ public class SwaggerDeserializer {
         if(node == null)
             return null;
 
-        Map<String, SecuritySchemeDefinition> output = new HashMap<String, SecuritySchemeDefinition>();
+        Map<String, SecuritySchemeDefinition> output = new LinkedHashMap<>();
         Set<String> keys = getKeys(node);
 
         for(String key : keys) {
@@ -1547,9 +1547,9 @@ public class SwaggerDeserializer {
 
     static class ParseResult {
         private boolean valid = true;
-        private Map<Location, JsonNode> extra = new HashMap<Location, JsonNode>();
-        private Map<Location, JsonNode> unsupported = new HashMap<Location, JsonNode>();
-        private Map<Location, String> invalidType = new HashMap<Location, String>();
+        private Map<Location, JsonNode> extra = new LinkedHashMap<Location, JsonNode>();
+        private Map<Location, JsonNode> unsupported = new LinkedHashMap<Location, JsonNode>();
+        private Map<Location, String> invalidType = new LinkedHashMap<Location, String>();
         private List<Location> missing = new ArrayList<Location>();
 
         public void unsupported(String location, String key, JsonNode value) {

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -836,49 +836,7 @@ public class SwaggerDeserializer {
     }
 
     public Object extension(JsonNode jsonNode) {
-        if(jsonNode.getNodeType().equals(JsonNodeType.BOOLEAN)) {
-            return jsonNode.asBoolean();
-        }
-        if(jsonNode.getNodeType().equals(JsonNodeType.STRING)) {
-            return jsonNode.asText();
-        }
-        if(jsonNode.getNodeType().equals(JsonNodeType.NUMBER)) {
-            NumericNode n = (NumericNode) jsonNode;
-            if(n.isLong()) {
-                return jsonNode.asLong();
-            }
-            if(n.isInt()) {
-                return jsonNode.asInt();
-            }
-            if(n.isBigDecimal()) {
-                return jsonNode.textValue();
-            }
-            if(n.isBoolean()) {
-                return jsonNode.asBoolean();
-            }
-            if(n.isFloat()) {
-                return jsonNode.floatValue();
-            }
-            if(n.isDouble()) {
-                return jsonNode.doubleValue();
-            }
-            if(n.isShort()) {
-                return jsonNode.intValue();
-            }
-            return jsonNode.asText();
-        }
-        if(jsonNode.getNodeType().equals(JsonNodeType.ARRAY)) {
-            ArrayNode an = (ArrayNode) jsonNode;
-            List<Object> o = new ArrayList<Object>();
-            for(JsonNode i : an) {
-                Object obj = extension(i);
-                if(obj != null) {
-                    o.add(obj);
-                }
-            }
-            return o;
-        }
-        return jsonNode;
+        return Json.mapper().convertValue(jsonNode, Object.class);
     }
 
     public Model allOfModel(ObjectNode node, String location, ParseResult result) {

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -132,19 +132,19 @@ public class SwaggerDeserializer {
             swagger.responses(responses);
 
             obj = getObject("securityDefinitions", on, false, location, result);
-            Map<String, SecuritySchemeDefinition> securityDefinitions = securityDefinitions(obj, location, result);
+            Map<String, SecuritySchemeDefinition> securityDefinitions = securityDefinitions(obj, "securityDefinitions", result);
             swagger.setSecurityDefinitions(securityDefinitions);
 
             array = getArray("security", on, false, location, result);
-            List<SecurityRequirement> security = securityRequirements(array, location, result);
+            List<SecurityRequirement> security = securityRequirements(array, "security", result);
             swagger.setSecurity(security);
 
             array = getArray("tags", on, false, location, result);
-            List<Tag> tags = tags(array, location, result);
+            List<Tag> tags = tags(array, "tags", result);
             swagger.tags(tags);
 
             obj = getObject("externalDocs", on, false, location, result);
-            ExternalDocs docs = externalDocs(obj, location, result);
+            ExternalDocs docs = externalDocs(obj, "externalDocs", result);
             swagger.externalDocs(docs);
 
             // extra keys
@@ -1184,7 +1184,7 @@ public class SwaggerDeserializer {
 
         for(String key : keys) {
             ObjectNode obj = getObject(key, node, false, location, result);
-            SecuritySchemeDefinition def = securityDefinition(obj, location, result);
+            SecuritySchemeDefinition def = securityDefinition(obj, location + "." + key, result);
 
             if(def != null) {
                 output.put(key, def);

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -480,10 +480,10 @@ public class SwaggerDeserializer {
                 map.put(DEFAULT, defaultValue);
                 sp.setDefault(defaultValue);
 
-                String numberAsString = getString("maximum", obj, false, location, result);
-                if(numberAsString != null) {
-                    map.put(MAXIMUM, new BigDecimal(numberAsString));
-                    sp.setMaximum(new BigDecimal(numberAsString));
+                BigDecimal bd = getBigDecimal("maximum", obj, false, location, result);
+                if(bd != null) {
+                    map.put(MAXIMUM, bd);
+                    sp.setMaximum(bd);
                 }
 
                 Boolean bl = getBoolean("exclusiveMaximum", obj, false, location, result);
@@ -492,10 +492,10 @@ public class SwaggerDeserializer {
                     sp.setExclusiveMaximum(bl);
                 }
 
-                numberAsString = getString("minimum", obj, false, location, result);
-                if(numberAsString != null) {
-                    map.put(MINIMUM, new BigDecimal(numberAsString.toString()));
-                    sp.setMinimum(new BigDecimal(numberAsString.toString()));
+                bd = getBigDecimal("minimum", obj, false, location, result);
+                if(bd != null) {
+                    map.put(MINIMUM, bd);
+                    sp.setMinimum(bd);
                 }
 
                 bl = getBoolean("exclusiveMinimum", obj, false, location, result);
@@ -504,8 +504,13 @@ public class SwaggerDeserializer {
                     sp.setExclusiveMinimum(bl);
                 }
 
-                map.put(MAX_LENGTH, getInteger("maxLength", obj, false, location, result));
-                map.put(MIN_LENGTH, getInteger("minLength", obj, false, location, result));
+                Integer maxLength = getInteger("maxLength", obj, false, location, result);
+                map.put(MAX_LENGTH, maxLength);
+                sp.setMaxLength(maxLength);
+
+                Integer minLength = getInteger("minLength", obj, false, location, result);
+                map.put(MIN_LENGTH, minLength);
+                sp.setMinLength(minLength);
 
                 String pat = getString("pattern", obj, false, location, result);
                 map.put(PATTERN, pat);
@@ -527,19 +532,26 @@ public class SwaggerDeserializer {
                 map.put(MAX_LENGTH, iv);
                 sp.setMaxLength(iv);
 
-                Double dbl = getDouble("multipleOf", obj, false, location, result);
-                if(dbl != null) {
-                    map.put(MULTIPLE_OF, new BigDecimal(dbl.toString()));
-                    sp.setMultipleOf(dbl);
+                bd = getBigDecimal("multipleOf", obj, false, location, result);
+                if(bd != null) {
+                    map.put(MULTIPLE_OF, bd);
+                    sp.setMultipleOf(bd.doubleValue());
                 }
 
-                map.put(UNIQUE_ITEMS, getBoolean("uniqueItems", obj, false, location, result));
+                Boolean uniqueItems = getBoolean("uniqueItems", obj, false, location, result);
+                map.put(UNIQUE_ITEMS, uniqueItems);
+                sp.setUniqueItems(uniqueItems);
 
                 ArrayNode an = getArray("enum", obj, false, location, result);
                 if(an != null) {
                     List<String> _enum = new ArrayList<String>();
                     for(JsonNode n : an) {
-                        _enum.add(n.textValue());
+                        if(n.isValueNode()) {
+                            _enum.add(n.asText());
+                        }
+                        else {
+                            result.invalidType(location, "enum", "value", n);
+                        }
                     }
                     sp.setEnum(_enum);
                     map.put(ENUM, _enum);
@@ -1419,8 +1431,8 @@ public class SwaggerDeserializer {
         return on;
     }
 
-    public Double getDouble(String key, ObjectNode node, boolean required, String location, ParseResult result) {
-        Double value = null;
+    public BigDecimal getBigDecimal(String key, ObjectNode node, boolean required, String location, ParseResult result) {
+        BigDecimal value = null;
         JsonNode v = node.get(key);
         if (node == null || v == null) {
             if (required) {
@@ -1429,7 +1441,7 @@ public class SwaggerDeserializer {
             }
         }
         else if(v.getNodeType().equals(JsonNodeType.NUMBER)) {
-            value = v.asDouble();
+            value = new BigDecimal(v.asText());
         }
         else if(!v.isValueNode()) {
             result.invalidType(location, key, "double", node);

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -1216,6 +1216,8 @@ public class SwaggerDeserializer {
                         output = new ApiKeyAuthDefinition()
                                 .name(name)
                                 .in(in);
+                        String description = getString("description", node, false, location, result);
+                        output.setDescription(description);
                     }
                 }
             }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -1,6 +1,5 @@
 package io.swagger.parser;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.models.ArrayModel;
 import io.swagger.models.ComposedModel;
 import io.swagger.models.Model;
@@ -762,4 +761,45 @@ public class SwaggerParserTest {
 
         assertNotNull(swagger.getVendorExtensions().get("x-error-defs"));
     }
+
+    @Test
+    public void testBadFormat() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/bad_format.yaml");
+
+        Path path = swagger.getPath("/pets");
+
+        Parameter parameter = path.getGet().getParameters().get(0);
+        assertNotNull(parameter);
+        assertTrue(parameter instanceof QueryParameter);
+        QueryParameter queryParameter = (QueryParameter) parameter;
+        assertEquals(queryParameter.getName(), "query-param-int32");
+        assertNotNull(queryParameter.getEnum());
+        assertEquals(queryParameter.getEnum().size(), 3);
+        List<Object> enumValues = queryParameter.getEnumValue();
+        assertEquals(enumValues.get(0), 1);
+        assertEquals(enumValues.get(1), 2);
+        assertEquals(enumValues.get(2), 7);
+
+        parameter = path.getGet().getParameters().get(1);
+        assertNotNull(parameter);
+        assertTrue(parameter instanceof QueryParameter);
+        queryParameter = (QueryParameter) parameter;
+        assertEquals(queryParameter.getName(), "query-param-invalid-format");
+        assertNotNull(queryParameter.getEnum());
+        assertEquals(queryParameter.getEnum().size(), 3);
+        enumValues = queryParameter.getEnumValue();
+        assertEquals(enumValues.get(0), 1);
+        assertEquals(enumValues.get(1), 2);
+        assertEquals(enumValues.get(2), 7);
+
+        parameter = path.getGet().getParameters().get(2);
+        assertNotNull(parameter);
+        assertTrue(parameter instanceof QueryParameter);
+        queryParameter = (QueryParameter) parameter;
+        assertEquals(queryParameter.getName(), "query-param-collection-format-and-uniqueItems");
+        assertEquals(queryParameter.getCollectionFormat(), "multi");
+        assertEquals(queryParameter.isUniqueItems(), true);
+    }
+
 }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -1,6 +1,5 @@
 package io.swagger.parser;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.models.ArrayModel;
 import io.swagger.models.ComposedModel;
@@ -27,7 +26,7 @@ import io.swagger.models.properties.StringProperty;
 import io.swagger.parser.util.SwaggerDeserializationResult;
 import io.swagger.util.Json;
 import io.swagger.util.Yaml;
-import org.junit.Assert;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
@@ -259,8 +258,10 @@ public class SwaggerParserTest {
         SwaggerParser parser = new SwaggerParser();
         final Swagger swagger = parser.read("src/test/resources/file-reference-with-vendor-ext/b.yaml");
         Map<String, Model> definitions = swagger.getDefinitions();
-        assertTrue(definitions.get("z").getVendorExtensions().get("x-foo") instanceof ObjectNode);
-        assertTrue(definitions.get("x").getVendorExtensions().get("x-foo") instanceof ObjectNode);
+        assertTrue(definitions.get("z").getVendorExtensions().get("x-foo") instanceof Map);
+        assertEquals(((Map)definitions.get("z").getVendorExtensions().get("x-foo")).get("bar"), "baz");
+        assertTrue(definitions.get("x").getVendorExtensions().get("x-foo") instanceof Map);
+        assertEquals(((Map)definitions.get("x").getVendorExtensions().get("x-foo")).get("bar"), "baz");
     }
 
     @Test
@@ -402,7 +403,7 @@ public class SwaggerParserTest {
 
         Swagger swagger = result.getSwagger();
 
-        assertEquals(swagger.getVendorExtensions().get("x-some-vendor"), Json.mapper().createObjectNode().put("sometesting", "bye!"));
+        assertEquals(((Map)swagger.getVendorExtensions().get("x-some-vendor")).get("sometesting"), "bye!");
         assertEquals(swagger.getPath("/foo").getVendorExtensions().get("x-something"), "yes, it is supported");
         assertTrue(result.getMessages().size() == 1);
         assertEquals(result.getMessages().get(0), "attribute paths.x-nothing is unsupported");
@@ -510,15 +511,15 @@ public class SwaggerParserTest {
 
         assertNotNull(extensions.get("x-examples"));
         Object o = extensions.get("x-examples");
-        assertTrue(o instanceof ObjectNode);
+        assertTrue(o instanceof Map);
 
-        ObjectNode on = (ObjectNode) o;
+        Map<String, Object> on = (Map<String, Object>) o;
 
-        JsonNode jn = on.get("application/json");
-        assertTrue(jn instanceof ObjectNode);
+        Object jn = on.get("application/json");
+        assertTrue(jn instanceof Map);
 
-        ObjectNode objectNode = (ObjectNode) jn;
-        assertEquals(objectNode.get("foo").textValue(), "bar");
+        Map<String, Object> objectNode = (Map<String, Object>) jn;
+        assertEquals(objectNode.get("foo"), "bar");
 
         Parameter stringBodyParameter = swagger.getPath("/otherPets").getPost().getParameters().get(0);
 

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
@@ -238,6 +238,26 @@ public class SwaggerDeserializerTest {
     }
 
     @Test
+    public void testSecurityDefinitionWithMissingAttribute() {
+        String json = "{\n" +
+                "  \"swagger\": \"2.0\",\n" +
+                "  \"securityDefinitions\": {\n" +
+                "    \"api_key\": {\n" +
+                "      \"description\": \"api key description\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        SwaggerParser parser = new SwaggerParser();
+
+        SwaggerDeserializationResult result = parser.readWithInfo(json);
+        List<String> messageList = result.getMessages();
+        Set<String> messages = new HashSet<>(messageList);
+
+        assertTrue(messages.contains("attribute securityDefinitions.api_key.type is missing"));
+    }
+
+    @Test
     public void testRootInfo() {
         String json = "{\n" +
                 "\t\"swagger\": \"2.0\",\n" +

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
@@ -192,6 +192,7 @@ public class SwaggerDeserializerTest {
                 "      \"type\": \"apiKey\",\n" +
                 "      \"name\": \"api_key\",\n" +
                 "      \"in\": \"header\",\n" +
+                "      \"description\": \"api key description\",\n" +
                 "      \"x-foo\": \"apiKeyBar\"\n" +
                 "    }\n" +
                 "  },\n" +
@@ -232,6 +233,7 @@ public class SwaggerDeserializerTest {
         ApiKeyAuthDefinition apiKey = (ApiKeyAuthDefinition) definition;
         assertEquals(apiKey.getName(), "api_key");
         assertEquals(apiKey.getIn(), In.HEADER);
+        assertEquals(apiKey.getDescription(), "api key description");
         assertEquals(apiKey.getVendorExtensions().get("x-foo"), "apiKeyBar");
     }
 

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
@@ -345,7 +345,7 @@ public class SwaggerDeserializerTest {
         assertTrue(messages.contains("attribute info.title is missing"));
         assertTrue(messages.contains("attribute paths is missing"));
 
-        assertEquals(result.getSwagger().getInfo().getLicense().getVendorExtensions().get("x-valid").toString(), "{\"isValid\":true}");
+        assertEquals(((Map)result.getSwagger().getInfo().getLicense().getVendorExtensions().get("x-valid")).get("isValid"), true);
     }
 
 

--- a/modules/swagger-parser/src/test/resources/bad_format.yaml
+++ b/modules/swagger-parser/src/test/resources/bad_format.yaml
@@ -1,0 +1,37 @@
+---
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Pets Store
+paths:
+  /pets:
+    parameters:
+    - name: "query-param-int32"
+      in: "query"
+      type: "integer"
+      format: "int32"
+      enum:
+      - 1
+      - 2
+      - 7
+      collectionFormat: "multi"
+      uniqueItems: true
+    - name: "query-param-invalid-format"
+      in: "query"
+      type: "integer"
+      format: "invalid"
+      enum:
+      - 1
+      - 2
+      - 7
+    - name: "query-param-collection-format-and-uniqueItems"
+      in: "query"
+      type: "array"
+      items:
+        type: "string"
+      collectionFormat: "multi"
+      uniqueItems: true
+    get:
+      responses:
+        200:
+          description: Returns all the pets


### PR DESCRIPTION
Several fixes related to https://github.com/swagger-api/swagger-parser/issues/398.

I did one commit per fix (see commit message) to facilitate the review

I'll be happy to discuss each commit
- commit `#e33949d` with message `feat(resolve): add settings to allow resolving references without adding resource parameters to each operation` do not change public behaviour (of `SwaggerParser`) but for those using directly `SwaggerResolver`, it allow to don't add resource parameters on operation, and have a behaviour closer to `ObjectMapper` and also to keep the `PathParameter`on path (not flatten to each operation)