### PR TITLE
Property description is lost when property uses ref schema

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/parser/v3/util/OpenAPIDeserializer.java
@@ -1823,6 +1823,12 @@ public class OpenAPIDeserializer {
             schema = SchemaTypeUtil.createSchemaByType(node);
         }
 
+        // Set description for inline or ref schemas
+        String value = getString("description",node,false,location,result);
+        if (StringUtils.isNotBlank(value)) {
+            schema.setDescription(value);
+        }
+
         JsonNode ref = node.get("$ref");
         if (ref != null) {
             if (ref.getNodeType().equals(JsonNodeType.STRING)) {
@@ -1835,7 +1841,7 @@ public class OpenAPIDeserializer {
         }
 
 
-        String value = getString("title",node,false,location,result);
+        value = getString("title",node,false,location,result);
         if (StringUtils.isNotBlank(value)) {
             schema.setTitle(value);
         }
@@ -1983,10 +1989,6 @@ public class OpenAPIDeserializer {
             if(additionalProperties != null) {
                 schema.setAdditionalProperties(additionalProperties);
             }
-        }
-        value = getString("description",node,false,location,result);
-        if (StringUtils.isNotBlank(value)) {
-            schema.setDescription(value);
         }
 
         value = getString("format", node, false, location, result);

--- a/modules/swagger-parser-v3/src/test/resources/oas3.yaml.template
+++ b/modules/swagger-parser-v3/src/test/resources/oas3.yaml.template
@@ -925,6 +925,7 @@ components:
         user:
           type: string
           example: doggie
+          description: This is the owner of the pet
           "$ref": "http://localhost:${dynamicPort}/remote/schema#/components/schemas/User"
         photoUrls:
           type: array


### PR DESCRIPTION
Noticed that properties with inline schema keep their description just fine but it was not working for properties with a ref schema.