### PR TITLE
Update json-schema-validator (SONATYPE-2015-0090)

### DIFF
--- a/modules/swagger-compat-spec-parser/pom.xml
+++ b/modules/swagger-compat-spec-parser/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.3</version>
+            <version>4.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>


### PR DESCRIPTION
Update json-schema-validator from 2.2.3 to 2.2.8 (with change in groupId to reflect ownership change).   Addresses Cross Site Scripting vulnerability from libphonenumber dependency.
