### PR TITLE
Fix example implementation on schema, header, parameter and media Type

### DIFF
--- a/modules/swagger-parser-v3/pom.xml
+++ b/modules/swagger-parser-v3/pom.xml
@@ -78,6 +78,6 @@
         </dependency>
     </dependencies>
     <properties>
-        <swagger-core-module-version>2.0.0-rc1</swagger-core-module-version>
+        <swagger-core-module-version>2.0.0-SNAPSHOT</swagger-core-module-version>
     </properties>
 </project>

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/processors/HeaderProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/processors/HeaderProcessor.java
@@ -52,7 +52,13 @@ public class HeaderProcessor {
 
         }
         if (header.getExamples() != null){
-            exampleProcessor.processExample(header.getExamples());
+            if (header.getExamples() != null) {
+                Map<String,Example> examples = header.getExamples();
+                for (String key : examples.keySet()){
+                    exampleProcessor.processExample(header.getExamples().get(key));
+                }
+
+            }
         }
         Schema schema = null;
         if(header.getContent() != null) {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/OpenAPIDeserializer.java
@@ -831,31 +831,10 @@ public class OpenAPIDeserializer {
             mediaType.setExamples(getExamples(examplesObject, String.format("%s.%s'", location, "examples"), result));
         }
 
-        JsonNode example = contentNode.get("example");
-        if (example != null) {
-            if (example.getNodeType().equals(JsonNodeType.STRING)) {
-                String value = getString("example", contentNode, false, location, result);
-                if (StringUtils.isNotBlank(value)) {
-                    mediaType.setExample(value);
-                }
-            }else if (example.getNodeType().equals(JsonNodeType.NUMBER)) {
-                Integer integerExample = getInteger("example", contentNode, false, location, result);
-                if (integerExample != null) {
-                    mediaType.setExample(integerExample.toString());
-                }
-            }else if (example.getNodeType().equals(JsonNodeType.OBJECT)) {
-                ObjectNode objectValue = getObject("example", contentNode, false, location, result);
-                if (objectValue != null) {
-                    mediaType.setExample(objectValue.toString());
-                }
-            } else if (example.getNodeType().equals(JsonNodeType.ARRAY)) {
-                ArrayNode arrayValue = getArray("example", contentNode, false, location, result);
-                if (arrayValue != null) {
-                    mediaType.setExample(arrayValue.toString());
-                }
-            }
+        String value = getAnyExample(contentNode, location,result);
+        if (StringUtils.isNotBlank(value)){
+            mediaType.setExample(value);
         }
-
 
 
         Set<String> keys = getKeys(contentNode);
@@ -1355,29 +1334,9 @@ public class OpenAPIDeserializer {
             parameter.setExamples(getExamples(examplesObject, String.format("%s.%s'", location, "examples"), result));
         }
 
-        JsonNode example = obj.get("example");
-        if (example != null) {
-            if (example.getNodeType().equals(JsonNodeType.STRING)) {
-                value = getString("example", obj, false, location, result);
-                if (StringUtils.isNotBlank(value)) {
-                    parameter.setExample(value);
-                }
-            } else if (example.getNodeType().equals(JsonNodeType.NUMBER)) {
-                Integer integerExample = getInteger("example", obj, false, location, result);
-                if (integerExample != null) {
-                    parameter.setExample(integerExample.toString());
-                }
-            } else if (example.getNodeType().equals(JsonNodeType.OBJECT)) {
-                ObjectNode objectValue = getObject("example", obj, false, location, result);
-                if (objectValue != null) {
-                    parameter.setExample(objectValue.toString());
-                }
-            } else if (example.getNodeType().equals(JsonNodeType.ARRAY)) {
-                ArrayNode arrayValue = getArray("example", obj, false, location, result);
-                if (arrayValue != null) {
-                    parameter.setExample(arrayValue.toString());
-                }
-            }
+        value = getAnyExample(obj, location,result);
+        if (StringUtils.isNotBlank(value)){
+            parameter.setExample(value);
         }
 
         ObjectNode contentNode = getObject("content",obj,false,location,result);
@@ -1484,29 +1443,9 @@ public class OpenAPIDeserializer {
             header.setExamples(getExampleList(examplesObject, location, result));
         }
 
-        JsonNode example = headerNode.get("example");
-        if (example != null) {
-            if (example.getNodeType().equals(JsonNodeType.STRING)) {
-                value = getString("example", headerNode, false, location, result);
-                if (StringUtils.isNotBlank(value)) {
-                    header.setExample(value);
-                }
-            } if (example.getNodeType().equals(JsonNodeType.NUMBER)) {
-                Integer integerExample = getInteger("example", headerNode, false, location, result);
-                if (integerExample != null) {
-                    header.setExample(integerExample.toString());
-                }
-            } else if (example.getNodeType().equals(JsonNodeType.OBJECT)) {
-                ObjectNode objectValue = getObject("example", headerNode, false, location, result);
-                if (objectValue != null) {
-                    header.setExample(objectValue.toString());
-                }
-            } else if (example.getNodeType().equals(JsonNodeType.ARRAY)) {
-                ArrayNode arrayValue = getArray("example", headerNode, false, location, result);
-                if (arrayValue != null) {
-                    header.setExample(arrayValue.toString());
-                }
-            }
+        value = getAnyExample(headerNode, location,result);
+        if (StringUtils.isNotBlank(value)){
+            header.setExample(value);
         }
 
         ObjectNode contentNode = getObject("content",headerNode,false,location,result);
@@ -1527,6 +1466,40 @@ public class OpenAPIDeserializer {
         }
 
         return header;
+    }
+
+    public String getAnyExample(ObjectNode node, String location, ParseResult result ){
+        JsonNode example = node.get("example");
+        if (example != null) {
+            if (example.getNodeType().equals(JsonNodeType.STRING)) {
+                String value = getString("example", node, false, location, result);
+                if (StringUtils.isNotBlank(value)) {
+                    return value;
+                }
+            } if (example.getNodeType().equals(JsonNodeType.NUMBER)) {
+                Integer integerExample = getInteger("example", node, false, location, result);
+                if (integerExample != null) {
+                    return integerExample.toString();
+                }else {
+                    BigDecimal bigDecimalExample = getBigDecimal("example", node, false, location, result);
+                    if (bigDecimalExample != null) {
+                        return bigDecimalExample.toString();
+
+                    }
+                }
+            } else if (example.getNodeType().equals(JsonNodeType.OBJECT)) {
+                ObjectNode objectValue = getObject("example", node, false, location, result);
+                if (objectValue != null) {
+                   return objectValue.toString();
+                }
+            } else if (example.getNodeType().equals(JsonNodeType.ARRAY)) {
+                ArrayNode arrayValue = getArray("example", node, false, location, result);
+                if (arrayValue != null) {
+                    return arrayValue.toString();
+                }
+            }
+        }
+        return null;
     }
 
     public Map<String, SecurityScheme> getSecuritySchemes(ObjectNode obj, String location, ParseResult result) {
@@ -2036,29 +2009,9 @@ public class OpenAPIDeserializer {
             }
         }
 
-        JsonNode example = node.get("example");
-        if (example != null) {
-            if (example.getNodeType().equals(JsonNodeType.STRING)) {
-                value = getString("example", node, false, location, result);
-                if (StringUtils.isNotBlank(value)) {
-                    schema.setExample(value);
-                }
-            }else    if (example.getNodeType().equals(JsonNodeType.NUMBER)) {
-                Integer integerExample = getInteger("example", node, false, location, result);
-                if (integerExample != null) {
-                    schema.setExample(integerExample.toString());
-                }
-            }else if (example.getNodeType().equals(JsonNodeType.OBJECT)) {
-                ObjectNode objectValue = getObject("example", node, false, location, result);
-                if (objectValue != null) {
-                    schema.setExample(objectValue);
-                }
-            } else if (example.getNodeType().equals(JsonNodeType.ARRAY)) {
-                ArrayNode arrayValue = getArray("example", node, false, location, result);
-                if (arrayValue != null) {
-                    schema.setExample(arrayValue);
-                }
-            }
+        value = getAnyExample(node, location,result);
+        if (StringUtils.isNotBlank(value)){
+            schema.setExample(value);
         }
 
         bool = getBoolean("deprecated", node, false, location, result);

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/OpenAPIDeserializer.java
@@ -816,19 +816,6 @@ public class OpenAPIDeserializer {
             mediaType.setSchema(getSchema(schemaObject,String.format("%s.%s'", location, "schema"),result));
         }
 
-        ObjectNode examplesObject = getObject("examples",contentNode,false,location,result);
-        if(examplesObject != null) {
-            mediaType.setExamples(getExamples(examplesObject, String.format("%s.%s'", location, "examples"), result));
-        }
-
-        JsonNode exampleNode = contentNode.get("example");
-        if(exampleNode != null) {
-            String value = getString("example", contentNode, false, location, result);
-            if(StringUtils.isNotBlank(value)) {
-                mediaType.setExample(value);
-            }
-        }
-
 
         ObjectNode encodingObject = getObject("encoding",contentNode,false,location,result);
         if(encodingObject!=null) {
@@ -838,6 +825,38 @@ public class OpenAPIDeserializer {
         if(extensions != null && extensions.size() > 0) {
             mediaType.setExtensions(extensions);
         }
+
+        ObjectNode examplesObject = getObject("examples",contentNode,false,location,result);
+        if(examplesObject!=null) {
+            mediaType.setExamples(getExamples(examplesObject, String.format("%s.%s'", location, "examples"), result));
+        }
+
+        JsonNode example = contentNode.get("example");
+        if (example != null) {
+            if (example.getNodeType().equals(JsonNodeType.STRING)) {
+                String value = getString("example", contentNode, false, location, result);
+                if (StringUtils.isNotBlank(value)) {
+                    mediaType.setExample(value);
+                }
+            }else if (example.getNodeType().equals(JsonNodeType.NUMBER)) {
+                Integer integerExample = getInteger("example", contentNode, false, location, result);
+                if (integerExample != null) {
+                    mediaType.setExample(integerExample.toString());
+                }
+            }else if (example.getNodeType().equals(JsonNodeType.OBJECT)) {
+                ObjectNode objectValue = getObject("example", contentNode, false, location, result);
+                if (objectValue != null) {
+                    mediaType.setExample(objectValue.toString());
+                }
+            } else if (example.getNodeType().equals(JsonNodeType.ARRAY)) {
+                ArrayNode arrayValue = getArray("example", contentNode, false, location, result);
+                if (arrayValue != null) {
+                    mediaType.setExample(arrayValue.toString());
+                }
+            }
+        }
+
+
 
         Set<String> keys = getKeys(contentNode);
         for(String key : keys) {
@@ -1336,11 +1355,28 @@ public class OpenAPIDeserializer {
             parameter.setExamples(getExamples(examplesObject, String.format("%s.%s'", location, "examples"), result));
         }
 
-        JsonNode exampleNode = obj.get("example");
-        if(exampleNode != null) {
-            value = getString("example", obj, false, location, result);
-            if(StringUtils.isNotBlank(value)) {
-                parameter.setExample(value);
+        JsonNode example = obj.get("example");
+        if (example != null) {
+            if (example.getNodeType().equals(JsonNodeType.STRING)) {
+                value = getString("example", obj, false, location, result);
+                if (StringUtils.isNotBlank(value)) {
+                    parameter.setExample(value);
+                }
+            } else if (example.getNodeType().equals(JsonNodeType.NUMBER)) {
+                Integer integerExample = getInteger("example", obj, false, location, result);
+                if (integerExample != null) {
+                    parameter.setExample(integerExample.toString());
+                }
+            } else if (example.getNodeType().equals(JsonNodeType.OBJECT)) {
+                ObjectNode objectValue = getObject("example", obj, false, location, result);
+                if (objectValue != null) {
+                    parameter.setExample(objectValue.toString());
+                }
+            } else if (example.getNodeType().equals(JsonNodeType.ARRAY)) {
+                ArrayNode arrayValue = getArray("example", obj, false, location, result);
+                if (arrayValue != null) {
+                    parameter.setExample(arrayValue.toString());
+                }
             }
         }
 
@@ -1448,11 +1484,28 @@ public class OpenAPIDeserializer {
             header.setExamples(getExampleList(examplesObject, location, result));
         }
 
-        JsonNode exampleNode = headerNode.get("example");
-        if(exampleNode != null) {
-            value = getString("example", headerNode, false, location, result);
-            if(StringUtils.isNotBlank(value)) {
-                header.setExample(value);
+        JsonNode example = headerNode.get("example");
+        if (example != null) {
+            if (example.getNodeType().equals(JsonNodeType.STRING)) {
+                value = getString("example", headerNode, false, location, result);
+                if (StringUtils.isNotBlank(value)) {
+                    header.setExample(value);
+                }
+            } if (example.getNodeType().equals(JsonNodeType.NUMBER)) {
+                Integer integerExample = getInteger("example", headerNode, false, location, result);
+                if (integerExample != null) {
+                    header.setExample(integerExample.toString());
+                }
+            } else if (example.getNodeType().equals(JsonNodeType.OBJECT)) {
+                ObjectNode objectValue = getObject("example", headerNode, false, location, result);
+                if (objectValue != null) {
+                    header.setExample(objectValue.toString());
+                }
+            } else if (example.getNodeType().equals(JsonNodeType.ARRAY)) {
+                ArrayNode arrayValue = getArray("example", headerNode, false, location, result);
+                if (arrayValue != null) {
+                    header.setExample(arrayValue.toString());
+                }
             }
         }
 
@@ -1983,9 +2036,29 @@ public class OpenAPIDeserializer {
             }
         }
 
-        String example = getString("example",node,false,location,result);
-        if (StringUtils.isNotBlank(example)) {
-            schema.setExample(example);
+        JsonNode example = node.get("example");
+        if (example != null) {
+            if (example.getNodeType().equals(JsonNodeType.STRING)) {
+                value = getString("example", node, false, location, result);
+                if (StringUtils.isNotBlank(value)) {
+                    schema.setExample(value);
+                }
+            }else    if (example.getNodeType().equals(JsonNodeType.NUMBER)) {
+                Integer integerExample = getInteger("example", node, false, location, result);
+                if (integerExample != null) {
+                    schema.setExample(integerExample.toString());
+                }
+            }else if (example.getNodeType().equals(JsonNodeType.OBJECT)) {
+                ObjectNode objectValue = getObject("example", node, false, location, result);
+                if (objectValue != null) {
+                    schema.setExample(objectValue);
+                }
+            } else if (example.getNodeType().equals(JsonNodeType.ARRAY)) {
+                ArrayNode arrayValue = getArray("example", node, false, location, result);
+                if (arrayValue != null) {
+                    schema.setExample(arrayValue);
+                }
+            }
         }
 
         bool = getBoolean("deprecated", node, false, location, result);

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/OpenAPIDeserializer.java
@@ -1438,9 +1438,9 @@ public class OpenAPIDeserializer {
             header.setSchema(getSchema(headerObject, location, result));
         }
 
-        ArrayNode examplesObject = getArray("examples",headerNode,false,location,result);
+        ObjectNode examplesObject = getObject("examples",headerNode,false,location,result);
         if(examplesObject!=null) {
-            header.setExamples(getExampleList(examplesObject, location, result));
+            header.setExamples(getExamples(examplesObject, location, result));
         }
 
         value = getAnyExample(headerNode, location,result);

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/test/OpenAPIResolverTest.java
@@ -404,7 +404,7 @@ public class OpenAPIResolverTest {
     @Test
     public void testIssue85(@Injectable final List<AuthorizationValue> auths) {
         String yaml =
-                "openapi: '3.0'\n" +
+                "openapi: '3.0.0'\n" +
                         "paths: \n" +
                         "  /test/method: \n" +
                         "    post: \n" +
@@ -453,7 +453,7 @@ public class OpenAPIResolverTest {
     @Test
     public void selfReferenceTest(@Injectable final List<AuthorizationValue> auths) {
         String yaml = "" +
-                "openapi: '3.0'\n" +
+                "openapi: '3.0.0'\n" +
                 "paths:\n" +
                 "  /selfRefA:\n" +
                 "    get:\n" +

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/test/OpenAPIResolverTest.java
@@ -267,8 +267,8 @@ public class OpenAPIResolverTest {
         //header remote schema ref
         assertEquals(headers.get("X-Rate-Limit-Remaining").getSchema().get$ref(),"#/components/schemas/User");
 
-        //TODO header examples
-        assertEquals(headers.get("X-Rate-Limit-Reset").getExamples().get(0).get$ref(), "#/components/examples/dog" );
+        //header examples
+        assertEquals(headers.get("X-Rate-Limit-Reset").getExamples().get("headerExample").get$ref(), "#/components/examples/dog" );
         //remote header ref
         assertEquals(headers.get("X-Ref-Limit-Limit").get$ref(),"#/components/headers/X-Rate-Limit-Reset" );
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/test/OpenAPIV3ParserTest.java
@@ -155,7 +155,7 @@ public class OpenAPIV3ParserTest {
 
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getOpenAPI());
-        Assert.assertEquals(result.getOpenAPI().getOpenapi(), "3.0");
+        Assert.assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0");
         Assert.assertEquals(result.getOpenAPI().getComponents().getSchemas().get("OrderRef").getType(),"object");
     }
 
@@ -173,7 +173,7 @@ public class OpenAPIV3ParserTest {
 
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getOpenAPI());
-        Assert.assertEquals(result.getOpenAPI().getOpenapi(), "3.0");
+        Assert.assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0");
         Assert.assertEquals(result.getOpenAPI().getComponents().getSchemas().get("OrderRef").getType(),"object");
     }
 
@@ -189,7 +189,7 @@ public class OpenAPIV3ParserTest {
 
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getOpenAPI());
-        Assert.assertEquals(result.getOpenAPI().getOpenapi(), "3.0");
+        Assert.assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0");
         Assert.assertEquals(result.getOpenAPI().getComponents().getSchemas().get("OrderRef").getType(),"object");
     }
 
@@ -201,7 +201,7 @@ public class OpenAPIV3ParserTest {
 
         OpenAPI openAPI = new OpenAPIV3Parser().read(url);
         Assert.assertNotNull(openAPI);
-        Assert.assertEquals(openAPI.getOpenapi(), "3.0");
+        Assert.assertEquals(openAPI.getOpenapi(), "3.0.0");
     }
 
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/test/OpenAPIV3ParserTest.java
@@ -155,13 +155,12 @@ public class OpenAPIV3ParserTest {
 
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getOpenAPI());
-        Assert.assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0-RC1");
+        Assert.assertEquals(result.getOpenAPI().getOpenapi(), "3.0");
         Assert.assertEquals(result.getOpenAPI().getComponents().getSchemas().get("OrderRef").getType(),"object");
     }
 
     @Test
     public void testResolveFully(@Injectable final List<AuthorizationValue> auths) throws Exception{
-
 
 
         String pathFile = FileUtils.readFileToString(new File("src/test/resources/oas3.yaml.template"));
@@ -174,7 +173,7 @@ public class OpenAPIV3ParserTest {
 
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getOpenAPI());
-        Assert.assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0-RC1");
+        Assert.assertEquals(result.getOpenAPI().getOpenapi(), "3.0");
         Assert.assertEquals(result.getOpenAPI().getComponents().getSchemas().get("OrderRef").getType(),"object");
     }
 
@@ -190,7 +189,7 @@ public class OpenAPIV3ParserTest {
 
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getOpenAPI());
-        Assert.assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0-RC1");
+        Assert.assertEquals(result.getOpenAPI().getOpenapi(), "3.0");
         Assert.assertEquals(result.getOpenAPI().getComponents().getSchemas().get("OrderRef").getType(),"object");
     }
 
@@ -202,7 +201,7 @@ public class OpenAPIV3ParserTest {
 
         OpenAPI openAPI = new OpenAPIV3Parser().read(url);
         Assert.assertNotNull(openAPI);
-        Assert.assertEquals(openAPI.getOpenapi(), "3.0.0-RC1");
+        Assert.assertEquals(openAPI.getOpenapi(), "3.0");
     }
 
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/OpenAPIDeserializerTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/OpenAPIDeserializerTest.java
@@ -176,8 +176,8 @@ public class OpenAPIDeserializerTest {
         Assert.assertNotNull(mediaTypeJson.getExamples());
         Assert.assertEquals(mediaTypeJson.getExamples().get("AnObject").get$ref(),"#/components/examples/AnObject");
 
-        //TODO Assert.assertNotNull(header1.getExamples()); uncoment when model of header is the same as parameter for examples
-        //Assert.assertEquals(header1.getExamples().get(0).getValue(),"httpbin");
+        Assert.assertNotNull(header1.getExamples());
+        Assert.assertEquals(header1.getExamples().get("httpbin").getValue(),"httpbin");
 
         Assert.assertNotNull(header2.getExample());
         Assert.assertEquals(header2.getExample(),"37");

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/OpenAPIDeserializerTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/OpenAPIDeserializerTest.java
@@ -50,7 +50,7 @@ public class OpenAPIDeserializerTest {
 
     @Test
     public void testExamples(@Injectable List<AuthorizationValue> auths){
-        String yaml = "openapi: 3.0\n"+
+        String yaml = "openapi: 3.0.0\n"+
                         "info:\n"+
                         "  title: httpbin\n"+
                         "  version: 0.0.0\n"+
@@ -193,7 +193,7 @@ public class OpenAPIDeserializerTest {
 
     @Test
     public void testSchemaExample(@Injectable List<AuthorizationValue> auths){
-        String yaml = "openapi: '3.0'\n" +
+        String yaml = "openapi: '3.0.0'\n" +
                 "components:\n" +
                 "  schemas:\n"+
                 "    Address:\n" +
@@ -265,7 +265,7 @@ public class OpenAPIDeserializerTest {
     }
 
     @Test void testDiscriminatorObject(@Injectable List<AuthorizationValue> auths){
-        String yaml = "openapi: '3.0'\n" +
+        String yaml = "openapi: '3.0.0'\n" +
                 "components:\n" +
                 "  schemas:\n" +
                 "    Pet:\n" +
@@ -338,7 +338,7 @@ public class OpenAPIDeserializerTest {
 
     @Test
     public void testAlmostEmpty(@Injectable List<AuthorizationValue> auths) {
-        String yaml = "openapi: '3.0'\n" +
+        String yaml = "openapi: '3.0.0'\n" +
                       "new: extra";
 
         OpenAPIV3Parser parser = new OpenAPIV3Parser();
@@ -367,7 +367,7 @@ public class OpenAPIDeserializerTest {
 
         final OpenAPI openAPI = result.getOpenAPI();
         Assert.assertNotNull(openAPI);
-        Assert.assertEquals(openAPI.getOpenapi(),"3.0");
+        Assert.assertEquals(openAPI.getOpenapi(),"3.0.0");
 
 
         final Info info = openAPI.getInfo();
@@ -809,7 +809,7 @@ public class OpenAPIDeserializerTest {
 
         final OpenAPI openAPI = result.getOpenAPI();
         Assert.assertNotNull(openAPI);
-        Assert.assertEquals(openAPI.getOpenapi(),"3.0");
+        Assert.assertEquals(openAPI.getOpenapi(),"3.0.0");
 
         final Components component = openAPI.getComponents();
         Assert.assertNotNull(component);

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/OpenAPIDeserializerTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/OpenAPIDeserializerTest.java
@@ -9,6 +9,7 @@ import io.swagger.oas.models.OpenAPI;
 import io.swagger.oas.models.Operation;
 import io.swagger.oas.models.PathItem;
 import io.swagger.oas.models.Paths;
+import io.swagger.oas.models.headers.Header;
 import io.swagger.oas.models.media.ArraySchema;
 import io.swagger.oas.models.media.ComposedSchema;
 import io.swagger.oas.models.media.Content;
@@ -46,6 +47,149 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 public class OpenAPIDeserializerTest {
+
+    @Test
+    public void testExamples(@Injectable List<AuthorizationValue> auths){
+        String yaml = "openapi: 3.0\n"+
+                        "info:\n"+
+                        "  title: httpbin\n"+
+                        "  version: 0.0.0\n"+
+                        "servers:\n"+
+                        "  - url: http://httpbin.org\n"+
+                        "paths:\n"+
+                        "  /post:\n"+
+                        "    post:\n"+
+                        "      summary: Returns the POSTed data\n"+
+                        "      requestBody:\n"+
+                        "        content:\n"+
+                        "          application/json:\n"+
+                        "            schema:\n"+
+                        "              $ref: '#/components/schemas/AnyValue'\n"+
+                        "            examples:\n"+
+                        "              AnObject:\n"+
+                        "                $ref: '#/components/examples/AnObject'\n"+
+                        "              ANull:\n"+
+                        "                $ref: '#/components/examples/ANull'\n"+
+                        "          application/yaml:\n"+
+                        "            schema:\n"+
+                        "              $ref: '#/components/schemas/AnyValue'\n"+
+                        "            examples:\n"+
+                        "              AString:\n"+
+                        "                $ref: '#/components/examples/AString'\n"+
+                        "              AnArray:\n"+
+                        "                $ref: '#/components/examples/AnArray'\n"+
+                        "          text/plain:\n"+
+                        "            schema:\n"+
+                        "              type: string\n"+
+                        "              example: Hi there\n"+
+                        "          application/x-www-form-urlencoded:\n"+
+                        "            schema:\n"+
+                        "              type: object\n"+
+                        "              properties:\n"+
+                        "                id:\n"+
+                        "                  type: integer\n"+
+                        "                name:\n"+
+                        "                  type: string\n"+
+                        "            example:\n"+
+                        "              id: 42\n"+
+                        "              name: Arthur Dent\n"+
+                        "      responses:\n"+
+                        "        '200':\n"+
+                        "          description: OK\n"+
+                        "          content:\n"+
+                        "            application/json:\n"+
+                        "              schema:\n"+
+                        "                type: object\n"+
+                        "\n"+
+                        "  #/response-headers:\n"+
+                        "  /:\n"+
+                        "    get:\n"+
+                        "      summary: Returns a response with the specified headers\n"+
+                        "      parameters:\n"+
+                        "        - in: header\n"+
+                        "          name: Server\n"+
+                        "          required: true\n"+
+                        "          schema:\n"+
+                        "            type: string\n"+
+                        "          examples:\n"+
+                        "            httpbin:\n"+
+                        "              value: httpbin\n"+
+                        "            unicorn:\n"+
+                        "              value: unicorn\n"+
+                        "        - in: header\n"+
+                        "          name: X-Request-Id\n"+
+                        "          required: true\n"+
+                        "          schema:\n"+
+                        "            type: integer\n"+
+                        "          example: 37\n"+
+                        "      responses:\n"+
+                        "        '200':\n"+
+                        "          description: A response with the specified headers\n"+
+                        "          headers:\n"+
+                        "            Server:\n"+
+                        "              schema:\n"+
+                        "                type: string\n"+
+                        "              examples:\n"+
+                        "                httpbin:\n"+
+                        "                  value: httpbin\n"+
+                        "                unicorn:\n"+
+                        "                  value: unicorn\n"+
+                        "            X-Request-Id:\n"+
+                        "              schema:\n"+
+                        "                type: integer\n"+
+                        "              example: 37\n"+
+                        "\n"+
+                        "components:\n"+
+                        "  schemas:\n"+
+                        "    AnyValue:\n"+
+                        "      nullable: true\n"+
+                        "      description: Can be anything - string, object, array, null, etc.\n"+
+                        "\n"+
+                        "  examples:\n"+
+                        "    AString:\n"+
+                        "      value: Hi there\n"+
+                        "    ANumber:\n"+
+                        "      value: 42\n"+
+                        "    ANull:\n"+
+                        "      value: null\n"+
+                        "    AnArray:\n"+
+                        "      value: [1, 2, 3]\n"+
+                        "    AnObject:\n"+
+                        "      value:\n"+
+                        "        id:  42\n"+
+                        "        name: Arthur Dent";
+
+        OpenAPIV3Parser parser = new OpenAPIV3Parser();
+
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+
+        SwaggerParseResult result = parser.readContents(yaml,auths,options);
+        OpenAPI openAPI = result.getOpenAPI();
+        MediaType mediaTypeJson = openAPI.getPaths().get("/post").getPost().getRequestBody().getContent().get("application/json");
+        Header header1 = openAPI.getPaths().get("/").getGet().getResponses().get("200").getHeaders().get("Server");
+        Header header2 = openAPI.getPaths().get("/").getGet().getResponses().get("200").getHeaders().get("X-Request-Id");
+        Parameter parameter1 = openAPI.getPaths().get("/").getGet().getParameters().get(0);
+        Parameter parameter2 = openAPI.getPaths().get("/").getGet().getParameters().get(1);
+
+
+        Assert.assertNotNull(mediaTypeJson.getExamples());
+        Assert.assertEquals(mediaTypeJson.getExamples().get("AnObject").get$ref(),"#/components/examples/AnObject");
+
+        //TODO Assert.assertNotNull(header1.getExamples()); uncoment when model of header is the same as parameter for examples
+        //Assert.assertEquals(header1.getExamples().get(0).getValue(),"httpbin");
+
+        Assert.assertNotNull(header2.getExample());
+        Assert.assertEquals(header2.getExample(),"37");
+
+        Assert.assertNotNull(parameter1.getExamples());
+        Assert.assertEquals(parameter1.getExamples().get("unicorn").getValue(),"unicorn");
+
+        Assert.assertNotNull(parameter2.getExample());
+        Assert.assertEquals(parameter2.getExample(),"37");
+    }
+
+
 
     @Test
     public void testSchemaExample(@Injectable List<AuthorizationValue> auths){
@@ -223,7 +367,7 @@ public class OpenAPIDeserializerTest {
 
         final OpenAPI openAPI = result.getOpenAPI();
         Assert.assertNotNull(openAPI);
-        Assert.assertEquals(openAPI.getOpenapi(),"3.0.0-RC1");
+        Assert.assertEquals(openAPI.getOpenapi(),"3.0");
 
 
         final Info info = openAPI.getInfo();
@@ -665,7 +809,7 @@ public class OpenAPIDeserializerTest {
 
         final OpenAPI openAPI = result.getOpenAPI();
         Assert.assertNotNull(openAPI);
-        Assert.assertEquals(openAPI.getOpenapi(),"3.0.0-RC1");
+        Assert.assertEquals(openAPI.getOpenapi(),"3.0");
 
         final Components component = openAPI.getComponents();
         Assert.assertNotNull(component);

--- a/modules/swagger-parser-v3/src/test/resources/oas.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/oas.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0
+openapi: 3.0.0
 paths:
   /pet:
     summary: "summary"

--- a/modules/swagger-parser-v3/src/test/resources/oas2.yaml.template
+++ b/modules/swagger-parser-v3/src/test/resources/oas2.yaml.template
@@ -1,4 +1,4 @@
-openapi: 3.0
+openapi: 3.0.0
 servers: []
 paths:
   /pet:

--- a/modules/swagger-parser-v3/src/test/resources/oas3.yaml.template
+++ b/modules/swagger-parser-v3/src/test/resources/oas3.yaml.template
@@ -1110,7 +1110,8 @@ components:
           schema:
             $ref: '#/components/schemas/ExtendedErrorModel'
       examples:
-      - $ref: "#/components/examples/dog"
+        headerExample:
+            $ref: "#/components/examples/dog"
   links:
     referenced:
       "$ref": "#/components/links/unsubscribe"

--- a/modules/swagger-parser-v3/src/test/resources/oas3.yaml.template
+++ b/modules/swagger-parser-v3/src/test/resources/oas3.yaml.template
@@ -1,5 +1,5 @@
 ---
-openapi: 3.0
+openapi: 3.0.0
 servers:
 - url: http://petstore.swagger.io/v2
 - url: https://development.gigantic-server.com/v1

--- a/modules/swagger-parser-v3/src/test/resources/oas3.yaml.template
+++ b/modules/swagger-parser-v3/src/test/resources/oas3.yaml.template
@@ -1,5 +1,5 @@
 ---
-openapi: 3.0.0-RC1
+openapi: 3.0
 servers:
 - url: http://petstore.swagger.io/v2
 - url: https://development.gigantic-server.com/v1

--- a/modules/swagger-parser-v3/src/test/resources/oas4.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/oas4.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0
+openapi: 3.0.0
 servers:
   - url: 'https://api.stripe.com/'
 x-origin:

--- a/modules/swagger-parser-v3/src/test/resources/oas4.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/oas4.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0-RC1
+openapi: 3.0
 servers:
   - url: 'https://api.stripe.com/'
 x-origin:

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <swagger-parser-v2-version>1.0.28</swagger-parser-v2-version>
         <commons-io-version>2.4</commons-io-version>
         <slf4j-version>1.6.3</slf4j-version>
-        <swagger-core-version>2.0.0-rc1</swagger-core-version>
+        <swagger-core-version>2.0.0-SNAPSHOT</swagger-core-version>
         <junit-version>4.8.1</junit-version>
         <testng-version>6.9.6</testng-version>
         <jmockit-version>1.19</jmockit-version>


### PR DESCRIPTION
The Example attribute now supports primitives (integer, big decimal, string), objects and arrays, where the spec says the value can be Any. 
Please Merge [[https://github.com/swagger-api/swagger-core/pull/2406]](https://github.com/swagger-api/swagger-core/pull/2406) before merging this.