### PR TITLE
:bug: Fix trace operations

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -572,6 +572,13 @@ public class OpenAPIDeserializer {
                 pathItem.setOptions(operation);
             }
         }
+        node = getObject("trace", obj, false, location, result);
+        if (node != null) {
+            Operation operation = getOperation(node, location + "(trace)", result);
+            if (operation != null) {
+                pathItem.setTrace(operation);
+            }
+        }
 
         Map <String,Object> extensions = getExtensions(obj);
         if(extensions != null && extensions.size() > 0) {

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/OpenAPIDeserializerTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/OpenAPIDeserializerTest.java
@@ -1067,6 +1067,9 @@ public class OpenAPIDeserializerTest {
         Assert.assertEquals(petEndpoint.getPost().getExternalDocs().getUrl(),"http://swagger.io");
         Assert.assertEquals(petEndpoint.getPost().getExternalDocs().getDescription(),"Find out more");
 
+        //Operation trace
+        Assert.assertNotNull(petEndpoint.getTrace());
+        Assert.assertNotNull(petEndpoint.getDescription());
 
         //Operation post
         Assert.assertNotNull(petEndpoint.getPost());
@@ -1080,7 +1083,6 @@ public class OpenAPIDeserializerTest {
         Assert.assertNotNull(petEndpoint.getParameters());
         Assert.assertEquals(petEndpoint.getParameters().size(), 2);
         Assert.assertNotNull(petEndpoint.getPost().getParameters());
-        Parameter parameter = petEndpoint.getParameters().get(0);
         Assert.assertEquals(petEndpoint.getPost().getSecurity().get(0).get("petstore_auth").get(0), "write:pets");
         Assert.assertEquals(petEndpoint.getPost().getSecurity().get(0).get("petstore_auth").get(1), "read:pets");
 

--- a/modules/swagger-parser-v3/src/test/resources/oas3.yaml.template
+++ b/modules/swagger-parser-v3/src/test/resources/oas3.yaml.template
@@ -102,6 +102,11 @@ paths:
   "/pet":
     summary: summary
     description: description
+    trace:
+      description: Dummy operation to test retrieval of trace operations
+      responses:
+        200:
+          description: Dummy response
     post:
       externalDocs:
         description: Find out more


### PR DESCRIPTION
## Impacted version

__v2.0.0-rc2__

## Issue description

When using __OpenAPIDeserializer__ to deserialize a PathItem with a `trace` operation, the said operation is null in the generated `OpenAPI` object.

## Simplest reproduction scenario

OAS 3 definition:

```yaml
openapi: 3.0.0
servers:
  - url: 'https://whatever.net/v1'
info:
  description: ''
  version: 1.0.0
  title: Demo for cookie apiKey
paths:
  /dummy:
    trace:
      description: Dummy operation to test retrieval of trace operations
      responses:
        200:
          description: Dummy response
```

Test code:

```java
import com.fasterxml.jackson.databind.JsonNode;
import io.swagger.v3.core.util.Yaml;
import io.swagger.v3.oas.models.PathItem;
import io.swagger.v3.parser.core.models.SwaggerParseResult;
import io.swagger.v3.parser.util.OpenAPIDeserializer;
import org.testng.annotations.Test;

import java.nio.file.Path;
import java.nio.file.Paths;

import static org.testng.Assert.assertNotNull;

public class TraceOperationTest {

    @Test
    public void test() throws Exception {
        final Path oas3Path = Paths.get("/tmp/traceOperation.yml"); // TODO: <=== change the path to fit your environment
        final JsonNode jsonNode = Yaml.mapper().readTree(oas3Path.toFile());
        final SwaggerParseResult parseResult = new OpenAPIDeserializer().deserialize(jsonNode);

        final PathItem path = parseResult.getOpenAPI().getPaths().get("/dummy");
        assertNotNull(path.getTrace());
    }
}
```

## Additional notes

I've taken the liberty to change the tests by I'm not sure how you want to test that exactly.
Just tell me if you'd like it done elseways. 