### PR TITLE
Fix discriminator mapping If there are any name conflict for ComposedSchema (oneOf)

### DIFF
--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -8,13 +8,12 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.AuthorizationValue;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
-import io.swagger.v3.parser.OpenAPIV3Parser;
 import mockit.Injectable;
 import org.apache.commons.io.FileUtils;
-
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -26,14 +25,9 @@ import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Random;
-import java.util.stream.Collectors;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.testng.Assert.*;
 
 
 public class OpenAPIV3ParserTest {
@@ -328,6 +322,16 @@ public class OpenAPIV3ParserTest {
         Assert.assertNotNull(openAPI.getComponents().getSchemas().get("UserEx"));
         Assert.assertNotNull(openAPI.getComponents().getSchemas().get("User"));
         Assert.assertTrue(openAPI.getPaths().get("/refToAllOf").getGet().getResponses().get("200").getContent().get("application/json").getSchema().getProperties().size() == 2);
+    }
+
+    @Test
+    public void testOneOfExternalRefConflictName() throws Exception {
+        OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/resources/oneof_name_conflict/oneOf-external-ref-name-conflict.yaml");
+        Assert.assertNotNull(openAPI);
+        Schema pet = openAPI.getComponents().getSchemas().get("Pet");
+        Assert.assertNotNull(pet);
+        Assert.assertTrue(pet.getDiscriminator().getMapping().containsKey("Cat"));
+        Assert.assertTrue(pet.getDiscriminator().getMapping().get("Cat").equals("#/components/schemas/Cat_2"));
     }
 
 

--- a/modules/swagger-parser-v3/src/test/resources/oneof_name_conflict/oneOf-external-ref-name-conflict.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/oneof_name_conflict/oneOf-external-ref-name-conflict.yaml
@@ -1,0 +1,93 @@
+openapi: 3.0.0
+servers:
+  - url: 'http://petstore.swagger.io/v2'
+info:
+  description: >-
+    This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net,
+    #swagger](http://swagger.io/irc/).  For this sample, you can use the api key
+    `special-key` to test the authorization filters.
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: 'http://swagger.io/terms/'
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pets:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid status value
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+      - pet_type
+      properties:
+        pet_type:
+          type: string
+      oneOf:
+      - $ref: './src/test/resources/oneof_name_conflict/relative_ref/OtherPets.yaml#/components/schemas/Cat'
+      - $ref: '#/components/schemas/Dog'
+      - $ref: '#/components/schemas/Lizard'
+      discriminator:
+        propertyName: pet_type
+    Cat:
+      allOf:
+      - $ref: '#/components/schemas/Pet'
+      # all other properties specific to a `Cat`
+      type: object
+      properties:
+        name:
+          type: string
+    Dog:
+      allOf:
+      - $ref: '#/components/schemas/Pet'
+      # all other properties specific to a `Dog`
+      type: object
+      properties:
+        bark:
+          type: string
+    Lizard:
+      allOf:
+      - $ref: '#/components/schemas/Pet'
+      # all other properties specific to a `Lizard`
+      type: object
+      properties:
+        lovesRocks:
+          type: boolean

--- a/modules/swagger-parser-v3/src/test/resources/oneof_name_conflict/relative_ref/OtherPets.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/oneof_name_conflict/relative_ref/OtherPets.yaml
@@ -1,0 +1,11 @@
+components:
+  schemas:
+    Cat:
+      type: object
+      required:
+      - pet_type
+      properties:
+        pet_type:
+          type: string
+        name:
+          type: string


### PR DESCRIPTION
in oneOf ComposedSchema by default the propertyName field of the discriminator has value same as schema name. In case of name conflict the name of the schema changes, effectively changing the mapping. Fixed this case by keeping the older mapping.
Also in case of name conflict, the reference in the mapping was not changing.