### PR TITLE
Json.pretty puts extensions in wrong place

### DIFF
--- a/modules/swagger-parser/src/test/java/io/swagger/parser/OpenAPIParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/OpenAPIParserTest.java
@@ -1,7 +1,9 @@
 package io.swagger.parser;
 
+import io.swagger.oas.models.OpenAPI;
 import io.swagger.parser.models.ParseOptions;
 import io.swagger.parser.models.SwaggerParseResult;
+import io.swagger.util.Json;
 import org.junit.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -55,5 +57,30 @@ public class OpenAPIParserTest {
         assertNotNull(result);
         assertNotNull(result.getOpenAPI());
         assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0-rc1");
+    }
+
+    @Test
+    public void testParsingPrettifiedExtensions() throws Exception {
+        String json =
+                "{\n" +
+                        "  \"openapi\": \"3.0.0\",\n" +
+                        "  \"x-some-extension\": \"some-value\"\n" +
+                        "}";
+
+        SwaggerParseResult result = new OpenAPIParser().readContents(json, null, null);
+        assertNotNull(result);
+        OpenAPI openAPI = result.getOpenAPI();
+        assertNotNull(openAPI);
+        assertNotNull(openAPI.getExtensions());
+        assertEquals(openAPI.getExtensions().get("x-some-extension"), "some-value");
+
+        String prettyJson = Json.pretty(openAPI);
+
+        SwaggerParseResult prettyResult = new OpenAPIParser().readContents(prettyJson, null, null);
+        assertNotNull(prettyResult);
+        OpenAPI prettyOpenAPI = prettyResult.getOpenAPI();
+        assertNotNull(prettyOpenAPI);
+        assertNotNull(prettyOpenAPI.getExtensions());
+        assertEquals(prettyOpenAPI.getExtensions().get("x-some-extension"), "some-value");
     }
 }


### PR DESCRIPTION
`Json.pretty(openAPI)` makes the extensions go under its own `extension` node. This results that when parsing it again they will be gone.

The variable `prettyJson` in my testcase has the value 
```json
{
  "openapi" : "3.0.0",
  "servers" : [ {
    "url" : "/"
  } ],
  "extensions" : {
    "x-some-extension" : "some-value"
  }
}
```

I would expect `x-some-extensions` to be directly under the root as it was in the initial `json` variable.