### PR TITLE
Added flag to avoid aggregation of anyOf/allOf/oneOf schemas while using resolveFully()

### DIFF
--- a/modules/swagger-parser-core/src/main/java/io/swagger/v3/parser/core/models/ParseOptions.java
+++ b/modules/swagger-parser-core/src/main/java/io/swagger/v3/parser/core/models/ParseOptions.java
@@ -2,6 +2,7 @@ package io.swagger.v3.parser.core.models;
 
 public class ParseOptions {
     private boolean resolve;
+    private boolean resolveCombinators = true;
     private boolean resolveFully;
     private boolean flatten;
 
@@ -11,6 +12,14 @@ public class ParseOptions {
 
     public void setResolve(boolean resolve) {
         this.resolve = resolve;
+    }
+
+    public boolean isResolveCombinators() {
+        return resolveCombinators;
+    }
+
+    public void setResolveCombinators(boolean resolveCombinators) {
+        this.resolveCombinators = resolveCombinators;
     }
 
     public boolean isResolveFully() {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIV3Parser.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIV3Parser.java
@@ -52,7 +52,7 @@ public class OpenAPIV3Parser implements SwaggerParserExtension {
                         }
                         if (options.isResolveFully()) {
                             result.setOpenAPI(resolver.resolve());
-                            new ResolverFully().resolveFully(result.getOpenAPI());
+                            new ResolverFully(options.isResolveCombinators()).resolveFully(result.getOpenAPI());
                         }else if (options.isFlatten()){
                             InlineModelResolver inlineResolver = new InlineModelResolver();
                             inlineResolver.flatten(result.getOpenAPI());
@@ -178,7 +178,7 @@ public class OpenAPIV3Parser implements SwaggerParserExtension {
                     }
                 }if (options.isResolveFully()){
                     result.setOpenAPI(new OpenAPIResolver(result.getOpenAPI(), auth, null).resolve());
-                    new ResolverFully().resolveFully(result.getOpenAPI());
+                    new ResolverFully(options.isResolveCombinators()).resolveFully(result.getOpenAPI());
 
                 }if (options.isFlatten()){
                     new InlineModelResolver().flatten(result.getOpenAPI());

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
@@ -540,9 +540,21 @@ public class OpenAPIResolverTest {
         options.setResolveFully(true);
         options.setResolveCombinators(false);
 
+        // Testing components/schemas
         OpenAPI openAPI = new OpenAPIV3Parser().readLocation("src/test/resources/composed.yaml",auths,options).getOpenAPI();
 
         ComposedSchema allOf = (ComposedSchema) openAPI.getComponents().getSchemas().get("ExtendedAddress");
+        assertEquals(allOf.getAllOf().size(), 2);
+
+        assertTrue(allOf.getAllOf().get(0).getProperties().containsKey("street"));
+        assertTrue(allOf.getAllOf().get(1).getProperties().containsKey("gps"));
+
+        // Testing path item
+        ComposedSchema schema = (ComposedSchema) openAPI.getPaths().get("/withInvalidComposedModel").getPost().getRequestBody().getContent().get("application/json").getSchema();
+
+        // In fact the schema resolved previously is the same of /withInvalidComposedModel
+        assertEquals(schema, allOf);
+
         assertEquals(allOf.getAllOf().size(), 2);
 
         assertTrue(allOf.getAllOf().get(0).getProperties().containsKey("street"));

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
@@ -555,10 +555,10 @@ public class OpenAPIResolverTest {
         // In fact the schema resolved previously is the same of /withInvalidComposedModel
         assertEquals(schema, allOf);
 
-        assertEquals(allOf.getAllOf().size(), 2);
+        assertEquals(schema.getAllOf().size(), 2);
 
-        assertTrue(allOf.getAllOf().get(0).getProperties().containsKey("street"));
-        assertTrue(allOf.getAllOf().get(1).getProperties().containsKey("gps"));
+        assertTrue(schema.getAllOf().get(0).getProperties().containsKey("street"));
+        assertTrue(schema.getAllOf().get(1).getProperties().containsKey("gps"));
 
     }
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
@@ -535,6 +535,22 @@ public class OpenAPIResolverTest {
     }
 
     @Test
+    public void resolveAllOfWithoutAggregatingParameters(@Injectable final List<AuthorizationValue> auths) {
+        ParseOptions options = new ParseOptions();
+        options.setResolveFully(true);
+        options.setResolveCombinators(false);
+
+        OpenAPI openAPI = new OpenAPIV3Parser().readLocation("src/test/resources/composed.yaml",auths,options).getOpenAPI();
+
+        ComposedSchema allOf = (ComposedSchema) openAPI.getComponents().getSchemas().get("ExtendedAddress");
+        assertEquals(allOf.getAllOf().size(), 2);
+
+        assertTrue(allOf.getAllOf().get(0).getProperties().containsKey("street"));
+        assertTrue(allOf.getAllOf().get(1).getProperties().containsKey("gps"));
+
+    }
+
+    @Test
     public void resolveComposedReferenceSchema(@Injectable final List<AuthorizationValue> auths){
 
 


### PR DESCRIPTION
Some users don't want to aggregate anyOf/allOf/oneOf schemas but simply wants all refs solved.
This solution adds a flag inside the `ResolverFully` and when schemas are processed It checks this flag. In case user don't want to aggregate, It generates a new list of subschemas solved and saves it to the composedSchema object.

I've also added a flag in `ParseOptions` that `OpenAPIV3Parser` reads during `readContents()` and I've wrote a test. For default the parser aggregate, as is now