### PR TITLE
Flatten Schema Option

### DIFF
--- a/modules/swagger-parser-core/src/main/java/io/swagger/parser/models/ParseOptions.java
+++ b/modules/swagger-parser-core/src/main/java/io/swagger/parser/models/ParseOptions.java
@@ -3,6 +3,7 @@ package io.swagger.parser.models;
 public class ParseOptions {
     private boolean resolve;
     private boolean resolveFully;
+    private boolean flatten;
 
     public boolean isResolve() {
         return resolve;
@@ -19,4 +20,8 @@ public class ParseOptions {
     public void setResolveFully(boolean resolveFully) {
         this.resolveFully = resolveFully;
     }
+
+    public boolean isFlatten() { return flatten; }
+
+    public void setFlatten(boolean flatten) { this.flatten = flatten; }
 }

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/OpenAPIV3Parser.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/OpenAPIV3Parser.java
@@ -9,6 +9,7 @@ import io.swagger.parser.models.ParseOptions;
 import io.swagger.parser.models.SwaggerParseResult;
 import io.swagger.parser.v3.util.ClasspathHelper;
 import io.swagger.parser.v3.util.DeserializationUtils;
+import io.swagger.parser.v3.util.InlineModelResolver;
 import io.swagger.parser.v3.util.OpenAPIDeserializer;
 import io.swagger.parser.v3.util.RemoteUrl;
 import io.swagger.parser.v3.util.ResolverFully;
@@ -54,6 +55,9 @@ public class OpenAPIV3Parser implements SwaggerParserExtension {
                         if (options.isResolveFully()) {
                             result.setOpenAPI(resolver.resolve());
                             new ResolverFully().resolveFully(result.getOpenAPI());
+                        }else if (options.isFlatten()){
+                            InlineModelResolver inlineResolver = new InlineModelResolver();
+                            inlineResolver.flatten(result.getOpenAPI());
                         }
                     }
                 }
@@ -177,6 +181,9 @@ public class OpenAPIV3Parser implements SwaggerParserExtension {
                 }if (options.isResolveFully()){
                     result.setOpenAPI(new OpenAPIResolver(result.getOpenAPI(), auth, null).resolve());
                     new ResolverFully().resolveFully(result.getOpenAPI());
+
+                }if (options.isFlatten()){
+                    new InlineModelResolver().flatten(result.getOpenAPI());
                 }
             }else{
                 try {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/InlineModelResolver.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/InlineModelResolver.java
@@ -1,5 +1,6 @@
 package io.swagger.parser.v3.util;
 
+import io.swagger.oas.models.Components;
 import io.swagger.oas.models.OpenAPI;
 import io.swagger.oas.models.Operation;
 import io.swagger.oas.models.PathItem;
@@ -41,6 +42,9 @@ public class InlineModelResolver {
 
         // operations
         Map<String, PathItem> paths = openAPI.getPaths();
+        if(openAPI.getComponents()== null){
+            openAPI.setComponents(new Components());
+        }
         Map<String, Schema> models = openAPI.getComponents().getSchemas();
 
         if (paths != null) {
@@ -441,9 +445,11 @@ public class InlineModelResolver {
      * @param target target property
      */
     public void copyVendorExtensions(Schema source, Schema target) {
-        Map<String, Object> vendorExtensions = source.getExtensions();
-        for (String extName : vendorExtensions.keySet()) {
-            target.addExtension(extName, vendorExtensions.get(extName));
+        if(source.getExtensions() != null) {
+            Map<String, Object> vendorExtensions = source.getExtensions();
+            for (String extName : vendorExtensions.keySet()) {
+                target.addExtension(extName, vendorExtensions.get(extName));
+            }
         }
     }
 

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/InlineModelResolver.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/InlineModelResolver.java
@@ -64,7 +64,7 @@ public class InlineModelResolver {
                                         Schema model = mediaType.getSchema();
                                         if (model.getProperties() != null && model.getProperties().size() > 0) {
                                             flattenProperties(model.getProperties(), pathname);
-                                            String modelName = resolveModelName(model.getTitle(), model.getName());
+                                            String modelName = resolveModelName(model.getTitle(), "body");
                                             mediaType.setSchema(new Schema().$ref(modelName));
                                             addGenerated(modelName, model);
                                             openAPI.getComponents().addSchemas(modelName, model);

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/InlineModelResolver.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/InlineModelResolver.java
@@ -1,0 +1,458 @@
+package io.swagger.parser.v3.util;
+
+import io.swagger.oas.models.OpenAPI;
+import io.swagger.oas.models.Operation;
+import io.swagger.oas.models.PathItem;
+import io.swagger.oas.models.media.ArraySchema;
+import io.swagger.oas.models.media.ComposedSchema;
+import io.swagger.oas.models.media.MediaType;
+import io.swagger.oas.models.media.ObjectSchema;
+import io.swagger.oas.models.media.Schema;
+import io.swagger.oas.models.media.XML;
+import io.swagger.oas.models.parameters.Parameter;
+import io.swagger.oas.models.parameters.RequestBody;
+import io.swagger.oas.models.responses.ApiResponse;
+import io.swagger.util.Json;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class InlineModelResolver {
+    private OpenAPI openAPI;
+    private boolean skipMatches;
+    static Logger LOGGER = LoggerFactory.getLogger(InlineModelResolver.class);
+
+    Map<String, Schema> addedModels = new HashMap<>();
+    Map<String, String> generatedSignature = new HashMap<>();
+
+    public void flatten(OpenAPI openAPI) {
+        this.openAPI = openAPI;
+
+        if (openAPI.getComponents() != null) {
+
+            if (openAPI.getComponents().getSchemas() == null) {
+                openAPI.getComponents().setSchemas(new HashMap<>());
+            }
+        }
+
+        // operations
+        Map<String, PathItem> paths = openAPI.getPaths();
+        Map<String, Schema> models = openAPI.getComponents().getSchemas();
+
+        if (paths != null) {
+            for (String pathname : paths.keySet()) {
+                PathItem path = paths.get(pathname);
+
+                for (Operation operation : path.readOperations()) {
+                    RequestBody body = operation.getRequestBody();
+
+                    if (body != null) {
+                        if (body.getContent() != null) {
+                            Map<String,MediaType> content = body.getContent();
+                            for(String key: content.keySet()) {
+                                if (content.get(key) != null) {
+                                    MediaType mediaType = content.get(key);
+                                    if(mediaType.getSchema() != null) {
+                                        Schema model = mediaType.getSchema();
+                                        if (model.getProperties() != null && model.getProperties().size() > 0) {
+                                            flattenProperties(model.getProperties(), pathname);
+                                            String modelName = resolveModelName(model.getTitle(), model.getName());
+                                            mediaType.setSchema(new Schema().$ref(modelName));
+                                            addGenerated(modelName, model);
+                                            openAPI.getComponents().addSchemas(modelName, model);
+
+                                        } else if (model instanceof ArraySchema) {
+                                            ArraySchema am = (ArraySchema) model;
+                                            Schema inner = am.getItems();
+
+                                            if (inner instanceof ObjectSchema) {
+                                                ObjectSchema op = (ObjectSchema) inner;
+                                                if (op.getProperties() != null && op.getProperties().size() > 0) {
+                                                    flattenProperties(op.getProperties(), pathname);
+                                                    String modelName = resolveModelName(op.getTitle(), model.getName());
+                                                    Schema innerModel = modelFromProperty(op, modelName);
+                                                    String existing = matchGenerated(innerModel);
+                                                    if (existing != null) {
+                                                        am.setItems(new Schema().$ref(existing));
+                                                    } else {
+                                                        am.setItems(new Schema().$ref(modelName));
+                                                        addGenerated(modelName, innerModel);
+                                                        openAPI.getComponents().addSchemas(modelName, innerModel);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Map<String, ApiResponse> responses = operation.getResponses();
+                    if (responses != null) {
+                        for (String key : responses.keySet()) {
+                            ApiResponse response = responses.get(key);
+                            if (response.getContent() != null) {
+                                Map<String,MediaType> content = response.getContent();
+                                for (String name: content.keySet()) {
+                                    if (content.get(name) != null) {
+                                        MediaType media = content.get(name);
+                                        if (media.getSchema() != null) {
+                                            Schema property = media.getSchema();
+                                            if (property instanceof ObjectSchema) {
+                                                ObjectSchema op = (ObjectSchema) property;
+                                                if (op.getProperties() != null && op.getProperties().size() > 0) {
+                                                    String modelName = resolveModelName(op.getTitle(), "inline_response_" + key);
+                                                    Schema model = modelFromProperty(op, modelName);
+                                                    String existing = matchGenerated(model);
+                                                    if (existing != null) {
+                                                        media.setSchema(this.makeRefProperty(existing, property));
+                                                    } else {
+                                                        media.setSchema(this.makeRefProperty(modelName, property));
+                                                        addGenerated(modelName, model);
+                                                        openAPI.getComponents().addSchemas(modelName, model);
+                                                    }
+                                                }
+                                            } else if (property instanceof ArraySchema) {
+                                                ArraySchema ap = (ArraySchema) property;
+                                                Schema inner = ap.getItems();
+
+                                                if (inner instanceof ObjectSchema) {
+                                                    ObjectSchema op = (ObjectSchema) inner;
+                                                    if (op.getProperties() != null && op.getProperties().size() > 0) {
+                                                        flattenProperties(op.getProperties(), pathname);
+                                                        String modelName = resolveModelName(op.getTitle(),
+                                                                "inline_response_" + key);
+                                                        Schema innerModel = modelFromProperty(op, modelName);
+                                                        String existing = matchGenerated(innerModel);
+                                                        if (existing != null) {
+                                                            ap.setItems(this.makeRefProperty(existing, op));
+                                                        } else {
+                                                            ap.setItems(this.makeRefProperty(modelName, op));
+                                                            addGenerated(modelName, innerModel);
+                                                            openAPI.getComponents().addSchemas(modelName, innerModel);
+                                                        }
+                                                    }
+                                                }
+                                            } else if (property.getAdditionalProperties() != null) {
+
+                                                Schema innerProperty = property.getAdditionalProperties();
+                                                if (innerProperty instanceof ObjectSchema) {
+                                                    ObjectSchema op = (ObjectSchema) innerProperty;
+                                                    if (op.getProperties() != null && op.getProperties().size() > 0) {
+                                                        flattenProperties(op.getProperties(), pathname);
+                                                        String modelName = resolveModelName(op.getTitle(),
+                                                                "inline_response_" + key);
+                                                        Schema innerModel = modelFromProperty(op, modelName);
+                                                        String existing = matchGenerated(innerModel);
+                                                        if (existing != null) {
+                                                            property.setAdditionalProperties(new Schema().$ref(existing));
+                                                        } else {
+                                                            property.setAdditionalProperties(new Schema().$ref(modelName));
+                                                            addGenerated(modelName, innerModel);
+                                                            openAPI.getComponents().addSchemas(modelName, innerModel);
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // definitions
+        if (models != null) {
+            List<String> modelNames = new ArrayList<String>(models.keySet());
+            for (String modelName : modelNames) {
+                Schema model = models.get(modelName);
+                if (model.getProperties() != null) {
+                    Map<String, Schema> properties = model.getProperties();
+                    flattenProperties(properties, modelName);
+                    fixStringModel(model);
+                } else if (model instanceof ArraySchema) {
+                    ArraySchema m = (ArraySchema) model;
+                    Schema inner = m.getItems();
+                    if (inner instanceof ObjectSchema) {
+                        ObjectSchema op = (ObjectSchema) inner;
+                        if (op.getProperties() != null && op.getProperties().size() > 0) {
+                            String innerModelName = resolveModelName(op.getTitle(), modelName + "_inner");
+                            Schema innerModel = modelFromProperty(op, innerModelName);
+                            String existing = matchGenerated(innerModel);
+                            if (existing == null) {
+                                openAPI.getComponents().addSchemas(innerModelName, innerModel);
+                                addGenerated(innerModelName, innerModel);
+                                m.setItems(new Schema().$ref(innerModelName));
+                            } else {
+                                m.setItems(new Schema().$ref(existing));
+                            }
+                        }
+                    }
+                } else if (model instanceof ComposedSchema) {
+                    ComposedSchema composedSchema = (ComposedSchema) model;
+                    List<Schema> list = null;
+                    if (composedSchema.getAllOf() != null) {
+                      list  = composedSchema.getAllOf();
+                    }else if (composedSchema.getAnyOf() != null) {
+                        list  = composedSchema.getAnyOf();
+                    }else if (composedSchema.getOneOf() != null) {
+                        list  = composedSchema.getOneOf();
+                    }
+                    for(int i= 0; i<list.size();i++){
+                        if(list.get(i).getProperties()!= null){
+                            flattenProperties(list.get(i).getProperties(), modelName);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * This function fix models that are string (mostly enum). Before this fix, the example
+     * would look something like that in the doc: "\"example from def\""
+     * @param m Model implementation
+     */
+    private void fixStringModel(Schema m) {
+        if (m.getType() != null && m.getType().equals("string") && m.getExample() != null) {
+            String example = m.getExample().toString();
+            if (example.substring(0, 1).equals("\"") &&
+                    example.substring(example.length() - 1).equals("\"")) {
+                m.setExample(example.substring(1, example.length() - 1));
+            }
+        }
+    }
+
+    private String resolveModelName(String title, String key) {
+        if (title == null) {
+            return uniqueName(key);
+        } else {
+            return uniqueName(title);
+        }
+    }
+
+    public String matchGenerated(Schema model) {
+        if (this.skipMatches) {
+            return null;
+        }
+        String json = Json.pretty(model);
+        if (generatedSignature.containsKey(json)) {
+            return generatedSignature.get(json);
+        }
+        return null;
+    }
+
+    public void addGenerated(String name, Schema model) {
+        generatedSignature.put(Json.pretty(model), name);
+    }
+
+    public String uniqueName(String key) {
+        int count = 0;
+        boolean done = false;
+        key = key.replaceAll("[^a-z_\\.A-Z0-9 ]", ""); // FIXME: a parameter
+        // should not be
+        // assigned. Also declare
+        // the methods parameters
+        // as 'final'.
+        while (!done) {
+            String name = key;
+            if (count > 0) {
+                name = key + "_" + count;
+            }
+            if (openAPI.getComponents().getSchemas() == null) {
+                return name;
+            } else if (!openAPI.getComponents().getSchemas().containsKey(name)) {
+                return name;
+            }
+            count += 1;
+        }
+        return key;
+    }
+
+    public void flattenProperties(Map<String, Schema> properties, String path) {
+        if (properties == null) {
+            return;
+        }
+        Map<String, Schema> propsToUpdate = new HashMap<>();
+        Map<String, Schema> modelsToAdd = new HashMap<>();
+        for (String key : properties.keySet()) {
+            Schema property = properties.get(key);
+            if (property instanceof ObjectSchema && ((ObjectSchema) property).getProperties() != null
+                    && ((ObjectSchema) property).getProperties().size() > 0) {
+
+                ObjectSchema op = (ObjectSchema) property;
+
+                String modelName = resolveModelName(op.getTitle(), path + "_" + key);
+                Schema model = modelFromProperty(op, modelName);
+
+                String existing = matchGenerated(model);
+
+                if (existing != null) {
+                    propsToUpdate.put(key, new Schema().$ref(existing));
+                } else {
+                    propsToUpdate.put(key, new Schema().$ref(modelName));
+                    modelsToAdd.put(modelName, model);
+                    addGenerated(modelName, model);
+                    openAPI.getComponents().addSchemas(modelName, model);
+                }
+            } else if (property instanceof ArraySchema) {
+                ArraySchema ap = (ArraySchema) property;
+                Schema inner = ap.getItems();
+
+                if (inner instanceof ObjectSchema) {
+                    ObjectSchema op = (ObjectSchema) inner;
+                    if (op.getProperties() != null && op.getProperties().size() > 0) {
+                        flattenProperties(op.getProperties(), path);
+                        String modelName = resolveModelName(op.getTitle(), path + "_" + key);
+                        Schema innerModel = modelFromProperty(op, modelName);
+                        String existing = matchGenerated(innerModel);
+                        if (existing != null) {
+                            ap.setItems(new Schema().$ref(existing));
+                        } else {
+                            ap.setItems(new Schema().$ref(modelName));
+                            addGenerated(modelName, innerModel);
+                            openAPI.getComponents().addSchemas(modelName, innerModel);
+                        }
+                    }
+                }
+            } else if (property.getAdditionalProperties() != null) {
+                Schema inner = property.getAdditionalProperties();
+
+                if (inner instanceof ObjectSchema) {
+                    ObjectSchema op = (ObjectSchema) inner;
+                    if (op.getProperties() != null && op.getProperties().size() > 0) {
+                        flattenProperties(op.getProperties(), path);
+                        String modelName = resolveModelName(op.getTitle(), path + "_" + key);
+                        Schema innerModel = modelFromProperty(op, modelName);
+                        String existing = matchGenerated(innerModel);
+                        if (existing != null) {
+                            property.setAdditionalProperties(new Schema().$ref(existing));
+                        } else {
+                            property.setAdditionalProperties(new Schema().$ref(modelName));
+                            addGenerated(modelName, innerModel);
+                            openAPI.getComponents().addSchemas(modelName, innerModel);
+                        }
+                    }
+                }
+            }
+        }
+        if (propsToUpdate.size() > 0) {
+            for (String key : propsToUpdate.keySet()) {
+                properties.put(key, propsToUpdate.get(key));
+            }
+        }
+        for (String key : modelsToAdd.keySet()) {
+            openAPI.getComponents().addSchemas(key, modelsToAdd.get(key));
+            this.addedModels.put(key, modelsToAdd.get(key));
+        }
+    }
+
+    @SuppressWarnings("static-method")
+    public Schema modelFromProperty(ArraySchema object, @SuppressWarnings("unused") String path) {
+        String description = object.getDescription();
+        String example = null;
+
+        Object obj = object.getExample();
+        if (obj != null) {
+            example = obj.toString();
+        }
+
+        Schema inner = object.getItems();
+        if (inner instanceof ObjectSchema) {
+            ArraySchema model = new ArraySchema();
+            model.setDescription(description);
+            model.setExample(example);
+            model.setItems(object.getItems());
+            return model;
+        }
+
+        return null;
+    }
+
+    public Schema modelFromProperty(ObjectSchema object, String path) {
+        String description = object.getDescription();
+        String example = null;
+
+        Object obj = object.getExample();
+        if (obj != null) {
+            example = obj.toString();
+        }
+        String name = object.getName();
+        XML xml = object.getXml();
+        Map<String, Schema> properties = object.getProperties();
+
+        Schema model = new Schema();//TODO Verify this!
+        model.setDescription(description);
+        model.setExample(example);
+        model.setName(name);
+        model.setXml(xml);
+
+        if (properties != null) {
+            flattenProperties(properties, path);
+            model.setProperties(properties);
+        }
+
+        return model;
+    }
+
+    @SuppressWarnings("static-method")
+    public Schema modelFromProperty(Schema object, @SuppressWarnings("unused") String path) {
+        String description = object.getDescription();
+        String example = null;
+
+        Object obj = object.getExample();
+        if (obj != null) {
+            example = obj.toString();
+        }
+
+        ArraySchema model = new ArraySchema();
+        model.setDescription(description);
+        model.setExample(example);
+        model.setItems(object.getAdditionalProperties());
+
+        return model;
+    }
+
+    /**
+     * Make a RefProperty
+     *
+     * @param ref new property name
+     * @param property Property
+     * @return
+     */
+    public Schema makeRefProperty(String ref, Schema property) {
+        Schema newProperty = new Schema().$ref(ref);
+
+        this.copyVendorExtensions(property, newProperty);
+        return newProperty;
+    }
+
+    /**
+     * Copy vendor extensions from Property to another Property
+     *
+     * @param source source property
+     * @param target target property
+     */
+    public void copyVendorExtensions(Schema source, Schema target) {
+        Map<String, Object> vendorExtensions = source.getExtensions();
+        for (String extName : vendorExtensions.keySet()) {
+            target.addExtension(extName, vendorExtensions.get(extName));
+        }
+    }
+
+    public boolean isSkipMatches() {
+        return skipMatches;
+    }
+
+    public void setSkipMatches(boolean skipMatches) {
+        this.skipMatches = skipMatches;
+    }
+
+}

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/InlineModelResolver.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/InlineModelResolver.java
@@ -77,7 +77,7 @@ public class InlineModelResolver {
                                                 ObjectSchema op = (ObjectSchema) inner;
                                                 if (op.getProperties() != null && op.getProperties().size() > 0) {
                                                     flattenProperties(op.getProperties(), pathname);
-                                                    String modelName = resolveModelName(op.getTitle(), model.getName());
+                                                    String modelName = resolveModelName(op.getTitle(), "body");
                                                     Schema innerModel = modelFromProperty(op, modelName);
                                                     String existing = matchGenerated(innerModel);
                                                     if (existing != null) {

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/InlineModelResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/InlineModelResolverTest.java
@@ -195,6 +195,7 @@ public class InlineModelResolverTest {
         addressSchema.setName("name");
         addressSchema.addProperties("street", new StringSchema());
         addressSchema.addProperties("city", new StringSchema());
+        addressSchema.addProperties("apartment", new StringSchema());
 
 
         Schema anotherSchema =  new Schema();
@@ -206,7 +207,7 @@ public class InlineModelResolverTest {
         anotherSchema.addProperties("name", new StringSchema());
         anotherSchema.addProperties("lastName", new StringSchema());
         anotherSchema.addProperties("address", addressSchema);
-        anotherSchema.addProperties("apartment", new StringSchema());
+
 
         openAPI.getComponents().addSchemas("AnotherUser", anotherSchema);
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/InlineModelResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/InlineModelResolverTest.java
@@ -2,9 +2,15 @@ package io.swagger.parser.v3.util;
 
 import io.swagger.oas.models.Components;
 import io.swagger.oas.models.OpenAPI;
+import io.swagger.oas.models.Operation;
+import io.swagger.oas.models.PathItem;
+import io.swagger.oas.models.media.Content;
+import io.swagger.oas.models.media.MediaType;
 import io.swagger.oas.models.media.ObjectSchema;
 import io.swagger.oas.models.media.Schema;
 import io.swagger.oas.models.media.StringSchema;
+import io.swagger.oas.models.responses.ApiResponse;
+import io.swagger.oas.models.responses.ApiResponses;
 import io.swagger.util.Json;
 import org.testng.annotations.Test;
 
@@ -231,42 +237,86 @@ public class InlineModelResolverTest {
     }
 
 
-    /*@Test
+    @Test
     public void testInlineResponseModel() throws Exception {
-        Swagger swagger = new Swagger();
+        OpenAPI openAPI = new OpenAPI();
 
-        swagger.path("/foo/bar", new Path()
-                .get(new Operation()
-                        .response(200, new Response()
-                                .description("it works!")
-                                .schema(new ObjectProperty()
-                                        .property("name", new StringProperty()).vendorExtension("x-ext", "ext-prop")))))
-                .path("/foo/baz", new Path()
-                        .get(new Operation()
-                                .response(200, new Response()
-                                        .vendorExtension("x-foo", "bar")
-                                        .description("it works!")
-                                        .schema(new ObjectProperty()
-                                                .property("name", new StringProperty()).vendorExtension("x-ext", "ext-prop")))));
-        new InlineModelResolver().flatten(swagger);
 
-        Map<String, Response> responses = swagger.getPaths().get("/foo/bar").getGet().getResponses();
+        StringSchema stringSchema1 = new StringSchema();
+        stringSchema1.addExtension("x-ext", "ext-prop");
 
-        Response response = responses.get("200");
+        ObjectSchema objectSchema1 = new ObjectSchema();
+        objectSchema1.addProperties("name", stringSchema1);
+
+        MediaType mediaType1 = new MediaType();
+        mediaType1.setSchema(objectSchema1);
+
+        Content content1 = new Content();
+        content1.addMediaType("*/*", mediaType1 );
+
+        ApiResponse response1= new ApiResponse();
+        response1.setDescription("it works!");
+        response1.setContent(content1);
+
+        ApiResponses responses1 = new ApiResponses();
+        responses1.addApiResponse("200",response1);
+
+        Operation operation1 = new Operation();
+        operation1.setResponses(responses1);
+
+        PathItem pathItem1 = new PathItem();
+        pathItem1.setGet(operation1);
+        openAPI.path("/foo/bar",pathItem1);
+
+
+
+        StringSchema stringSchema2 = new StringSchema();
+        stringSchema1.addExtension("x-ext", "ext-prop");
+
+        ObjectSchema objectSchema2 = new ObjectSchema();
+        objectSchema2.addProperties("name", stringSchema2);
+
+        MediaType mediaType2 = new MediaType();
+        mediaType2.setSchema(objectSchema2);
+
+        Content content2 = new Content();
+        content2.addMediaType("*/*", mediaType2 );
+
+        ApiResponse response2 = new ApiResponse();
+        response2.setDescription("it works!");
+        response2.addExtension("x-foo","bar");
+        response2.setContent(content2);
+
+        ApiResponses responses2 = new ApiResponses();
+        responses2.addApiResponse("200",response2);
+
+        Operation operation2 = new Operation();
+        operation2.setResponses(responses2);
+
+        PathItem pathItem2 = new PathItem();
+        pathItem2.setGet(operation2);
+        openAPI.path("/foo/baz",pathItem2);
+
+        new InlineModelResolver().flatten(openAPI);
+
+        Map<String, ApiResponse> responses = openAPI.getPaths().get("/foo/bar").getGet().getResponses();
+
+        ApiResponse response = responses.get("200");
         assertNotNull(response);
-        Property schema = response.getSchema();
-        assertTrue(schema instanceof RefProperty);
-        assertEquals(1, schema.getVendorExtensions().size());
-        assertEquals("ext-prop", schema.getVendorExtensions().get("x-ext"));
+        System.out.println(response);
+        Schema schema = response.getContent().get("*/*").getSchema();
+        assertTrue(schema.get$ref() != null);
+        assertEquals(1, schema.getExtensions().size());
+        assertEquals("ext-prop", schema.getExtensions().get("x-ext"));
 
-        ModelImpl model = (ModelImpl)swagger.getDefinitions().get("inline_response_200");
+        Schema model = openAPI.getComponents().getSchemas().get("inline_response_200");
         assertTrue(model.getProperties().size() == 1);
         assertNotNull(model.getProperties().get("name"));
-        assertTrue(model.getProperties().get("name") instanceof StringProperty);
+        assertTrue(model.getProperties().get("name") instanceof StringSchema);
     }
 
 
-    @Test
+    /*@Test
     public void testInlineResponseModelWithTitle() throws Exception {
         Swagger swagger = new Swagger();
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/InlineModelResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/InlineModelResolverTest.java
@@ -1,0 +1,999 @@
+package io.swagger.parser.v3.util;
+
+import io.swagger.oas.models.Components;
+import io.swagger.oas.models.OpenAPI;
+import io.swagger.oas.models.media.ObjectSchema;
+import io.swagger.oas.models.media.Schema;
+import io.swagger.oas.models.media.StringSchema;
+import io.swagger.util.Json;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.AssertJUnit.*;
+
+@SuppressWarnings("static-method")
+public class InlineModelResolverTest {
+    @Test
+    public void resolveInlineModelTestWithoutTitle() throws Exception {
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.setComponents(new Components());
+
+
+        Schema objectSchema = new ObjectSchema();
+        objectSchema.setDefault("default");
+        objectSchema.setReadOnly(false);
+        objectSchema.setDescription("description");
+        objectSchema.setName("name");
+        objectSchema.addProperties("street", new StringSchema());
+        objectSchema.addProperties("city", new StringSchema());
+
+        Schema schema =  new Schema();
+        schema.setName("user");
+        schema.setDescription("a common user");
+        List<String> required = new ArrayList<>();
+        required.add("address");
+        schema.setRequired(required);
+        schema.addProperties("name", new StringSchema());
+        schema.addProperties("address", objectSchema);
+
+
+        openAPI.getComponents().addSchemas("User", schema);
+
+        new InlineModelResolver().flatten(openAPI);
+
+        Schema user = openAPI.getComponents().getSchemas().get("User");
+
+        assertNotNull(user);
+        Schema address = (Schema)user.getProperties().get("address");
+        assertTrue((address.get$ref()!= null));
+
+        Schema userAddress = openAPI.getComponents().getSchemas().get("User_address");
+        assertNotNull(userAddress);
+        assertNotNull(userAddress.getProperties().get("city"));
+        assertNotNull(userAddress.getProperties().get("street"));
+    }
+
+    @Test
+    public void resolveInlineModelTestWithTitle() throws Exception {
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.setComponents(new Components());
+
+
+        Schema objectSchema = new ObjectSchema();
+        objectSchema.setTitle("UserAddressTitle");
+        objectSchema.setDefault("default");
+        objectSchema.setReadOnly(false);
+        objectSchema.setDescription("description");
+        objectSchema.setName("name");
+        objectSchema.addProperties("street", new StringSchema());
+        objectSchema.addProperties("city", new StringSchema());
+
+        Schema schema =  new Schema();
+        schema.setName("user");
+        schema.setDescription("a common user");
+        List<String> required = new ArrayList<>();
+        required.add("address");
+        schema.setRequired(required);
+        schema.addProperties("name", new StringSchema());
+        schema.addProperties("address", objectSchema);
+
+
+        openAPI.getComponents().addSchemas("User", schema);
+
+        new InlineModelResolver().flatten(openAPI);
+
+        Schema user = openAPI.getComponents().getSchemas().get("User");
+
+        assertNotNull(user);
+        Schema address = (Schema)user.getProperties().get("address");
+        assertTrue( address.get$ref() != null);
+
+        Schema userAddressTitle = openAPI.getComponents().getSchemas().get("UserAddressTitle");
+        assertNotNull(userAddressTitle);
+        assertNotNull(userAddressTitle.getProperties().get("city"));
+        assertNotNull(userAddressTitle.getProperties().get("street"));
+    }
+
+    @Test
+    public void resolveInlineModel2EqualInnerModels() throws Exception {
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.setComponents(new Components());
+
+
+        Schema objectSchema = new ObjectSchema();
+        objectSchema.setTitle("UserAddressTitle");
+        objectSchema.setDefault("default");
+        objectSchema.setReadOnly(false);
+        objectSchema.setDescription("description");
+        objectSchema.setName("name");
+        objectSchema.addProperties("street", new StringSchema());
+        objectSchema.addProperties("city", new StringSchema());
+
+        Schema schema =  new Schema();
+        schema.setName("user");
+        schema.setDescription("a common user");
+        List<String> required = new ArrayList<>();
+        required.add("address");
+        schema.setRequired(required);
+        schema.addProperties("name", new StringSchema());
+        schema.addProperties("address", objectSchema);
+
+
+        openAPI.getComponents().addSchemas("User", schema);
+
+        Schema addressSchema = new ObjectSchema();
+        addressSchema.setTitle("UserAddressTitle");
+        addressSchema.setDefault("default");
+        addressSchema.setReadOnly(false);
+        addressSchema.setDescription("description");
+        addressSchema.setName("name");
+        addressSchema.addProperties("street", new StringSchema());
+        addressSchema.addProperties("city", new StringSchema());
+
+        Schema anotherSchema =  new Schema();
+        anotherSchema.setName("user");
+        anotherSchema.setDescription("a common user");
+        List<String> requiredFields = new ArrayList<>();
+        requiredFields.add("address");
+        anotherSchema.setRequired(requiredFields);
+        anotherSchema.addProperties("name", new StringSchema());
+        anotherSchema.addProperties("lastName", new StringSchema());
+        anotherSchema.addProperties("address", addressSchema);
+
+        openAPI.getComponents().addSchemas("AnotherUser", anotherSchema);
+
+        new InlineModelResolver().flatten(openAPI);
+
+        Schema user = openAPI.getComponents().getSchemas().get("User");
+
+        assertNotNull(user);
+        Schema addressSchema1 = (Schema) user.getProperties().get("address");
+        assertTrue(addressSchema1.get$ref() != null);
+
+        Schema address = openAPI.getComponents().getSchemas().get("UserAddressTitle");
+        assertNotNull(address);
+        assertNotNull(address.getProperties().get("city"));
+        assertNotNull(address.getProperties().get("street"));
+        Schema duplicateAddress = openAPI.getComponents().getSchemas().get("UserAddressTitle_0");
+        assertNull(duplicateAddress);
+    }
+
+    @Test
+    public void resolveInlineModel2DifferentInnerModelsWIthSameTitle() throws Exception {
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.setComponents(new Components());
+
+        Schema objectSchema = new ObjectSchema();
+        objectSchema.setTitle("UserAddressTitle");
+        objectSchema.setDefault("default");
+        objectSchema.setReadOnly(false);
+        objectSchema.setDescription("description");
+        objectSchema.setName("name");
+        objectSchema.addProperties("street", new StringSchema());
+        objectSchema.addProperties("city", new StringSchema());
+
+        Schema schema =  new Schema();
+        schema.setName("user");
+        schema.setDescription("a common user");
+        List<String> required = new ArrayList<>();
+        required.add("address");
+        schema.setRequired(required);
+        schema.addProperties("name", new StringSchema());
+        schema.addProperties("address", objectSchema);
+
+
+        openAPI.getComponents().addSchemas("User", schema);
+
+        Schema addressSchema = new ObjectSchema();
+        addressSchema.setTitle("UserAddressTitle");
+        addressSchema.setDefault("default");
+        addressSchema.setReadOnly(false);
+        addressSchema.setDescription("description");
+        addressSchema.setName("name");
+        addressSchema.addProperties("street", new StringSchema());
+        addressSchema.addProperties("city", new StringSchema());
+
+
+        Schema anotherSchema =  new Schema();
+        anotherSchema.setName("AnotherUser");
+        anotherSchema.setDescription("a common user");
+        List<String> requiredFields = new ArrayList<>();
+        requiredFields.add("address");
+        anotherSchema.setRequired(requiredFields);
+        anotherSchema.addProperties("name", new StringSchema());
+        anotherSchema.addProperties("lastName", new StringSchema());
+        anotherSchema.addProperties("address", addressSchema);
+        anotherSchema.addProperties("apartment", new StringSchema());
+
+        openAPI.getComponents().addSchemas("AnotherUser", anotherSchema);
+
+        new InlineModelResolver().flatten(openAPI);
+
+        Schema user = openAPI.getComponents().getSchemas().get("User");
+
+        assertNotNull(user);
+        Schema userAddress = (Schema) user.getProperties().get("address");
+        assertTrue( userAddress.get$ref()!= null);
+        System.out.println(Json.pretty(openAPI));
+        Schema address = openAPI.getComponents().getSchemas().get("UserAddressTitle");
+        assertNotNull(address);
+        assertNotNull(address.getProperties().get("city"));
+        assertNotNull(address.getProperties().get("street"));
+        Schema duplicateAddress = openAPI.getComponents().getSchemas().get("UserAddressTitle_1");
+        assertNotNull(duplicateAddress);
+        assertNotNull(duplicateAddress.getProperties().get("city"));
+        assertNotNull(duplicateAddress.getProperties().get("street"));
+        assertNotNull(duplicateAddress.getProperties().get("apartment"));
+    }
+
+
+    /*@Test
+    public void testInlineResponseModel() throws Exception {
+        Swagger swagger = new Swagger();
+
+        swagger.path("/foo/bar", new Path()
+                .get(new Operation()
+                        .response(200, new Response()
+                                .description("it works!")
+                                .schema(new ObjectProperty()
+                                        .property("name", new StringProperty()).vendorExtension("x-ext", "ext-prop")))))
+                .path("/foo/baz", new Path()
+                        .get(new Operation()
+                                .response(200, new Response()
+                                        .vendorExtension("x-foo", "bar")
+                                        .description("it works!")
+                                        .schema(new ObjectProperty()
+                                                .property("name", new StringProperty()).vendorExtension("x-ext", "ext-prop")))));
+        new InlineModelResolver().flatten(swagger);
+
+        Map<String, Response> responses = swagger.getPaths().get("/foo/bar").getGet().getResponses();
+
+        Response response = responses.get("200");
+        assertNotNull(response);
+        Property schema = response.getSchema();
+        assertTrue(schema instanceof RefProperty);
+        assertEquals(1, schema.getVendorExtensions().size());
+        assertEquals("ext-prop", schema.getVendorExtensions().get("x-ext"));
+
+        ModelImpl model = (ModelImpl)swagger.getDefinitions().get("inline_response_200");
+        assertTrue(model.getProperties().size() == 1);
+        assertNotNull(model.getProperties().get("name"));
+        assertTrue(model.getProperties().get("name") instanceof StringProperty);
+    }
+
+
+    @Test
+    public void testInlineResponseModelWithTitle() throws Exception {
+        Swagger swagger = new Swagger();
+
+        String responseTitle = "GetBarResponse";
+        swagger.path("/foo/bar", new Path()
+                .get(new Operation()
+                        .response(200, new Response()
+                                .description("it works!")
+                                .schema(new ObjectProperty().title(responseTitle)
+                                        .property("name", new StringProperty())))))
+                .path("/foo/baz", new Path()
+                        .get(new Operation()
+                                .response(200, new Response()
+                                        .vendorExtension("x-foo", "bar")
+                                        .description("it works!")
+                                        .schema(new ObjectProperty()
+                                                .property("name", new StringProperty())))));
+        new InlineModelResolver().flatten(swagger);
+
+        Map<String, Response> responses = swagger.getPaths().get("/foo/bar").getGet().getResponses();
+
+        Response response = responses.get("200");
+        assertNotNull(response);
+        assertTrue(response.getSchema() instanceof RefProperty);
+
+        ModelImpl model = (ModelImpl)swagger.getDefinitions().get(responseTitle);
+        assertTrue(model.getProperties().size() == 1);
+        assertNotNull(model.getProperties().get("name"));
+        assertTrue(model.getProperties().get("name") instanceof StringProperty);
+    }
+
+
+    @Test
+    public void resolveInlineArrayModelWithTitle() throws Exception {
+        Swagger swagger = new Swagger();
+
+        swagger.addDefinition("User", new ArrayModel()
+                .items(new ObjectProperty()
+                        .title("InnerUserTitle")
+                        ._default("default")
+                        .access("access")
+                        .readOnly(false)
+                        .required(true)
+                        .description("description")
+                        .name("name")
+                        .property("street", new StringProperty())
+                        .property("city", new StringProperty())));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Model model = swagger.getDefinitions().get("User");
+        assertTrue(model instanceof ArrayModel);
+
+        Model user = swagger.getDefinitions().get("InnerUserTitle");
+        assertNotNull(user);
+        assertEquals("description", user.getDescription());
+    }
+
+    @Test
+    public void resolveInlineArrayModelWithoutTitle() throws Exception {
+        Swagger swagger = new Swagger();
+
+        swagger.addDefinition("User", new ArrayModel()
+                .items(new ObjectProperty()
+                        ._default("default")
+                        .access("access")
+                        .readOnly(false)
+                        .required(true)
+                        .description("description")
+                        .name("name")
+                        .property("street", new StringProperty())
+                        .property("city", new StringProperty())));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Model model = swagger.getDefinitions().get("User");
+        assertTrue(model instanceof ArrayModel);
+
+        Model user = swagger.getDefinitions().get("User_inner");
+        assertNotNull(user);
+        assertEquals("description", user.getDescription());
+    }
+
+
+
+
+    @Test
+    public void resolveInlineBodyParameter() throws Exception {
+        Swagger swagger = new Swagger();
+
+        swagger.path("/hello", new Path()
+                .get(new Operation()
+                        .parameter(new BodyParameter()
+                                .name("body")
+                                .schema(new ModelImpl()
+                                        .property("address", new ObjectProperty()
+                                                .property("street", new StringProperty()))
+                                        .property("name", new StringProperty())))));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Operation operation = swagger.getPaths().get("/hello").getGet();
+        BodyParameter bp = (BodyParameter)operation.getParameters().get(0);
+        assertTrue(bp.getSchema() instanceof RefModel);
+
+        Model body = swagger.getDefinitions().get("body");
+        assertTrue(body instanceof ModelImpl);
+
+        ModelImpl impl = (ModelImpl) body;
+        assertNotNull(impl.getProperties().get("address"));
+    }
+
+    @Test
+    public void resolveInlineBodyParameterWithTitle() throws Exception {
+        Swagger swagger = new Swagger();
+
+        ModelImpl addressModelItem = new ModelImpl();
+        String addressModelName = "DetailedAddress";
+        addressModelItem.setTitle(addressModelName);
+        swagger.path("/hello", new Path()
+                .get(new Operation()
+                        .parameter(new BodyParameter()
+                                .name("body")
+                                .schema(addressModelItem
+                                        .property("address", new ObjectProperty()
+                                                .property("street", new StringProperty()))
+                                        .property("name", new StringProperty())))));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Operation operation = swagger.getPaths().get("/hello").getGet();
+        BodyParameter bp = (BodyParameter)operation.getParameters().get(0);
+        assertTrue(bp.getSchema() instanceof RefModel);
+
+        Model body = swagger.getDefinitions().get(addressModelName);
+        assertTrue(body instanceof ModelImpl);
+
+        ModelImpl impl = (ModelImpl) body;
+        assertNotNull(impl.getProperties().get("address"));
+    }
+
+    @Test
+    public void notResolveNonModelBodyParameter() throws Exception {
+        Swagger swagger = new Swagger();
+
+        swagger.path("/hello", new Path()
+                .get(new Operation()
+                        .parameter(new BodyParameter()
+                                .name("body")
+                                .schema(new ModelImpl()
+                                        .type("string")
+                                        .format("binary")))));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Operation operation = swagger.getPaths().get("/hello").getGet();
+        BodyParameter bp = (BodyParameter)operation.getParameters().get(0);
+        assertTrue(bp.getSchema() instanceof ModelImpl);
+        ModelImpl m = (ModelImpl) bp.getSchema();
+        assertEquals("string", m.getType());
+        assertEquals("binary", m.getFormat());
+    }
+
+    @Test
+    public void resolveInlineArrayBodyParameter() throws Exception {
+        Swagger swagger = new Swagger();
+
+        swagger.path("/hello", new Path()
+                .get(new Operation()
+                        .parameter(new BodyParameter()
+                                .name("body")
+                                .schema(new ArrayModel()
+                                        .items(new ObjectProperty()
+                                                .property("address", new ObjectProperty()
+                                                        .property("street", new StringProperty())))))));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Parameter param = swagger.getPaths().get("/hello").getGet().getParameters().get(0);
+        assertTrue(param instanceof BodyParameter);
+
+        BodyParameter bp = (BodyParameter) param;
+        Model schema = bp.getSchema();
+
+        assertTrue(schema instanceof ArrayModel);
+
+        ArrayModel am = (ArrayModel) schema;
+        Property inner = am.getItems();
+        assertTrue(inner instanceof RefProperty);
+
+        RefProperty rp = (RefProperty) inner;
+
+        assertEquals(rp.getType(), "ref");
+        assertEquals(rp.get$ref(), "#/definitions/body");
+        assertEquals(rp.getSimpleRef(), "body");
+
+        Model inline = swagger.getDefinitions().get("body");
+        assertNotNull(inline);
+        assertTrue(inline instanceof ModelImpl);
+        ModelImpl impl = (ModelImpl) inline;
+        RefProperty rpAddress = (RefProperty) impl.getProperties().get("address");
+        assertNotNull(rpAddress);
+        assertEquals(rpAddress.getType(), "ref");
+        assertEquals(rpAddress.get$ref(), "#/definitions/hello_address");
+        assertEquals(rpAddress.getSimpleRef(), "hello_address");
+
+        Model inlineProp = swagger.getDefinitions().get("hello_address");
+        assertNotNull(inlineProp);
+        assertTrue(inlineProp instanceof ModelImpl);
+        ModelImpl implProp = (ModelImpl) inlineProp;
+        assertNotNull(implProp.getProperties().get("street"));
+        assertTrue(implProp.getProperties().get("street") instanceof StringProperty);
+    }
+
+    @Test
+    public void resolveInlineArrayResponse() throws Exception {
+        Swagger swagger = new Swagger();
+
+        ArrayProperty schema = new ArrayProperty()
+                .items(new ObjectProperty()
+                        .property("name", new StringProperty())
+                        .vendorExtension("x-ext", "ext-items"))
+                .vendorExtension("x-ext", "ext-prop");
+        swagger.path("/foo/baz", new Path()
+                .get(new Operation()
+                        .response(200, new Response()
+                                .vendorExtension("x-foo", "bar")
+                                .description("it works!")
+                                .schema(schema))));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Response response = swagger.getPaths().get("/foo/baz").getGet().getResponses().get("200");
+        assertNotNull(response);
+
+        assertNotNull(response.getSchema());
+        Property responseProperty = response.getSchema();
+
+        // no need to flatten more
+        assertTrue(responseProperty instanceof ArrayProperty);
+
+        ArrayProperty ap = (ArrayProperty) responseProperty;
+        assertEquals(1, ap.getVendorExtensions().size());
+        assertEquals("ext-prop", ap.getVendorExtensions().get("x-ext"));
+
+        Property p = ap.getItems();
+
+        assertNotNull(p);
+
+        RefProperty rp = (RefProperty) p;
+        assertEquals(rp.getType(), "ref");
+        assertEquals(rp.get$ref(), "#/definitions/inline_response_200");
+        assertEquals(rp.getSimpleRef(), "inline_response_200");
+        assertEquals(1, rp.getVendorExtensions().size());
+        assertEquals("ext-items", rp.getVendorExtensions().get("x-ext"));
+
+        Model inline = swagger.getDefinitions().get("inline_response_200");
+        assertNotNull(inline);
+        assertTrue(inline instanceof ModelImpl);
+        ModelImpl impl = (ModelImpl) inline;
+        assertNotNull(impl.getProperties().get("name"));
+        assertTrue(impl.getProperties().get("name") instanceof StringProperty);
+    }
+
+    @Test
+    public void resolveInlineArrayResponseWithTitle() throws Exception {
+        Swagger swagger = new Swagger();
+
+        swagger.path("/foo/baz", new Path()
+                .get(new Operation()
+                        .response(200, new Response()
+                                .vendorExtension("x-foo", "bar")
+                                .description("it works!")
+                                .schema(new ArrayProperty()
+                                        .items(new ObjectProperty()
+                                                .title("FooBar")
+                                                .property("name", new StringProperty()))))));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Response response = swagger.getPaths().get("/foo/baz").getGet().getResponses().get("200");
+        assertNotNull(response);
+
+        assertNotNull(response.getSchema());
+        Property responseProperty = response.getSchema();
+
+        // no need to flatten more
+        assertTrue(responseProperty instanceof ArrayProperty);
+
+        ArrayProperty ap = (ArrayProperty) responseProperty;
+        Property p = ap.getItems();
+
+        assertNotNull(p);
+
+        RefProperty rp = (RefProperty) p;
+        assertEquals(rp.getType(), "ref");
+        assertEquals(rp.get$ref(), "#/definitions/"+ "FooBar");
+        assertEquals(rp.getSimpleRef(), "FooBar");
+
+        Model inline = swagger.getDefinitions().get("FooBar");
+        assertNotNull(inline);
+        assertTrue(inline instanceof ModelImpl);
+        ModelImpl impl = (ModelImpl) inline;
+        assertNotNull(impl.getProperties().get("name"));
+        assertTrue(impl.getProperties().get("name") instanceof StringProperty);
+    }
+
+    @Test
+    public void testInlineMapResponse() throws Exception {
+        Swagger swagger = new Swagger();
+
+        MapProperty schema = new MapProperty();
+        schema.setAdditionalProperties(new StringProperty());
+        schema.setVendorExtension("x-ext", "ext-prop");
+
+        swagger.path("/foo/baz", new Path()
+                .get(new Operation()
+                        .response(200, new Response()
+                                .vendorExtension("x-foo", "bar")
+                                .description("it works!")
+                                .schema(schema))));
+        new InlineModelResolver().flatten(swagger);
+        Json.prettyPrint(swagger);
+
+        Response response = swagger.getPaths().get("/foo/baz").getGet().getResponses().get("200");
+
+        Property property = response.getSchema();
+        assertTrue(property instanceof MapProperty);
+        assertTrue(swagger.getDefinitions().size() == 0);
+        assertEquals(1, property.getVendorExtensions().size());
+        assertEquals("ext-prop", property.getVendorExtensions().get("x-ext"));
+    }
+
+    @Test
+    public void testInlineMapResponseWithObjectProperty() throws Exception {
+        Swagger swagger = new Swagger();
+
+        MapProperty schema = new MapProperty();
+        schema.setAdditionalProperties(new ObjectProperty()
+                .property("name", new StringProperty()));
+        schema.setVendorExtension("x-ext", "ext-prop");
+
+        swagger.path("/foo/baz", new Path()
+                .get(new Operation()
+                        .response(200, new Response()
+                                .vendorExtension("x-foo", "bar")
+                                .description("it works!")
+                                .schema(schema))));
+        new InlineModelResolver().flatten(swagger);
+
+        Response response = swagger.getPaths().get("/foo/baz").getGet().getResponses().get("200");
+        Property property = response.getSchema();
+        assertTrue(property instanceof MapProperty);
+        assertEquals(1, property.getVendorExtensions().size());
+        assertEquals("ext-prop", property.getVendorExtensions().get("x-ext"));
+        assertTrue(swagger.getDefinitions().size() == 1);
+
+        Model inline = swagger.getDefinitions().get("inline_response_200");
+        assertTrue(inline instanceof ModelImpl);
+        ModelImpl impl = (ModelImpl) inline;
+        assertNotNull(impl.getProperties().get("name"));
+        assertTrue(impl.getProperties().get("name") instanceof StringProperty);
+    }
+
+    @Test
+    public void testArrayResponse() {
+        Swagger swagger = new Swagger();
+
+        ArrayProperty schema = new ArrayProperty();
+        schema.setItems(new ObjectProperty()
+                .property("name", new StringProperty()));
+
+        swagger.path("/foo/baz", new Path()
+                .get(new Operation()
+                        .response(200, new Response()
+                                .vendorExtension("x-foo", "bar")
+                                .description("it works!")
+                                .schema(schema))));
+        new InlineModelResolver().flatten(swagger);
+
+        Response response = swagger.getPaths().get("/foo/baz").getGet().getResponses().get("200");
+        assertTrue(response.getSchema() instanceof ArrayProperty);
+
+        ArrayProperty am = (ArrayProperty) response.getSchema();
+        Property items = am.getItems();
+        assertTrue(items instanceof RefProperty);
+        RefProperty rp = (RefProperty) items;
+        assertEquals(rp.getType(), "ref");
+        assertEquals(rp.get$ref(), "#/definitions/inline_response_200");
+        assertEquals(rp.getSimpleRef(), "inline_response_200");
+
+        Model inline = swagger.getDefinitions().get("inline_response_200");
+        assertTrue(inline instanceof ModelImpl);
+        ModelImpl impl = (ModelImpl) inline;
+        assertNotNull(impl.getProperties().get("name"));
+        assertTrue(impl.getProperties().get("name") instanceof StringProperty);
+    }
+
+    @Test
+    public void testBasicInput() {
+        Swagger swagger = new Swagger();
+
+        ModelImpl user = new ModelImpl()
+                .property("name", new StringProperty());
+
+        swagger.path("/foo/baz", new Path()
+                .post(new Operation()
+                        .parameter(new BodyParameter()
+                                .name("myBody")
+                                .schema(new RefModel("User")))));
+
+        swagger.addDefinition("User", user);
+
+        new InlineModelResolver().flatten(swagger);
+
+        Json.prettyPrint(swagger);
+    }
+
+    @Test
+    public void testArbitraryObjectBodyParam() {
+        Swagger swagger = new Swagger();
+
+        swagger.path("/hello", new Path()
+                .get(new Operation()
+                        .parameter(new BodyParameter()
+                                .name("body")
+                                .schema(new ModelImpl()))));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Operation operation = swagger.getPaths().get("/hello").getGet();
+        BodyParameter bp = (BodyParameter)operation.getParameters().get(0);
+        assertTrue(bp.getSchema() instanceof ModelImpl);
+        ModelImpl m = (ModelImpl) bp.getSchema();
+        assertNull(m.getType());
+    }
+
+    @Test
+    public void testArbitraryObjectBodyParamInline() {
+        Swagger swagger = new Swagger();
+
+        swagger.path("/hello", new Path()
+                .get(new Operation()
+                        .parameter(new BodyParameter()
+                                .name("body")
+                                .schema(new ModelImpl()
+                                        .property("arbitrary", new ObjectProperty())))));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Operation operation = swagger.getPaths().get("/hello").getGet();
+        BodyParameter bp = (BodyParameter)operation.getParameters().get(0);
+        assertTrue(bp.getSchema() instanceof RefModel);
+
+        Model body = swagger.getDefinitions().get("body");
+        assertTrue(body instanceof ModelImpl);
+
+        ModelImpl impl = (ModelImpl) body;
+        Property p = impl.getProperties().get("arbitrary");
+        assertNotNull(p);
+        assertTrue(p instanceof ObjectProperty);
+    }
+
+    @Test
+    public void testArbitraryObjectBodyParamWithArray() {
+        Swagger swagger = new Swagger();
+
+        swagger.path("/hello", new Path()
+                .get(new Operation()
+                        .parameter(new BodyParameter()
+                                .name("body")
+                                .schema(new ArrayModel()
+                                        .items(new ObjectProperty())))));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Parameter param = swagger.getPaths().get("/hello").getGet().getParameters().get(0);
+        assertTrue(param instanceof BodyParameter);
+
+        BodyParameter bp = (BodyParameter) param;
+        Model schema = bp.getSchema();
+
+        assertTrue(schema instanceof ArrayModel);
+
+        ArrayModel am = (ArrayModel) schema;
+        Property inner = am.getItems();
+        assertTrue(inner instanceof ObjectProperty);
+
+        ObjectProperty op = (ObjectProperty) inner;
+        assertNotNull(op);
+        assertNull(op.getProperties());
+    }
+
+    @Test
+    public void testArbitraryObjectBodyParamArrayInline() {
+        Swagger swagger = new Swagger();
+
+        swagger.path("/hello", new Path()
+                .get(new Operation()
+                        .parameter(new BodyParameter()
+                                .name("body")
+                                .schema(new ArrayModel()
+                                        .items(new ObjectProperty()
+                                                .property("arbitrary", new ObjectProperty()))))));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Parameter param = swagger.getPaths().get("/hello").getGet().getParameters().get(0);
+        assertTrue(param instanceof BodyParameter);
+
+        BodyParameter bp = (BodyParameter) param;
+        Model schema = bp.getSchema();
+
+        assertTrue(schema instanceof ArrayModel);
+
+        ArrayModel am = (ArrayModel) schema;
+        Property inner = am.getItems();
+        assertTrue(inner instanceof RefProperty);
+
+        RefProperty rp = (RefProperty) inner;
+
+        assertEquals(rp.getType(), "ref");
+        assertEquals(rp.get$ref(), "#/definitions/body");
+        assertEquals(rp.getSimpleRef(), "body");
+
+        Model inline = swagger.getDefinitions().get("body");
+        assertNotNull(inline);
+        assertTrue(inline instanceof ModelImpl);
+        ModelImpl impl = (ModelImpl) inline;
+        Property p = impl.getProperties().get("arbitrary");
+        assertNotNull(p);
+        assertTrue(p instanceof ObjectProperty);
+    }
+
+    @Test
+    public void testArbitraryObjectResponse() {
+        Swagger swagger = new Swagger();
+
+        swagger.path("/foo/bar", new Path()
+                .get(new Operation()
+                        .response(200, new Response()
+                                .description("it works!")
+                                .schema(new ObjectProperty()))));
+        new InlineModelResolver().flatten(swagger);
+
+        Map<String, Response> responses = swagger.getPaths().get("/foo/bar").getGet().getResponses();
+
+        Response response = responses.get("200");
+        assertNotNull(response);
+        assertTrue(response.getSchema() instanceof ObjectProperty);
+        ObjectProperty op = (ObjectProperty) response.getSchema();
+        assertNull(op.getProperties());
+    }
+
+    @Test
+    public void testArbitraryObjectResponseArray() {
+        Swagger swagger = new Swagger();
+
+        swagger.path("/foo/baz", new Path()
+                .get(new Operation()
+                        .response(200, new Response()
+                                .description("it works!")
+                                .schema(new ArrayProperty()
+                                        .items(new ObjectProperty())))));
+        new InlineModelResolver().flatten(swagger);
+
+        Response response = swagger.getPaths().get("/foo/baz").getGet().getResponses().get("200");
+        assertTrue(response.getSchema() instanceof ArrayProperty);
+
+        ArrayProperty am = (ArrayProperty) response.getSchema();
+        Property items = am.getItems();
+        assertTrue(items instanceof ObjectProperty);
+        ObjectProperty op = (ObjectProperty) items;
+        assertNull(op.getProperties());
+    }
+
+    @Test
+    public void testArbitraryObjectResponseArrayInline() {
+        Swagger swagger = new Swagger();
+
+        swagger.path("/foo/baz", new Path()
+                .get(new Operation()
+                        .response(200, new Response()
+                                .vendorExtension("x-foo", "bar")
+                                .description("it works!")
+                                .schema(new ArrayProperty()
+                                        .items(new ObjectProperty()
+                                                .property("arbitrary", new ObjectProperty()))))));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Response response = swagger.getPaths().get("/foo/baz").getGet().getResponses().get("200");
+        assertNotNull(response);
+
+        assertNotNull(response.getSchema());
+        Property responseProperty = response.getSchema();
+        assertTrue(responseProperty instanceof ArrayProperty);
+
+        ArrayProperty ap = (ArrayProperty) responseProperty;
+        Property p = ap.getItems();
+        assertNotNull(p);
+
+        RefProperty rp = (RefProperty) p;
+        assertEquals(rp.getType(), "ref");
+        assertEquals(rp.get$ref(), "#/definitions/inline_response_200");
+        assertEquals(rp.getSimpleRef(), "inline_response_200");
+
+        Model inline = swagger.getDefinitions().get("inline_response_200");
+        assertNotNull(inline);
+        assertTrue(inline instanceof ModelImpl);
+        ModelImpl impl = (ModelImpl) inline;
+        Property inlineProp = impl.getProperties().get("arbitrary");
+        assertNotNull(inlineProp);
+        assertTrue(inlineProp instanceof ObjectProperty);
+        ObjectProperty op = (ObjectProperty) inlineProp;
+        assertNull(op.getProperties());
+    }
+
+    @Test
+    public void testArbitraryObjectResponseMapInline() {
+        Swagger swagger = new Swagger();
+
+        MapProperty schema = new MapProperty();
+        schema.setAdditionalProperties(new ObjectProperty());
+
+        swagger.path("/foo/baz", new Path()
+                .get(new Operation()
+                        .response(200, new Response()
+                                .description("it works!")
+                                .schema(schema))));
+        new InlineModelResolver().flatten(swagger);
+
+        Response response = swagger.getPaths().get("/foo/baz").getGet().getResponses().get("200");
+
+        Property property = response.getSchema();
+        assertTrue(property instanceof MapProperty);
+        assertTrue(swagger.getDefinitions().size() == 0);
+        Property inlineProp = ((MapProperty) property).getAdditionalProperties();
+        assertTrue(inlineProp instanceof ObjectProperty);
+        ObjectProperty op = (ObjectProperty) inlineProp;
+        assertNull(op.getProperties());
+    }
+
+    @Test
+    public void testArbitraryObjectModelInline() {
+        Swagger swagger = new Swagger();
+
+        swagger.addDefinition("User", new ModelImpl()
+                .name("user")
+                .description("a common user")
+                .property("name", new StringProperty())
+                .property("arbitrary", new ObjectProperty()
+                        .title("title")
+                        ._default("default")
+                        .access("access")
+                        .readOnly(false)
+                        .required(true)
+                        .description("description")
+                        .name("name")));
+
+        new InlineModelResolver().flatten(swagger);
+
+        ModelImpl user = (ModelImpl)swagger.getDefinitions().get("User");
+        assertNotNull(user);
+        Property inlineProp = user.getProperties().get("arbitrary");
+        assertTrue(inlineProp instanceof ObjectProperty);
+        ObjectProperty op = (ObjectProperty) inlineProp;
+        assertNull(op.getProperties());
+    }
+
+    @Test
+    public void testArbitraryObjectModelWithArrayInlineWithoutTitle() {
+        Swagger swagger = new Swagger();
+
+        swagger.addDefinition("User", new ArrayModel()
+                .items(new ObjectProperty()
+                        ._default("default")
+                        .access("access")
+                        .readOnly(false)
+                        .required(true)
+                        .description("description")
+                        .name("name")
+                        .property("arbitrary", new ObjectProperty())));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Model model = swagger.getDefinitions().get("User");
+        assertTrue(model instanceof ArrayModel);
+        ArrayModel am = (ArrayModel) model;
+        Property inner = am.getItems();
+        assertTrue(inner instanceof RefProperty);
+
+        ModelImpl userInner = (ModelImpl)swagger.getDefinitions().get("User_inner");
+        assertNotNull(userInner);
+        Property inlineProp = userInner.getProperties().get("arbitrary");
+        assertTrue(inlineProp instanceof ObjectProperty);
+        ObjectProperty op = (ObjectProperty) inlineProp;
+        assertNull(op.getProperties());
+    }
+
+    @Test
+    public void testArbitraryObjectModelWithArrayInlineWithTitle() {
+        Swagger swagger = new Swagger();
+
+        swagger.addDefinition("User", new ArrayModel()
+                .items(new ObjectProperty()
+                        .title("InnerUserTitle")
+                        ._default("default")
+                        .access("access")
+                        .readOnly(false)
+                        .required(true)
+                        .description("description")
+                        .name("name")
+                        .property("arbitrary", new ObjectProperty())));
+
+        new InlineModelResolver().flatten(swagger);
+
+        Model model = swagger.getDefinitions().get("User");
+        assertTrue(model instanceof ArrayModel);
+        ArrayModel am = (ArrayModel) model;
+        Property inner = am.getItems();
+        assertTrue(inner instanceof RefProperty);
+
+        ModelImpl userInner = (ModelImpl)swagger.getDefinitions().get("InnerUserTitle");
+        assertNotNull(userInner);
+        Property inlineProp = userInner.getProperties().get("arbitrary");
+        assertTrue(inlineProp instanceof ObjectProperty);
+        ObjectProperty op = (ObjectProperty) inlineProp;
+        assertNull(op.getProperties());
+    }*/
+}

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/InlineModelResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/InlineModelResolverTest.java
@@ -469,7 +469,7 @@ public class InlineModelResolverTest {
 
 
     @Test
-    public void resolveInlineBodyParameter() throws Exception {
+    public void resolveInlineRequestBody() throws Exception {
         OpenAPI openAPI = new OpenAPI();
 
 
@@ -508,36 +508,37 @@ public class InlineModelResolverTest {
         assertNotNull(bodySchema.getProperties().get("address"));
     }
 
-   /* @Test
+   @Test
     public void resolveInlineBodyParameterWithTitle() throws Exception {
-        Swagger swagger = new Swagger();
+        OpenAPI openAPI = new OpenAPI();
 
-        ModelImpl addressModelItem = new ModelImpl();
+        ObjectSchema objectSchema = new ObjectSchema();
+        objectSchema.addProperties("street", new StringSchema());
+        objectSchema.addProperties("name", new StringSchema());
+        Schema addressModelItem = new Schema();
         String addressModelName = "DetailedAddress";
         addressModelItem.setTitle(addressModelName);
-        swagger.path("/hello", new Path()
+        addressModelItem.addProperties("address", objectSchema);
+
+        openAPI.path("/hello", new PathItem()
                 .get(new Operation()
-                        .parameter(new BodyParameter()
-                                .name("body")
-                                .schema(addressModelItem
-                                        .property("address", new ObjectProperty()
-                                                .property("street", new StringProperty()))
-                                        .property("name", new StringProperty())))));
+                        .requestBody(new RequestBody()
+                                .content(new Content().addMediaType("*/*", new MediaType()
+                                .schema(addressModelItem))))));
 
-        new InlineModelResolver().flatten(swagger);
+        new InlineModelResolver().flatten(openAPI);
 
-        Operation operation = swagger.getPaths().get("/hello").getGet();
-        BodyParameter bp = (BodyParameter)operation.getParameters().get(0);
-        assertTrue(bp.getSchema() instanceof RefModel);
+        Operation operation = openAPI.getPaths().get("/hello").getGet();
+        RequestBody bp = operation.getRequestBody();
+        assertTrue(bp.getContent().get("*/*").getSchema().get$ref() != null);
 
-        Model body = swagger.getDefinitions().get(addressModelName);
-        assertTrue(body instanceof ModelImpl);
+        Schema body = openAPI.getComponents().getSchemas().get(addressModelName);
+        assertTrue(body instanceof Schema);
 
-        ModelImpl impl = (ModelImpl) body;
-        assertNotNull(impl.getProperties().get("address"));
+        assertNotNull(body.getProperties().get("address"));
     }
 
-    @Test
+    /*@Test
     public void notResolveNonModelBodyParameter() throws Exception {
         Swagger swagger = new Swagger();
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/InlineModelResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/InlineModelResolverTest.java
@@ -12,6 +12,7 @@ import io.swagger.oas.models.media.MediaType;
 import io.swagger.oas.models.media.ObjectSchema;
 import io.swagger.oas.models.media.Schema;
 import io.swagger.oas.models.media.StringSchema;
+import io.swagger.oas.models.parameters.Parameter;
 import io.swagger.oas.models.parameters.RequestBody;
 import io.swagger.oas.models.responses.ApiResponse;
 import io.swagger.oas.models.responses.ApiResponses;
@@ -506,6 +507,47 @@ public class InlineModelResolverTest {
         assertTrue(body.getContent().get("*/*").getSchema().get$ref() != null);
 
         Schema bodySchema = openAPI.getComponents().getSchemas().get("body");
+        assertTrue(bodySchema instanceof Schema);
+
+        assertNotNull(bodySchema.getProperties().get("address"));
+    }
+
+    @Test
+    public void resolveInlineParameter() throws Exception {
+        OpenAPI openAPI = new OpenAPI();
+
+
+        ObjectSchema objectSchema = new ObjectSchema();
+        objectSchema.addProperties("street", new StringSchema());
+
+        Schema schema = new Schema();
+        schema.addProperties("address", objectSchema);
+        schema.addProperties("name", new StringSchema());
+
+        Parameter parameter = new Parameter();
+        parameter.setName("name");
+        parameter.setSchema(schema);
+
+        List parameters = new ArrayList();
+        parameters.add(parameter);
+
+
+        Operation operation = new Operation();
+        operation.setParameters(parameters);
+
+        PathItem pathItem = new PathItem();
+        pathItem.setGet(operation);
+        openAPI.path("/hello",pathItem);
+
+        new InlineModelResolver().flatten(openAPI);
+
+        Operation getOperation = openAPI.getPaths().get("/hello").getGet();
+        Parameter param = getOperation.getParameters().get(0);
+        assertTrue(param.getSchema().get$ref() != null);
+
+
+
+        Schema bodySchema = openAPI.getComponents().getSchemas().get("name");
         assertTrue(bodySchema instanceof Schema);
 
         assertNotNull(bodySchema.getProperties().get("address"));

--- a/modules/swagger-parser-v3/src/test/resources/flatten.json
+++ b/modules/swagger-parser-v3/src/test/resources/flatten.json
@@ -1,0 +1,30 @@
+{
+  "openapi" : "3.0.0",
+  "components" : {
+    "schemas" : {
+      "User" : {
+        "required" : [ "address" ],
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "address" : {
+            "type" : "object",
+            "properties" : {
+              "street" : {
+                "type" : "string"
+              },
+              "city" : {
+                "type" : "string"
+              }
+            },
+            "description" : "description",
+            "readOnly" : false,
+            "default" : "default"
+          }
+        },
+        "description" : "a common user"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR contains:
New option in the parser: flatten.
It flattens the schemas in every object of an operation.
