### PR TITLE
Fix for #620: allOf fails to process load properties with external $ref

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
@@ -92,31 +92,14 @@ public final class ExternalRefProcessor {
                         } else {
                             processRefToExternalDefinition(file + refModel.get$ref(), RefFormat.RELATIVE);
                         }
+                    } else if (allOfModel instanceof ModelImpl) {
+                        //Loop through additional properties of allOf and recursively call this method;
+                        processProperties(allOfModel.getProperties(), file);
                     }
                 }
             }
             //Loop the properties and recursively call this method;
-            Map<String, Property> subProps = model.getProperties();
-            if (subProps != null) {
-                for (Map.Entry<String, Property> prop : subProps.entrySet()) {
-                    if (prop.getValue() instanceof RefProperty) {
-                        processRefProperty((RefProperty) prop.getValue(), file);
-                    } else if (prop.getValue() instanceof ArrayProperty) {
-                        ArrayProperty arrayProp = (ArrayProperty) prop.getValue();
-                        if (arrayProp.getItems() instanceof RefProperty) {
-                            processRefProperty((RefProperty) arrayProp.getItems(), file);
-                        }
-                    } else if (prop.getValue() instanceof MapProperty) {
-                        MapProperty mapProp = (MapProperty) prop.getValue();
-                        if (mapProp.getAdditionalProperties() instanceof RefProperty) {
-                            processRefProperty((RefProperty) mapProp.getAdditionalProperties(), file);
-                        } else if (mapProp.getAdditionalProperties() instanceof ArrayProperty &&
-                                ((ArrayProperty) mapProp.getAdditionalProperties()).getItems() instanceof RefProperty) {
-                            processRefProperty((RefProperty) ((ArrayProperty) mapProp.getAdditionalProperties()).getItems(), file);
-                        }
-                    }
-                }
-            }
+            processProperties(model.getProperties(), file);
             if (model instanceof  ModelImpl) {
                 ModelImpl modelImpl = (ModelImpl) model;
                 Property additionalProperties = modelImpl.getAdditionalProperties();
@@ -146,6 +129,31 @@ public final class ExternalRefProcessor {
         }
 
         return newRef;
+    }
+
+    private void processProperties(final Map<String, Property> subProps, final String file) {
+        if (subProps == null || 0 == subProps.entrySet().size() ) {
+            return;
+        }
+        for (Map.Entry<String, Property> prop : subProps.entrySet()) {
+            if (prop.getValue() instanceof RefProperty) {
+                processRefProperty((RefProperty) prop.getValue(), file);
+            } else if (prop.getValue() instanceof ArrayProperty) {
+                ArrayProperty arrayProp = (ArrayProperty) prop.getValue();
+                if (arrayProp.getItems() instanceof RefProperty) {
+                    processRefProperty((RefProperty) arrayProp.getItems(), file);
+                }
+            } else if (prop.getValue() instanceof MapProperty) {
+                MapProperty mapProp = (MapProperty) prop.getValue();
+                if (mapProp.getAdditionalProperties() instanceof RefProperty) {
+                    processRefProperty((RefProperty) mapProp.getAdditionalProperties(), file);
+                } else if (mapProp.getAdditionalProperties() instanceof ArrayProperty &&
+                        ((ArrayProperty) mapProp.getAdditionalProperties()).getItems() instanceof RefProperty) {
+                    processRefProperty((RefProperty) ((ArrayProperty) mapProp.getAdditionalProperties()).getItems(),
+                            file);
+                }
+            }
+        }
     }
 
     private void processRefProperty(RefProperty subRef, String externalFile) {

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
@@ -70,7 +70,7 @@ public class RefUtils {
                 return readExternalRef(url, RefFormat.URL, auths, null);
             }
         } catch (Exception e) {
-            throw new RuntimeException("Unable to load " + refFormat + " ref: " + file, e);
+            throw new RuntimeException("Unable to load " + refFormat + " ref: " + file + " path:" + rootPath, e);
         }
 
         return result;
@@ -143,7 +143,7 @@ public class RefUtils {
 
             }
         } catch (Exception e) {
-            throw new RuntimeException("Unable to load " + refFormat + " ref: " + file, e);
+            throw new RuntimeException("Unable to load " + refFormat + " ref: " + file + " path: "+parentDirectory, e);
         }
 
         return result;

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/FileReferenceTests.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/FileReferenceTests.java
@@ -1,12 +1,16 @@
 package io.swagger.parser;
 
 import io.swagger.models.*;
+import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.parser.util.SwaggerDeserializationResult;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
+import java.util.Arrays;
+import java.util.Map;
+
 
 public class FileReferenceTests {
     @Test
@@ -148,9 +152,20 @@ public class FileReferenceTests {
     @Test
     public void testIssue304() {
         SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("./src/test/resources/nested-file-references/issue-304.json", null, true);
-        assertNotNull(result.getSwagger());
+        assertNotNull(result.getSwagger().getDefinitions());
+    }
 
-        Swagger swagger = result.getSwagger();
-        assertFalse(swagger.getDefinitions().get("BarData") instanceof RefModel);
+    @Test
+    public void testAllOfFlatAndNested() {
+        for (String path : Arrays.asList("./src/test/resources/allOf-properties-ext-ref/models/swagger.json",
+                "./src/test/resources/allOf-properties-ext-ref/swagger.json")) {
+            Swagger swagger = new SwaggerParser().read(path);
+            assertEquals(3, swagger.getDefinitions().size());
+            ComposedModel composedModel = (ComposedModel)swagger.getDefinitions().get("record");
+            assertEquals(((RefModel) composedModel.getParent()).getSimpleRef(), "pet");
+            Map<String, Property> props = composedModel.getChild().getProperties();
+            assertEquals(((RefProperty) props.get("mother")).getSimpleRef(), "pet");
+            assertEquals(((RefProperty) ((ArrayProperty) props.get("siblings")).getItems()).getSimpleRef(), "pet");
+        }
     }
 }

--- a/modules/swagger-parser/src/test/resources/allOf-properties-ext-ref/models/pet.json
+++ b/modules/swagger-parser/src/test/resources/allOf-properties-ext-ref/models/pet.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "color": {
+      "type": "string"
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/allOf-properties-ext-ref/models/purebred_pet.json
+++ b/modules/swagger-parser/src/test/resources/allOf-properties-ext-ref/models/purebred_pet.json
@@ -1,0 +1,25 @@
+{
+  "allOf": [
+    {
+      "$ref": "./pet.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "breed": {
+          "type": "string",
+          "sample": "Labrador"
+        },
+        "mother": {
+          "$ref": "./pet.json"
+        },
+        "siblings": {
+          "type": "array",
+          "items": {
+            "$ref": "./pet.json"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/modules/swagger-parser/src/test/resources/allOf-properties-ext-ref/models/swagger.json
+++ b/modules/swagger-parser/src/test/resources/allOf-properties-ext-ref/models/swagger.json
@@ -1,0 +1,12 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "flat",
+    "version": "1.0.0"
+  },
+  "definitions": {
+    "record": {
+      "$ref": "./purebred_pet.json"
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/allOf-properties-ext-ref/swagger.json
+++ b/modules/swagger-parser/src/test/resources/allOf-properties-ext-ref/swagger.json
@@ -1,0 +1,12 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "flat",
+    "version": "1.0.0"
+  },
+  "definitions": {
+    "record": {
+      "$ref": "./models/purebred_pet.json"
+    }
+  }
+}


### PR DESCRIPTION
Fix for issue #620 where `allOf` fails to process load properties with external `$ref`
sample: 
```
{
  "allOf": [
    {
      "$ref": "./pet.json"
    },
    {
      "type": "object",
      "properties": {
        "mother": {
          "$ref": "./pet.json"
        }
      }
    }
  ]
}
```

This PR fixes the issue where `pet.json` under `properties` fails to load.
