### PR TITLE
Fix for issue #616 allOf fails to resolve RELATIVE ref

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
@@ -87,7 +87,8 @@ public final class ExternalRefProcessor {
                     if (allOfModel instanceof RefModel) {
                         RefModel refModel = (RefModel) allOfModel;
                         if (isAnExternalRefFormat(refModel.getRefFormat())) {
-                            refModel.set$ref(processRefToExternalDefinition(refModel.get$ref(), refModel.getRefFormat()));
+                            String joinedRef = join(file, refModel.get$ref());
+                            refModel.set$ref(processRefToExternalDefinition(joinedRef, refModel.getRefFormat()));
                         } else {
                             processRefToExternalDefinition(file + refModel.get$ref(), RefFormat.RELATIVE);
                         }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -1020,6 +1020,12 @@ public class SwaggerParserTest {
 
     }
 
+    @Test(description = "Issue #616 Relative references inside of 'allOf'")
+    public void checkAllOfWithRelativeReferencesAreFound() {
+        Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-relative-file-references/parent.json");
+        assertEquals(4, swagger.getDefinitions().size());
+    }
+
     @Test(description = "A string example should not be over quoted when parsing a yaml string")
     public void readingSpecStringShouldNotOverQuotingStringExample() throws Exception {
         SwaggerParser parser = new SwaggerParser();

--- a/modules/swagger-parser/src/test/resources/allOf-relative-file-references/models/fancy_pet.json
+++ b/modules/swagger-parser/src/test/resources/allOf-relative-file-references/models/fancy_pet.json
@@ -1,0 +1,15 @@
+{
+  "allOf": [
+    {
+      "$ref": "./pet.json"
+    },
+    {
+      "properties": {
+        "breed": {
+          "type": "string",
+          "example": "Labrador"
+        }
+      }
+    }
+  ]
+}

--- a/modules/swagger-parser/src/test/resources/allOf-relative-file-references/models/pet.json
+++ b/modules/swagger-parser/src/test/resources/allOf-relative-file-references/models/pet.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "format": "int64"
+    },
+    "name": {
+      "type": "string",
+      "example": "Cooper"
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/allOf-relative-file-references/parent.json
+++ b/modules/swagger-parser/src/test/resources/allOf-relative-file-references/parent.json
@@ -1,0 +1,84 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Issue #616. This is a modified Petstore server where we have two pet definitions  1. pet and 2. fancy_pet which inherits pet using allOf."
+  },
+  "host": "petstore.swagger.io",
+  "basePath": "/v3",
+  "paths": {
+    "/pet": {
+      "get": {
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "./models/pet.json"
+            }
+          }
+        }
+      }
+    },
+    "/fancy-pet": {
+      "get": {
+        "operationId": "getFancyPetById",
+        "parameters": [
+          {
+            "name": "fancyPetId",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "schema": {
+              "$ref": "./models/fancy_pet.json"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "DomesticPet": {
+      "allOf": [
+        {
+          "$ref": "./models/pet.json"
+        },
+        {
+          "properties": {
+            "description": {
+              "type": "string",
+              "example": "friendly"
+            }
+          }
+        }
+      ]
+    },
+    "DancingPet": {
+      "allOf": [
+        {
+          "$ref": "./models/fancy_pet.json"
+        },
+        {
+          "properties": {
+            "style": {
+              "type": "string",
+              "example": "salsa"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fix for Issue #616

Issue #616 arises due to an unchecked use-case where one external file is referenced with respect to the `parent` instead of the `source` where the reference is made.

Similar use-cases are handled correctly elsewhere but missed out in the case of `ComposedModels`. This issue is specific to ComposedModel only i.e. `allOf`. 

The fix leverages existing `join` function to normalize and resolve the paths before sending it for processing the external definitions.

CC: @tzimisce012 based on previous commits in this area.