### PR TITLE
Add version check to 3.0 parser to prevent 2.0 docs parsed into OpenAPI

### DIFF
--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/test/OAIDeserializationTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/test/OAIDeserializationTest.java
@@ -5,6 +5,7 @@ import io.swagger.parser.v3.OpenAPIV3Parser;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 public class OAIDeserializationTest {
     @Test
@@ -30,6 +31,32 @@ public class OAIDeserializationTest {
         SwaggerParseResult result = new OpenAPIV3Parser().readContents(yaml, null, null);
 
         assertNotNull(result.getOpenAPI());
+
+    }
+
+    @Test
+    public void testSkipSerializingV2Document() throws Exception {
+        String yaml =
+            "{\n" +
+            "  \"swagger\": \"2.0\",\n" +
+            "  \"info\": {\n" +
+            "    \"title\": \"Swagger Petstore\",\n" +
+            "    \"description\": \"This is a sample server Petstore server. You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/). For this sample, you can use the api key `special-key` to test the authorization filters.\",\n" +
+            "    \"termsOfService\": \"http://swagger.io/terms/\",\n" +
+            "    \"contact\": {\n" +
+            "      \"email\": \"apiteam@swagger.io\"\n" +
+            "    },\n" +
+            "    \"license\": {\n" +
+            "      \"name\": \"Apache 2.0\",\n" +
+            "      \"url\": \"http://www.apache.org/licenses/LICENSE-2.0.html\"\n" +
+            "    },\n" +
+            "    \"version\": \"1.0.0\"\n" +
+            "  }\n" +
+            "}";
+
+        SwaggerParseResult result = new OpenAPIV3Parser().readContents(yaml, null, null);
+
+        assertNull(result.getOpenAPI());
 
     }
 }


### PR DESCRIPTION
In some conditions 3.0 parser can produce OpenAPI object and it bypasses the 2.0 converter
This lines sometimes produce non null object from v2 documents
`OpenAPI api = mapper.readValue(swaggerAsString, OpenAPI.class);
result.setOpenAPI(api);`