### PR TITLE
NPE in ResolverFully when components is missing

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
@@ -32,14 +32,14 @@ public class ResolverFully {
 
 
     public void resolveFully(OpenAPI openAPI) {
-        if (openAPI.getComponents().getSchemas() != null) {
+        if (openAPI.getComponents() != null && openAPI.getComponents().getSchemas() != null) {
             schemas = openAPI.getComponents().getSchemas();
             if (schemas == null) {
                 schemas = new HashMap<>();
             }
         }
 
-        if (openAPI.getComponents().getExamples() != null) {
+        if (openAPI.getComponents() != null && openAPI.getComponents().getExamples() != null) {
             examples = openAPI.getComponents().getExamples();
             if (examples == null) {
                 examples = new HashMap<>();

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -192,6 +192,18 @@ public class OpenAPIV3ParserTest {
     }
 
     @Test
+    public void testResolveEmpty(@Injectable final List<AuthorizationValue> auths) throws Exception{
+        String pathFile = FileUtils.readFileToString(new File("src/test/resources/empty-oas.yaml"));
+        ParseOptions options = new ParseOptions();
+        options.setResolveFully(true);
+
+        SwaggerParseResult result = new OpenAPIV3Parser().readContents(pathFile, auths, options  );
+
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getOpenAPI());
+    }
+
+    @Test
     public void testResolveFullyExample(@Injectable final List<AuthorizationValue> auths) throws Exception{
 
 

--- a/modules/swagger-parser-v3/src/test/resources/empty-oas.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/empty-oas.yaml
@@ -1,0 +1,6 @@
+openapi: 3.0.0
+info:
+  version: '1.0.0'
+  title: 'Empty spec'
+  description: 'A spec without any content'
+paths: {}


### PR DESCRIPTION
A spec without components couldn't be resolved fully. Instead you got a NPE.