### PR TITLE
Maven plugin for spec reading and validation

### DIFF
--- a/modules/swagger-parser-maven-plugin/pom.xml
+++ b/modules/swagger-parser-maven-plugin/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.swagger</groupId>
+        <artifactId>swagger-parser-project</artifactId>
+        <version>1.0.32</version>
+    </parent>
+
+    <artifactId>swagger-parser-maven-plugin</artifactId>
+    <version>1.0.32</version>
+    <packaging>maven-plugin</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-parser</artifactId>
+            <version>1.0.32</version>
+        </dependency>
+
+        <!-- dependencies to annotations -->
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.4</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/modules/swagger-parser-maven-plugin/src/main/java/io/swagger/parser/ValidateMojo.java
+++ b/modules/swagger-parser-maven-plugin/src/main/java/io/swagger/parser/ValidateMojo.java
@@ -1,0 +1,30 @@
+package io.swagger.parser;
+
+import io.swagger.models.auth.AuthorizationValue;
+import io.swagger.parser.util.SwaggerDeserializationResult;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.util.Collections;
+
+@Mojo( name = "validate")
+public class ValidateMojo extends AbstractMojo
+{
+    @Parameter(property = "swaggerSpecPath", required = true)
+    private String swaggerSpecPath;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        getLog().info("Reading and validating spec at " +  swaggerSpecPath);
+
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(swaggerSpecPath, Collections.<AuthorizationValue>emptyList(), false);
+        if (!result.getMessages().isEmpty()) {
+            for (String message : result.getMessages()) {
+                getLog().error(message);
+            }
+            throw new MojoFailureException("There are validation failures.");
+        }
+    }
+}

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/Swagger20Parser.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/Swagger20Parser.java
@@ -74,7 +74,7 @@ public class Swagger20Parser implements SwaggerParserExtension {
         }
         catch (Exception e) {
             SwaggerDeserializationResult output = new SwaggerDeserializationResult();
-            output.message("unable to read location `" + location + "`");
+            output.message("unable to read location `" + location + "`" + e);
             return output;
         }
     }

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/DeserializationUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/DeserializationUtils.java
@@ -3,7 +3,10 @@ package io.swagger.parser.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.util.Json;
 import io.swagger.util.Yaml;
+import org.yaml.snakeyaml.constructor.AbstractConstruct;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.Tag;
 
 import java.io.IOException;
 
@@ -58,12 +61,25 @@ public class DeserializationUtils {
     }
 
     public static JsonNode readYamlTree(String contents) {
-        org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml(new SafeConstructor());
-        return Json.mapper().convertValue(yaml.load(contents), JsonNode.class);
+        return readYamlValue(contents, JsonNode.class);
     }
 
     public static <T> T readYamlValue(String contents, Class<T> expectedType) {
-        org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml(new SafeConstructor());
+        org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml(new OverridenNullConstructor());
         return Json.mapper().convertValue(yaml.load(contents), expectedType);
+    }
+
+    private static class OverridenNullConstructor extends SafeConstructor {
+        public static final class SafeNullConstructor extends AbstractConstruct {
+            SafeNullConstructor() {
+            }
+
+            public Object construct(Node node) {
+                return "null";
+            }
+        }
+        OverridenNullConstructor() {
+            this.yamlConstructors.put(Tag.NULL, new SafeNullConstructor());
+        }
     }
 }

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/validation/ReferencedDefinitionExistsValidator.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/validation/ReferencedDefinitionExistsValidator.java
@@ -1,0 +1,95 @@
+package io.swagger.parser.validation;
+
+import com.google.common.collect.Sets;
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.Response;
+import io.swagger.models.Swagger;
+import io.swagger.models.parameters.BodyParameter;
+import io.swagger.models.parameters.Parameter;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.RefProperty;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ReferencedDefinitionExistsValidator implements SpecValidator {
+    @Override
+    public List<String> validate(Swagger swagger) {
+        List<String> errors = new ArrayList<>();
+        Set<String> definitionRefs = getDefinitionsReferencedInPaths(swagger);
+
+        Set<String> producedDefinitions = getDefinitionsDefinedInSwagger(swagger);
+        Sets.SetView<String> difference = Sets.difference(definitionRefs, producedDefinitions);
+
+        for (String modelWhichWasNotFound : difference) {
+            errors.add("Could not find a referenced definition named " + modelWhichWasNotFound);
+        }
+        return errors;
+    }
+
+    private Set<String> getDefinitionsDefinedInSwagger(Swagger swagger) {
+        if (swagger.getDefinitions() == null) {
+            return new HashSet<>();
+        }
+        return swagger.getDefinitions().keySet();
+    }
+
+    private Set<String> getDefinitionsReferencedInPaths(Swagger swagger) {
+        Set<String> definitionRefs = new HashSet<>();
+        if (swagger.getPaths() != null) {
+            for (Path path : swagger.getPaths().values()) {
+                for (Operation operation : path.getOperations()) {
+                    List<String> definitions = collectDefinitions(operation);
+                    for (String definition : definitions) {
+                        definitionRefs.add(definition.replace("#/definitions/", ""));
+                    }
+                }
+            }
+        }
+        return definitionRefs;
+    }
+
+    private List<String> collectDefinitions(Operation operation) {
+        List<String> definitions = new ArrayList<>();
+        for (BodyParameter bodyParameter : getBodyParameters(operation)) {
+            if (bodyParameter.getSchema().getReference() != null) {
+                definitions.add(bodyParameter.getSchema().getReference());
+            }
+        }
+        if (operation.getResponses() != null) {
+            for (Response response : operation.getResponses().values()) {
+                String refFromResponse = getRefFromResponse(response);
+                if (refFromResponse != null) {
+                    definitions.add(refFromResponse);
+                }
+            }
+        }
+        return definitions;
+    }
+
+    private String getRefFromResponse(Response response) {
+        if (response.getSchema() instanceof RefProperty) {
+            return ((RefProperty) response.getSchema()).get$ref();
+        } else if (response.getSchema() instanceof ArrayProperty) {
+            Property items = ((ArrayProperty) response.getSchema()).getItems();
+            return ((RefProperty) items).get$ref();
+        }
+        return null;
+    }
+
+    private List<BodyParameter> getBodyParameters(Operation operation) {
+        List<BodyParameter> bodyParameters = new ArrayList<>();
+        for (Parameter parameter : operation.getParameters()) {
+            if (parameter instanceof BodyParameter) {
+                bodyParameters.add((BodyParameter) parameter);
+            }
+        }
+        return bodyParameters;
+    }
+}

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/validation/SpecValidator.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/validation/SpecValidator.java
@@ -1,0 +1,9 @@
+package io.swagger.parser.validation;
+
+import io.swagger.models.Swagger;
+
+import java.util.List;
+
+public interface SpecValidator {
+    List<String> validate(Swagger spec);
+}

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -41,7 +41,9 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -931,6 +933,40 @@ public class SwaggerParserTest {
         assertNotNull(petArray.getVendorExtensions());
         assertNotNull(petArray.getVendorExtensions().get(xTag));
         assertEquals(petArray.getVendorExtensions().get(xTag),xVal);
+    }
+
+    @Test
+    public void testNoResponseForOperation() throws Exception {
+        String yaml =
+                "swagger: \"2.0\"\n" +
+                        "info:\n" +
+                        "  version: 0.0.0\n" +
+                        "  title: Simple API\n" +
+                        "paths:\n" +
+                        "  /:\n" +
+                        "    get:\n" +
+                        "      responses:\n" +
+                        "        '200':\n" +
+                        "          description: OK\n" +
+                        "          schema:\n" +
+                        "            $ref: \"#/definitions/Simple\"\n";
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
+        assertFalse(result.getMessages().size() == 0);
+    }
+
+    @Test
+    public void testDanglingReferences() throws Exception {
+        String yaml =
+                "swagger: \"2.0\"\n" +
+                        "info:\n" +
+                        "  version: 0.0.0\n" +
+                        "  title: Simple API\n" +
+                        "paths:\n" +
+                        "  /:\n" +
+                        "    get:\n" +
+                        "      responses:\n";
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
+        assertFalse(result.getMessages().size() == 0);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,7 @@
     <modules>
         <module>modules/swagger-parser</module>
         <module>modules/swagger-compat-spec-parser</module>
+        <module>modules/swagger-parser-maven-plugin</module>
     </modules>
     <properties>
         <commons-io-version>2.4</commons-io-version>


### PR DESCRIPTION
So I've started to integrate swagger generation into our build process. I've noticed that there is no package or method which allows you to verify if a swagger file is valid - that each operation has a response and that there are no definition references which cannot be resolved.

So the PR adds a new module which creates a maven plugin with a new mojo called validate. It throws a build error exception when swagger parser returns at least one error.

Do you have any advice on where to place the validation code? I know this can be improved, but wanted to quickly code this and get your feedback.

