### PR TITLE
Add test for boolean `additionalProperties` (#499)

### DIFF
--- a/modules/swagger-parser/src/test/java/io/swagger/parser/OpenAPIParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/OpenAPIParserTest.java
@@ -3,9 +3,12 @@ package io.swagger.parser;
 import io.swagger.parser.models.ParseOptions;
 import io.swagger.parser.models.SwaggerParseResult;
 import org.junit.Test;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 public class OpenAPIParserTest {
     @Test
@@ -55,5 +58,16 @@ public class OpenAPIParserTest {
         assertNotNull(result);
         assertNotNull(result.getOpenAPI());
         assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0-rc1");
+    }
+
+    @Test
+    public void allowBooleanAdditionalPropertiesIssue499() {
+        SwaggerParseResult result = new OpenAPIParser().readLocation("booleanAdditonalProperties.json", null, null);
+
+        assertNotNull(result);
+        assertNotNull(result.getOpenAPI());
+        assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0");
+        List<String> messages = result.getMessages();
+        assertTrue(messages.isEmpty(), messages.stream().collect(Collectors.joining("\n")));
     }
 }

--- a/modules/swagger-parser/src/test/resources/booleanAdditonalProperties.json
+++ b/modules/swagger-parser/src/test/resources/booleanAdditonalProperties.json
@@ -1,0 +1,71 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Boolean `additionProperties` example"
+    },
+    "paths": {
+        "/someResource": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Fetching of some resource successful",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/someObject"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "someObject": {
+                "type": "object",
+                "required": [
+                    "innerObject"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "innerObject": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "stringProperty": {
+                                "type": "string"
+                            },
+                            "objectProperty": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "firstPossibleProperty": {
+                                        "type": "integer"
+                                    },
+                                    "secondPossibleProperty": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "objectAdditionalProperties": {
+                                "type": "object",
+                                "properties": {
+                                    "integerProperty": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Provides a sample file and test which reproduces issue #499 stating that according to the OpenAPI 3.0.0 specification, `additionalProperties` of boolean type should be allowed.

Currently, only removing the boolean `additionalProperties` makes this test pass. You will also notice that the error message only reports an error at the location `components.schemas'.someObject'` even if only more deeply nested boolean `additionalProperties` are left.