### PR TITLE
Example specification petstore.json is not compliant with the OpenAPI specification 2.0

### DIFF
--- a/modules/swagger-parser/src/test/resources/petstore.json
+++ b/modules/swagger-parser/src/test/resources/petstore.json
@@ -700,7 +700,9 @@
         "tags": [
           "user"
         ],
-        "scheme": "https",
+        "scheme": [
+          "https"
+        ],
         "summary": "Logs user into the system",
         "description": "",
         "operationId": "loginUser",
@@ -743,7 +745,9 @@
         "tags": [
           "user"
         ],
-        "scheme": "https",
+        "scheme": [
+          "https"
+        ],
         "summary": "Logs out current logged in user session",
         "description": "",
         "operationId": "logoutUser",


### PR DESCRIPTION
This fixes a validation error of petstore.json against the OpenAPI specification 2.0. petstore.json will pass a validation against the OpenAPI specification 2.0.