### PR TITLE
Issue 358 Path param matching fails

### DIFF
--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -800,4 +800,15 @@ public class SwaggerParserTest {
         assertEquals(queryParameter.getCollectionFormat(), "multi");
         assertEquals(queryParameter.isUniqueItems(), true);
     }
+
+    @Test
+    public void testIssue358() {
+	SwaggerParser parser = new SwaggerParser();
+	final Swagger swagger = parser.read("src/test/resources/issue_358.yaml");
+	assertNotNull(swagger);
+	List<Parameter> parms = swagger.getPath("/testApi").getGet().getParameters();
+	assertEquals(1, parms.size());
+	assertEquals("pathParam", parms.get(0).getName());
+    }
 }
+

--- a/modules/swagger-parser/src/test/resources/issue_358.yaml
+++ b/modules/swagger-parser/src/test/resources/issue_358.yaml
@@ -1,0 +1,28 @@
+swagger: "2.0"
+info:
+  title: Test model for swagger-parser issue 357
+  contact:
+    name: Andy Lowry
+    email: andy.lowry@reprezen.com
+  version: "1.0"
+paths:
+  /testApi:
+    get:
+      operationId: getTest
+      parameters: 
+        - name: pathParam
+          in: query
+          type: integer
+      responses:
+        default:
+          description: OK
+          
+    parameters:
+      - $ref: "#/parameters/pathParam"
+
+
+parameters:
+  pathParam:
+    name: pathParam
+    in: query
+    type: string


### PR DESCRIPTION
I've supplied a test that demonstrates the problem described by the
issue.

When the swagger model is parsed, the GET operation ends up with two identical parameters, because the override test in `PathsProcessor` was performed before the path parameter was resolved, causing the parameter not to match the operation parameter.