### PR TITLE
Added support for $ref Headers

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ResponseProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ResponseProcessor.java
@@ -1,30 +1,62 @@
 package io.swagger.parser.processors;
 
+import java.util.Map;
+
+import io.swagger.models.RefResponse;
 import io.swagger.models.Response;
 import io.swagger.models.Swagger;
 import io.swagger.models.properties.Property;
+import io.swagger.models.properties.RefProperty;
 import io.swagger.parser.ResolverCache;
 
 public class ResponseProcessor {
 
     private final PropertyProcessor propertyProcessor;
+    private final ResolverCache cache;
 
     public ResponseProcessor(ResolverCache cache, Swagger swagger) {
+        this.cache = cache;
         propertyProcessor = new PropertyProcessor(cache, swagger);
     }
 
     public void processResponse(Response response) {
-        //process the response body
+        // process the response body
         final Property schema = response.getSchema();
 
         if (schema != null) {
             propertyProcessor.processProperty(schema);
         }
 
-        /* intentionally ignoring the response headers, even those these were modelled as a
-         Map<String, Property> they should never have a $ref because what does it mean to have a
-         complex object in an HTTP header?
-          */
+        /*
+         * intentionally ignoring the response headers, even those these were
+         * modelled as a Map<String, Property> they should never have a $ref
+         * because what does it mean to have a complex object in an HTTP header?
+         * 
+         * @tompahoward: Having $ref in headers doesn't mean they are complex
+         * objects, it means that we don't want to repeat the definition for
+         * each header in every response. We should be able to define a header
+         * once and $ref refer to it everywhere we ant to use it.
+         */
 
+        final Map<String, Property> headers = response.getHeaders();
+        if (headers != null) {
+            for (String headerName : headers.keySet()) {
+                Property header = headers.get(headerName);
+
+                if (header != null) {
+                    if (header instanceof RefProperty) {
+                        RefProperty refHeader = (RefProperty) header;
+                        Property resolvedHeader = cache.loadRef(refHeader.get$ref(), refHeader.getRefFormat(),
+                                Property.class);
+
+                        if (resolvedHeader != null) {
+                            header = resolvedHeader;
+                            headers.put(headerName, resolvedHeader);
+                        }
+                    }
+                    propertyProcessor.processProperty(header);
+                }
+            }
+        }
     }
 }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -28,6 +28,9 @@ import io.swagger.util.Yaml;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.io.File;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
@@ -801,5 +804,15 @@ public class SwaggerParserTest {
         assertEquals(queryParameter.getCollectionFormat(), "multi");
         assertEquals(queryParameter.isUniqueItems(), true);
     }
+    
+    
+    @Test(description = "it should parse the example with $ref headers")
+    public void testRefHeaders() throws JsonProcessingException {
+        final SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("headers.yaml");
+        final Property property = (Property) swagger.getPaths().get("/pets").getGet().getResponses().get("200").getHeaders().get("ETag");
+        assertEquals(property.getType(), "string");
+    }
+
 
 }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/processors/ResponseProcessorTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/processors/ResponseProcessorTest.java
@@ -30,6 +30,7 @@ public class ResponseProcessorTest {
             new PropertyProcessor(cache, swagger); times=1; result = propertyProcessor;
 
             propertyProcessor.processProperty(responseSchema); times=1;
+            propertyProcessor.processProperty(responseHeader); times=1;
         }};
 
         Response response = new Response();

--- a/modules/swagger-parser/src/test/resources/header_definitions.yaml
+++ b/modules/swagger-parser/src/test/resources/header_definitions.yaml
@@ -1,0 +1,9 @@
+headers:
+  ETag:
+    description: |
+      The ETag response-header field provides the value of the entity tag for the requested entity.
+      The entity tag MAY be used for comparison with other entities from the same resource.
+
+      https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.19
+    type: string
+    pattern: '([wW]/)?"([^"]|\\")*"'

--- a/modules/swagger-parser/src/test/resources/headers.yaml
+++ b/modules/swagger-parser/src/test/resources/headers.yaml
@@ -1,0 +1,22 @@
+---
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Pets Store
+paths:
+  /pets:
+    get:
+      responses:
+        200:
+          description: Returns all the pets
+          headers:
+            ETag:
+              $ref: "./header_definitions.yaml#/headers/ETag"
+  /foods:
+    get:
+      responses:
+        200:
+          description: Returns all the foods
+          headers:
+            ETag:
+              $ref: "./header_definitions.yaml#/headers/ETag"


### PR DESCRIPTION
We shouldn’t have to repeat the definitions for headers in every single
response.

Please don’t make me repeat the header definitions in every response
(ಥ﹏ಥ)

Please see modules/swagger-parser/src/test/resources/headers.yaml for
an example

@Helmsdown what’s your view? From what I can tell, you originally made
the comment that it wasn’t needed. If so, your feedback (positive or
negative) would be greatly appreciated.