### PR TITLE
Resolve fully examples

### DIFF
--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/test/OpenAPIV3ParserTest.java
@@ -4,8 +4,11 @@ package io.swagger.parser.test;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.swagger.oas.models.Components;
 import io.swagger.oas.models.OpenAPI;
+import io.swagger.oas.models.Operation;
 import io.swagger.oas.models.media.Schema;
+import io.swagger.oas.models.responses.ApiResponse;
 import io.swagger.parser.models.AuthorizationValue;
 import io.swagger.parser.models.ParseOptions;
 import io.swagger.parser.models.SwaggerParseResult;
@@ -187,6 +190,26 @@ public class OpenAPIV3ParserTest {
         Assert.assertNotNull(result.getOpenAPI());
         Assert.assertEquals(result.getOpenAPI().getOpenapi(), "3.0.0");
         Assert.assertEquals(result.getOpenAPI().getComponents().getSchemas().get("OrderRef").getType(),"object");
+    }
+
+    @Test
+    public void testResolveFullyExample(@Injectable final List<AuthorizationValue> auths) throws Exception{
+
+
+        String pathFile = FileUtils.readFileToString(new File("src/test/resources/oas3.yaml.template"));
+        pathFile = pathFile.replace("${dynamicPort}", String.valueOf(this.serverPort));
+        ParseOptions options = new ParseOptions();
+        //options.setResolve(true);
+        options.setResolveFully(true);
+
+        SwaggerParseResult result = new OpenAPIV3Parser().readContents(pathFile, auths, options  );
+
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getOpenAPI());
+        Components components = result.getOpenAPI().getComponents();
+        ApiResponse response = result.getOpenAPI().getPaths().get("/mockResponses/objectMultipleExamples").getGet().getResponses().get("200");
+        Assert.assertEquals(response.getContent().get("application/json").getExamples().get("ArthurDent"), components.getExamples().get("Arthur"));
+        Assert.assertEquals(response.getContent().get("application/xml").getExamples().get("Trillian"), components.getExamples().get("Trillian"));
     }
 
     @Test

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/InlineModelResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/InlineModelResolverTest.java
@@ -63,7 +63,6 @@ public class InlineModelResolverTest {
         assertNotNull(user);
         Schema address = (Schema)user.getProperties().get("address");
         assertTrue((address.get$ref()!= null));
-
         Schema userAddress = openAPI.getComponents().getSchemas().get("User_address");
         assertNotNull(userAddress);
         assertNotNull(userAddress.getProperties().get("city"));

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/OpenAPIDeserializerTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/parser/v3/util/OpenAPIDeserializerTest.java
@@ -891,7 +891,7 @@ public class OpenAPIDeserializerTest {
 
         final Paths paths = openAPI.getPaths();
         Assert.assertNotNull(paths);
-        Assert.assertEquals(paths.size(), 17);
+        Assert.assertEquals(paths.size(), 18);
 
         //parameters operation get
         PathItem petByStatusEndpoint = paths.get("/pet/findByStatus");
@@ -915,7 +915,7 @@ public class OpenAPIDeserializerTest {
 
         final Paths paths = openAPI.getPaths();
         Assert.assertNotNull(paths);
-        Assert.assertEquals(paths.size(), 17);
+        Assert.assertEquals(paths.size(), 18);
 
         //parameters operation get
         PathItem petByStatusEndpoint = paths.get("/pet/findByStatus");
@@ -941,7 +941,7 @@ public class OpenAPIDeserializerTest {
 
         final Paths paths = openAPI.getPaths();
         Assert.assertNotNull(paths);
-        Assert.assertEquals(paths.size(), 17);
+        Assert.assertEquals(paths.size(), 18);
 
         //parameters operation get
         PathItem producesTestEndpoint = paths.get("/producesTest");
@@ -1009,7 +1009,7 @@ public class OpenAPIDeserializerTest {
 
         final Paths paths = openAPI.getPaths();
         Assert.assertNotNull(paths);
-        Assert.assertEquals(paths.size(), 17);
+        Assert.assertEquals(paths.size(), 18);
 
 
         PathItem petRef = paths.get("/pathItemRef");

--- a/modules/swagger-parser-v3/src/test/resources/oas3.yaml.template
+++ b/modules/swagger-parser-v3/src/test/resources/oas3.yaml.template
@@ -65,6 +65,36 @@ tags:
     description: Find out more about our store
     url: http://swagger.io
 paths:
+  "/mockResponses/objectMultipleExamples":
+    get:
+      responses:
+        '200':
+          description: A string
+          content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/User1'
+             examples:
+               ArthurDent:
+                  $ref: '#/components/examples/Arthur'
+               Trillian:
+                 $ref: '#/components/examples/Trillian'
+           application/yaml:
+             schema:
+               $ref: '#/components/schemas/User1'
+             examples:
+               ArthurDent:
+                 $ref: '#/components/examples/Arthur'
+               Trillian:
+                 $ref: '#/components/examples/Trillian'
+           application/xml:
+             schema:
+               $ref: '#/components/schemas/User1'
+             examples:
+               ArthurDent:
+                 $ref: '#/components/examples/Arthur'
+               Trillian:
+                 $ref: '#/components/examples/Trillian'
   "/pathItemRef":
     "$ref": 'http://localhost:${dynamicPort}/remote/path#/paths/~1pet'
   "/pathItemRef2":
@@ -901,6 +931,23 @@ components:
           description: User Status
       xml:
         name: User
+    User1:
+      type: object
+      xml:
+        name: USER
+      properties:
+        id:
+          type: integer
+          format: int32
+          example: 4
+          xml:
+            attribute: true
+            name: ID
+        name:
+          type: string
+          example: Arthur Dent
+          xml:
+            name: NAME
     Tag:
       type: object
       properties:
@@ -1029,6 +1076,14 @@ components:
         type: integer
         format: int32
   examples:
+    Trillian:
+      value:
+        id: 3
+        name: Tricia McMillan
+    Arthur:
+      value:
+        id: 4
+        name: Arthur Dent
     referenceCat:
       "$ref": "http://localhost:${dynamicPort}/remote/example"
     cat:


### PR DESCRIPTION
This PR solves the refs examples:
When the option ResolveFully is set to true, it will bring all the ref schemas and ref examples in components and will put them inline.
This is used in the inflector in order to mock the example responses when the controller is not implemented.
Solves #558 