### PR TITLE
Referring without components

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ResolverCache.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ResolverCache.java
@@ -154,37 +154,37 @@ public class ResolverCache {
     private Object loadInternalRef(String ref) {
         Object result = null;
 
-        if(ref.startsWith("#/components/schemas")) {
-            result = getFromMap(ref, openApi.getComponents().getSchemas(), SCHEMAS_PATTERN);
-        }
-        else if(ref.startsWith("#/components/requestBodies")) {
-            result = getFromMap(ref, openApi.getComponents().getRequestBodies(), REQUEST_BODIES_PATTERN);
-        }
-        else if(ref.startsWith("#/components/examples")) {
-            result = getFromMap(ref, openApi.getComponents().getExamples(), EXAMPLES_PATTERN);
-        }
-        else if(ref.startsWith("#/components/responses")) {
-            result = getFromMap(ref, openApi.getComponents().getResponses(), RESPONSES_PATTERN);
-        }
-        else if(ref.startsWith("#/components/parameters")) {
-            result = getFromMap(ref, openApi.getComponents().getParameters(), PARAMETERS_PATTERN);
-        }
-        else if(ref.startsWith("#/components/links")) {
-            result = getFromMap(ref, openApi.getComponents().getLinks(), LINKS_PATTERN);
-        }
-        else if(ref.startsWith("#/components/headers")) {
-            result = getFromMap(ref, openApi.getComponents().getHeaders(), HEADERS_PATTERN);
-        }
-        else if(ref.startsWith("#/components/callbacks")) {
-            result = getFromMap(ref, openApi.getComponents().getCallbacks(), CALLBACKS_PATTERN);
-        }
-        else if(ref.startsWith("#/components/securitySchemes")) {
-            result = getFromMap(ref, openApi.getComponents().getSecuritySchemes(), SECURITY_SCHEMES);
-        }
-        else if(ref.startsWith("#/paths")) {
+        if (ref.startsWith("#/paths")) {
             result = getFromMap(ref, openApi.getPaths(), PATHS_PATTERN);
+        } else if (openApi.getComponents() != null){
+            if(ref.startsWith("#/components/schemas")) {
+                result = getFromMap(ref, openApi.getComponents().getSchemas(), SCHEMAS_PATTERN);
+            }
+            else if(ref.startsWith("#/components/requestBodies")) {
+                result = getFromMap(ref, openApi.getComponents().getRequestBodies(), REQUEST_BODIES_PATTERN);
+            }
+            else if(ref.startsWith("#/components/examples")) {
+                result = getFromMap(ref, openApi.getComponents().getExamples(), EXAMPLES_PATTERN);
+            }
+            else if(ref.startsWith("#/components/responses")) {
+                result = getFromMap(ref, openApi.getComponents().getResponses(), RESPONSES_PATTERN);
+            }
+            else if(ref.startsWith("#/components/parameters")) {
+                result = getFromMap(ref, openApi.getComponents().getParameters(), PARAMETERS_PATTERN);
+            }
+            else if(ref.startsWith("#/components/links")) {
+                result = getFromMap(ref, openApi.getComponents().getLinks(), LINKS_PATTERN);
+            }
+            else if(ref.startsWith("#/components/headers")) {
+                result = getFromMap(ref, openApi.getComponents().getHeaders(), HEADERS_PATTERN);
+            }
+            else if(ref.startsWith("#/components/callbacks")) {
+                result = getFromMap(ref, openApi.getComponents().getCallbacks(), CALLBACKS_PATTERN);
+            }
+            else if(ref.startsWith("#/components/securitySchemes")) {
+                result = getFromMap(ref, openApi.getComponents().getSecuritySchemes(), SECURITY_SCHEMES);
+            }
         }
-
 
         return result;
 

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -1,6 +1,7 @@
 package io.swagger.v3.parser.processors;
 
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.callbacks.Callback;
 import io.swagger.v3.oas.models.examples.Example;
@@ -46,6 +47,9 @@ public final class ExternalRefProcessor {
         }
         String newRef;
 
+        if (openAPI.getComponents() == null) {
+            openAPI.setComponents(new Components());
+        }
         Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
 
         if (schemas == null) {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -125,6 +125,9 @@ public final class ExternalRefProcessor {
         }
         String newRef;
 
+        if (openAPI.getComponents() == null) {
+            openAPI.setComponents(new Components());
+        }
         Map<String, ApiResponse> responses = openAPI.getComponents().getResponses();
 
         if (responses == null) {
@@ -175,6 +178,9 @@ public final class ExternalRefProcessor {
         }
         String newRef;
 
+        if (openAPI.getComponents() == null) {
+            openAPI.setComponents(new Components());
+        }
         Map<String, RequestBody> bodies = openAPI.getComponents().getRequestBodies();
 
         if (bodies == null) {
@@ -225,6 +231,9 @@ public final class ExternalRefProcessor {
         }
         String newRef;
 
+        if (openAPI.getComponents() == null) {
+            openAPI.setComponents(new Components());
+        }
         Map<String, Header> headers = openAPI.getComponents().getHeaders();
 
         if (headers == null) {
@@ -275,6 +284,9 @@ public final class ExternalRefProcessor {
         }
         String newRef;
 
+        if (openAPI.getComponents() == null) {
+            openAPI.setComponents(new Components());
+        }
         Map<String, SecurityScheme> securitySchemeMap = openAPI.getComponents().getSecuritySchemes();
 
         if (securitySchemeMap == null) {
@@ -325,6 +337,9 @@ public final class ExternalRefProcessor {
         }
         String newRef;
 
+        if (openAPI.getComponents() == null) {
+            openAPI.setComponents(new Components());
+        }
         Map<String, Link> links = openAPI.getComponents().getLinks();
 
         if (links == null) {
@@ -375,6 +390,9 @@ public final class ExternalRefProcessor {
         }
         String newRef;
 
+        if (openAPI.getComponents() == null) {
+            openAPI.setComponents(new Components());
+        }
         Map<String, Example> examples = openAPI.getComponents().getExamples();
 
         if (examples == null) {
@@ -425,6 +443,9 @@ public final class ExternalRefProcessor {
         }
         String newRef;
 
+        if (openAPI.getComponents() == null) {
+            openAPI.setComponents(new Components());
+        }
         Map<String, Parameter> parameters = openAPI.getComponents().getParameters();
 
         if (parameters == null) {
@@ -475,6 +496,9 @@ public final class ExternalRefProcessor {
         }
         String newRef;
 
+        if (openAPI.getComponents() == null) {
+            openAPI.setComponents(new Components());
+        }
         Map<String, Callback> callbacks = openAPI.getComponents().getCallbacks();
 
         if (callbacks == null) {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -136,7 +136,7 @@ public class OpenAPIDeserializer {
                 openAPI.setPaths(paths);
             }
 
-            obj = getObject("components", rootNode, true, location, result);
+            obj = getObject("components", rootNode, false, location, result);
             if (obj != null) {
                 Components components = getComponents(obj, "components", result);
                 openAPI.setComponents(components);

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
@@ -603,6 +603,17 @@ public class OpenAPIResolverTest {
 
     }
 
+    @Test
+    public void referringSpecWithoutComponentsTag() throws Exception {
+        ParseOptions resolve = new ParseOptions();
+        resolve.setResolveFully(true);
+        final OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/resources/ref-without-component/a.yaml", null, resolve);
+
+        Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
+        Assert.assertEquals("Example value", schemas.get("CustomerType").getExample());
+    }
+
+
     private static int getDynamicPort() {
         return new Random().ints(50000, 60000).findFirst().getAsInt();
     }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/OpenAPIDeserializerTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/OpenAPIDeserializerTest.java
@@ -542,7 +542,6 @@ public class OpenAPIDeserializerTest {
 
         assertTrue(messages.contains("attribute info is missing"));
         assertTrue(messages.contains("attribute paths is missing"));
-        assertTrue(messages.contains("attribute components is missing"));
         assertTrue(messages.contains("attribute new is unexpected"));
     }
 

--- a/modules/swagger-parser-v3/src/test/resources/ref-without-component/a.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/ref-without-component/a.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.0
+paths:
+  "/newPerson":
+    post:
+      summary: Create new person
+      description: Create new person
+      responses:
+        '200':
+          description: OK
+          content:
+            "*/*":
+              schema:
+                "$ref": "./src/test/resources/ref-without-component/b.yaml#/components/schemas/CustomerType"

--- a/modules/swagger-parser-v3/src/test/resources/ref-without-component/b.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/ref-without-component/b.yaml
@@ -1,0 +1,6 @@
+openapi: 3.0.0
+components:
+  schemas:
+    CustomerType:
+      type: string
+      example: Example value


### PR DESCRIPTION
According to how i interpret the spec the "components" object is not required. I wish it were! (Or at least default to an empty components object) I have had so some bugs where I assume components exists...

According to the deserializer it assumes it is required. (The `true` means it is required) https://github.com/swagger-api/swagger-parser/blob/647bfe2c8cad362d837c052980939134933c70b2/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java#L137

This PR fixes a NPE in the resolver when the spec is missing the components tag and using external refs. I haven't checked, but I wouldn't be surprised if there are other cases of `openAPI.getComponents().getSomeSubObject()` assuming components is not null. Maybe thinking about defaulting the root components to an empty object is worth thinking about...