### PR TITLE
do not discard empty schemas

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -831,8 +831,6 @@ public class SwaggerDeserializer {
                     result.extra(location, key, node.get(key));
                 }
             }
-            if("{ }".equals(Json.pretty(impl)))
-                return null;
             model = impl;
         }
         JsonNode exampleNode = node.get("example");

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerReaderTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerReaderTest.java
@@ -391,4 +391,25 @@ public class SwaggerReaderTest {
         assertEquals(objectNode.get("id").intValue(), 42);
         assertEquals(objectNode.get("name").textValue(), "Arthur Dent");
     }
+
+    @Test
+    public void testEmptySchema() {
+      String spec =
+              "swagger: '2.0'\n" +
+                      "info:\n" +
+                      "  title: nice\n" +
+                      "paths: {}\n" +
+                      "definitions:\n" +
+                      "  Empty:\n" +
+                      "    description: 'Expected empty response could be {}'";
+
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(spec);
+        assertTrue(result.getMessages().size() == 0);
+
+        Swagger swagger = result.getSwagger();
+        Model definition = swagger.getDefinitions().get("Empty");
+        assertNotNull(definition);
+        assertTrue(definition instanceof ModelImpl);
+    }
+
 }


### PR DESCRIPTION
Fixes empty schema issue, useful when empty schemas are used as place-holders for future use. 
https://github.com/swagger-api/swagger-codegen/issues/5916
Added Unit test.  Successfully tested with travis-ci.
