### PR TITLE
Avoid overflow when storing an int64 in an Integer

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -1193,7 +1193,9 @@ public class OpenAPIDeserializer {
             }
         }
         else if(v.getNodeType().equals(JsonNodeType.NUMBER)) {
-            value = v.intValue();
+            if (v.isInt()) {
+                value = v.intValue();
+            }
         }
         else if(!v.isValueNode()) {
             result.invalidType(location, key, "integer", node);

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -7,6 +7,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.parser.OpenAPIV3Parser;
@@ -350,6 +351,13 @@ public class OpenAPIV3ParserTest {
         Assert.assertNotNull(pet);
         Assert.assertTrue(pet.getDiscriminator().getMapping().containsKey("Cat"));
         Assert.assertTrue(pet.getDiscriminator().getMapping().get("Cat").equals("#/components/schemas/Cat_2"));
+    }
+
+    @Test
+    public void int64ExampleWithoutOverflow() throws Exception {
+        OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/resources/int64example.yaml");
+        IntegerSchema date = ((IntegerSchema) openAPI.getPaths().get("/foo").getGet().getResponses().get("200").getContent().get("application/json").getSchema().getProperties().get("date"));
+        Assert.assertEquals("1516042231144", date.getExample().toString());
     }
 
 

--- a/modules/swagger-parser-v3/src/test/resources/int64example.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/int64example.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  version: 0.0.0
+  title: int64 mocking test
+paths:
+  /foo:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  date:
+                    type: integer
+                    format: int64
+                    example: 1516042231144
+                required:
+                  - date


### PR DESCRIPTION
In int64example.yaml the example value comes out as -81224344 in an Integer. 

Maybe there is a better way of checking for int64 examples, but this seems to do the job at least. I'm happy to change if there is some obvious better way this should be done in. :)