### PR TITLE
Fix to SwaggerCompatConverter so it can load inputSpec from classpath.

### DIFF
--- a/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
+++ b/modules/swagger-compat-spec-parser/src/main/java/io/swagger/parser/SwaggerCompatConverter.java
@@ -52,18 +52,23 @@ import io.swagger.models.resourcelisting.BasicAuthorization;
 import io.swagger.models.resourcelisting.ImplicitGrant;
 import io.swagger.models.resourcelisting.OAuth2Authorization;
 import io.swagger.models.resourcelisting.ResourceListing;
+import io.swagger.parser.util.ClasspathHelper;
 import io.swagger.parser.util.RemoteUrl;
 import io.swagger.parser.util.SwaggerDeserializationResult;
 import io.swagger.report.MessageBuilder;
 import io.swagger.transform.migrate.ApiDeclarationMigrator;
 import io.swagger.transform.migrate.ResourceListingMigrator;
 import io.swagger.util.Json;
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -186,7 +191,22 @@ public class SwaggerCompatConverter implements SwaggerParserExtension {
                 String json = RemoteUrl.urlToString(input, auths);
                 jsonNode = Json.mapper().readTree(json);
             } else {
-                jsonNode = Json.mapper().readTree(new File(input));
+                final String fileScheme = "file:";
+                java.nio.file.Path path;
+                if (input.toLowerCase().startsWith(fileScheme)) {
+                    path = Paths.get(URI.create(input));
+                } else {
+                    path = Paths.get(input);
+                }
+                String json;
+                if (Files.exists(path)) {
+                    json= FileUtils.readFileToString(path.toFile(), "UTF-8");
+                } else {
+                    json = ClasspathHelper.loadFileFromClasspath(input  );
+                }
+
+                jsonNode = Json.mapper().readTree(json);
+
             }
             if (jsonNode.get("swaggerVersion") == null) {
                 return null;
@@ -489,7 +509,21 @@ public class SwaggerCompatConverter implements SwaggerParserExtension {
                 String json = RemoteUrl.urlToString(input, auths);
                 jsonNode = Json.mapper().readTree(json);
             } else {
-                jsonNode = Json.mapper().readTree(new java.io.File(input));
+                final String fileScheme = "file:";
+                java.nio.file.Path path;
+                if (input.toLowerCase().startsWith(fileScheme)) {
+                    path = Paths.get(URI.create(input));
+                } else {
+                    path = Paths.get(input);
+                }
+                String json;
+                if (Files.exists(path)) {
+                     json= FileUtils.readFileToString(path.toFile(), "UTF-8");
+                } else {
+                    json = ClasspathHelper.loadFileFromClasspath(input  );
+                }
+
+                jsonNode = Json.mapper().readTree(json);
             }
 
             // this should be moved to a json patch

--- a/modules/swagger-compat-spec-parser/src/test/java/io/swagger/parserExtensions/SwaggerCompatConverterTest.java
+++ b/modules/swagger-compat-spec-parser/src/test/java/io/swagger/parserExtensions/SwaggerCompatConverterTest.java
@@ -1,0 +1,25 @@
+package io.swagger.parserExtensions;
+
+import io.swagger.models.Swagger;
+import io.swagger.parser.SwaggerCompatConverter;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.testng.Assert.assertTrue;
+
+public class SwaggerCompatConverterTest {
+    @Test
+    public void loadsSpecFromClasspath() throws IOException {
+        SwaggerCompatConverter converter = new SwaggerCompatConverter();
+        Swagger result = converter.read("/specs/v1_2/singleFile.json");
+        assertTrue(result != null, "Didn't load spec from classpath");
+    }
+
+    @Test
+    public void failsOnNonExistentSpec() throws IOException {
+        SwaggerCompatConverter converter = new SwaggerCompatConverter();
+        Swagger result = converter.read("specs/v1_2/not-exists.json");
+        assertTrue(result == null);
+    }
+}


### PR DESCRIPTION
Swagger20Parser already can load input spec from classpath, but codegen project loads extensions one them is SwaggerCompatConverter and it fails loading from classpath

This fixes https://github.com/swagger-api/swagger-codegen/issues/2666