### PR TITLE
Over quoted string example

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -841,8 +841,9 @@ public class SwaggerDeserializer {
                 if(on != null) {
                     model.setExample(on);
                 }
-            }
-            else {
+            } else if (exampleNode.isValueNode()) {
+                model.setExample(exampleNode.asText());
+            } else {
                 model.setExample(exampleNode.toString());
             }
         }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -1,5 +1,6 @@
 package io.swagger.parser;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.models.ArrayModel;
 import io.swagger.models.ComposedModel;
 import io.swagger.models.Model;
@@ -31,7 +32,9 @@ import io.swagger.util.Json;
 import io.swagger.util.Yaml;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.testng.reporters.Files;
 
+import java.io.File;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
@@ -957,5 +960,25 @@ public class SwaggerParserTest {
         Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-example/allOf.json");
         assertEquals(2, swagger.getDefinitions().size());
 
+    }
+
+    @Test(description = "A string example should not be over quoted when parsing a yaml string")
+    public void readingSpecStringShouldNotOverQuotingStringExample() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/over-quoted-example.yaml", null, false);
+
+        Map<String, Model> definitions = swagger.getDefinitions();
+        assertEquals("NoQuotePlease", definitions.get("CustomerType").getExample());
+    }
+
+    @Test(description = "A string example should not be over quoted when parsing a yaml node")
+    public void readingSpecNodeShouldNotOverQuotingStringExample() throws Exception {
+        String yaml = Files.readFile(new File("src/test/resources/over-quoted-example.yaml"));
+        JsonNode rootNode = Yaml.mapper().readValue(yaml, JsonNode.class);
+        SwaggerParser parser = new SwaggerParser();
+        Swagger swagger = parser.read(rootNode,true);
+
+        Map<String, Model> definitions = swagger.getDefinitions();
+        assertEquals("NoQuotePlease", definitions.get("CustomerType").getExample());
     }
 }

--- a/modules/swagger-parser/src/test/resources/over-quoted-example.yaml
+++ b/modules/swagger-parser/src/test/resources/over-quoted-example.yaml
@@ -1,0 +1,16 @@
+swagger: '2.0'
+paths:
+ /newPerson:
+  post:
+    summary: Create new person
+    description: Create new person
+    parameters: []
+    responses:
+      200:
+       description: OK
+       schema:
+        $ref: "#/definitions/CustomerType"
+definitions:
+  CustomerType:
+    type: string
+    example: NoQuotePlease


### PR DESCRIPTION
Removes the extra surrounding `"` around string examples.

I have found that swagger-codegen has a workaround for this, but I prefer fixing it right in the code here.
See https://github.com/swagger-api/swagger-codegen/pull/5778