### PR TITLE
adding maxItems and MinItems into ArrayModel deserializing - ticket#594

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -731,6 +731,12 @@ public class SwaggerDeserializer {
                 am.items(items);
             }
 
+            Integer maxItems = getInteger("maxItems", node, false, location, result);
+            am.setMaxItems(maxItems);
+
+            Integer minItems = getInteger("minItems", node, false, location, result);
+            am.setMinItems(minItems);
+
             // extra keys
             Set<String> keys = getKeys(node);
             for(String key : keys) {

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -954,6 +954,35 @@ public class SwaggerParserTest {
     }
 
     @Test
+    public void testIssue594() {
+        String yaml =
+                "swagger: '2.0'\n" +
+                        "paths:\n" +
+                        "  /test:\n" +
+                        "    post:\n" +
+                        "      parameters:\n" +
+                        "        - name: body\n" +
+                        "          in: body\n" +
+                        "          description: Hello world\n" +
+                        "          schema:\n" +
+                        "            type: array\n" +
+                        "            minItems: 1\n" +
+                        "            maxItems: 1\n" +
+                        "            items: \n" +
+                        "              $ref: \"#/definitions/Pet\"\n" +
+                        "      responses:\n" +
+                        "        200:\n" +
+                        "          description: 'OK'\n";
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
+        assertNotNull(result.getSwagger());
+        ArrayModel schema = (ArrayModel)((BodyParameter)result.getSwagger().getPaths().get("/test").getPost().getParameters().get(0)).getSchema();
+        assertEquals(((RefProperty)schema.getItems()).get$ref(),"#/definitions/Pet");
+        assertNotNull(schema.getMaxItems());
+        assertNotNull(schema.getMinItems());
+
+    }
+
+    @Test
     public void testIssue450() {
         String desc = "An array of Pets";
         String xTag = "x-my-tag";


### PR DESCRIPTION
This PR fixes the issue #594  adding maxItems and minItems to the definitions method in the deserializer, when the Model in the body Parameter is ArrayModel.