### PR TITLE
:bug: Fix in:cookie in apiKey security schemes

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -56,6 +56,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1577,14 +1578,12 @@ public class OpenAPIDeserializer {
             securityScheme.setName(value);
         }
 
-        value = getString("in", node, inRequired, location, result);
-        if (StringUtils.isNotBlank(value)) {
-            if (QUERY_PARAMETER.equals(value)) {
-                securityScheme.setIn(SecurityScheme.In.QUERY);
-            } else if (HEADER_PARAMETER.equals(value)) {
-                securityScheme.setIn(SecurityScheme.In.HEADER);
-            }
-        }
+        final String securitySchemeIn = getString("in", node, inRequired, location, result);
+        final Optional<SecurityScheme.In> matchingIn = Arrays.stream(SecurityScheme.In.values())
+                .filter(in -> in.toString().equals(securitySchemeIn))
+                .findFirst();
+
+        securityScheme.setIn(matchingIn.orElse(null));
 
         value = getString("scheme", node, schemeRequired, location, result);
         if (StringUtils.isNotBlank(value)) {

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/OpenAPIDeserializerTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/OpenAPIDeserializerTest.java
@@ -810,7 +810,7 @@ public class OpenAPIDeserializerTest {
 
         final Map<String, SecurityScheme> securitySchemes = openAPI.getComponents().getSecuritySchemes();
         Assert.assertNotNull(securitySchemes);
-        Assert.assertEquals(securitySchemes.size(),9);
+        Assert.assertEquals(securitySchemes.size(),10);
 
         SecurityScheme securityScheme = securitySchemes.get("reference");
         assertTrue(securityScheme.get$ref().equals("#/components/securitySchemes/api_key"));
@@ -832,7 +832,12 @@ public class OpenAPIDeserializerTest {
         
         securityScheme = securitySchemes.get("api_key");
         assertTrue(securityScheme.getType()== SecurityScheme.Type.APIKEY);
-        
+        assertTrue(securityScheme.getIn()== SecurityScheme.In.HEADER);
+
+        securityScheme = securitySchemes.get("api_key_cookie");
+        assertTrue(securityScheme.getType()== SecurityScheme.Type.APIKEY);
+        assertTrue(securityScheme.getIn()== SecurityScheme.In.COOKIE);
+
         securityScheme = securitySchemes.get("http");
         assertTrue(securityScheme.getType()== SecurityScheme.Type.HTTP);
 

--- a/modules/swagger-parser-v3/src/test/resources/oas3.yaml.template
+++ b/modules/swagger-parser-v3/src/test/resources/oas3.yaml.template
@@ -1170,6 +1170,10 @@ components:
       type: apiKey
       name: api_key
       in: header
+    api_key_cookie:
+      type: apiKey
+      name: api_key
+      in: cookie
     http:
       type: http
       scheme: Basic


### PR DESCRIPTION
## Impacted version

__v2.0.0-rc2__

## Issue description

When using __OpenAPIDeserializer__ to deserialize security schemes with `type: apiKey` and `in: cookie`, the value of `in` is `null` in the generated `OpenAPI` object.

## Simplest reproduction scenario

OAS 3 definition:

```yaml
openapi: 3.0.0
servers:
  - url: 'https://whatever.net/v1'
info:
  description: ''
  version: 1.0.0
  title: Demo for cookie apiKey
paths: {}
components:
  securitySchemes:
    API_KEY:
      type: apiKey
      description: The API key
      name: auth
      in: cookie
```

Test code:

```java
import com.fasterxml.jackson.databind.JsonNode;
import io.swagger.v3.core.util.Yaml;
import io.swagger.v3.oas.models.security.SecurityScheme;
import io.swagger.v3.parser.core.models.SwaggerParseResult;
import org.testng.annotations.Test;

import java.nio.file.Path;
import java.nio.file.Paths;
import java.util.Map;

import static org.testng.Assert.assertEquals;

public class ApiKeyCookieTest {

    @Test
    public void test() throws Exception {
        final Path oas3Path = Paths.get("/tmp/apiKeyCookie.yml"); // TODO: <=== change the path to fit your environment
        final JsonNode jsonNode = Yaml.mapper().readTree(oas3Path.toFile());
        final SwaggerParseResult parseResult = new OpenAPIDeserializer().deserialize(jsonNode);

        final Map<String, SecurityScheme> securitySchemes = parseResult.getOpenAPI().getComponents().getSecuritySchemes();
        assertEquals(securitySchemes.get("API_KEY").getIn(), SecurityScheme.In.COOKIE);
    }
}
```

## Additional notes

I've taken the liberty to change the tests by I'm not sure how you want to test that exactly.
Just tell me if you'd like it done elseways. 