### PR TITLE
 Avoid duplicating definitions when they have the same name

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
@@ -13,7 +13,8 @@ import java.util.Set;
 
 public class RefUtils {
 
-    public static String computeDefinitionName(String ref, Set<String> reserved) {
+    public static String computeDefinitionName(String ref) {
+
 
         final String[] refParts = ref.split("#/");
 
@@ -37,15 +38,9 @@ public class RefUtils {
             final String[] split = plausibleName.split("\\.");
             plausibleName = split[0];
         }
-        String tryName = plausibleName;
 
-        for (int i = 2; reserved.contains(tryName); i++) {
-            tryName = plausibleName + "_" + i;
-        }
-
-        return tryName;
+        return plausibleName;
     }
-
     public static boolean isAnExternalRefFormat(RefFormat refFormat) {
         return refFormat == RefFormat.URL || refFormat == RefFormat.RELATIVE;
     }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -1125,7 +1125,7 @@ public class SwaggerParserTest {
     @Test
     public void testIssue643() throws Exception {
         Swagger swagger = new SwaggerParser().read("src/test/resources/issue_643.yaml");
-        
+
         Assert.assertNotNull(swagger);
 
         Assert.assertTrue(swagger.getDefinitions().size() == 1);

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -1085,6 +1085,10 @@ public class SwaggerParserTest {
     public void testRefNameConflicts() throws Exception {
         Swagger swagger = new SwaggerParser().read("./refs-name-conflict/a.yaml");
 
+        Yaml.prettyPrint(swagger);
+
+        assertTrue(swagger.getDefinitions().size() == 2);
+
         assertEquals("#/definitions/PersonObj", ((RefProperty) swagger.getPath("/newPerson").getPost().getResponses().get("200").getSchema()).get$ref());
         assertEquals("#/definitions/PersonObj_2", ((RefProperty) swagger.getPath("/oldPerson").getPost().getResponses().get("200").getSchema()).get$ref());
         assertEquals("#/definitions/PersonObj_2", ((RefProperty) swagger.getPath("/yetAnotherPerson").getPost().getResponses().get("200").getSchema()).get$ref());
@@ -1112,13 +1116,23 @@ public class SwaggerParserTest {
         Assert.assertNotNull(swagger);
 
         Assert.assertTrue(swagger.getDefinitions().size() == 5);
-        Yaml.prettyPrint(swagger);
 
         Assert.assertNotNull(swagger.getDefinitions().get("PrintInfo"));
         Assert.assertNotNull(swagger.getDefinitions().get("SomeEnum"));
         Assert.assertNotNull(swagger.getDefinitions().get("ShippingInfo"));
     }
 
+    @Test
+    public void testIssue643() throws Exception {
+        Swagger swagger = new SwaggerParser().read("src/test/resources/issue_643.yaml");
+        
+        Assert.assertNotNull(swagger);
+
+        Assert.assertTrue(swagger.getDefinitions().size() == 1);
+
+        Assert.assertNotNull(swagger.getDefinitions().get("XYZResponse"));
+
+    }
 
 
 }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/processors/ExternalRefProcessorTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/processors/ExternalRefProcessorTest.java
@@ -36,9 +36,9 @@ public class ExternalRefProcessorTest {
         final RefFormat refFormat = RefFormat.URL;
 
         new StrictExpectations() {{
-        	cache.getRenamedRef(ref);
-        	times = 1;
-        	result = null;
+			cache.getRenamedRef(ref);
+			times = 1;
+			result = null;
 
             cache.loadRef(ref, refFormat, Model.class);
             times = 1;
@@ -59,6 +59,8 @@ public class ExternalRefProcessorTest {
         String newRef = new ExternalRefProcessor(cache, swagger).processRefToExternalDefinition(ref, refFormat);
         assertEquals(newRef, "bar");
     }
+
+
 
     @Test
     public void testNestedExternalRefs(@Injectable final Model mockedModel){

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/RefUtilsTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/RefUtilsTest.java
@@ -66,12 +66,12 @@ public class RefUtilsTest {
         doComputeDefinitionNameTestCase("./path/to/file#/foo/bar/hello", "hello");
 
         // Name conflicts resolved by adding _number
-        assertEquals("file_2", RefUtils.computeDefinitionName("http://my.company.com/path/to/file.json", singleton("file")));
-        assertEquals("file_3", RefUtils.computeDefinitionName("http://my.company.com/path/to/file.json", new HashSet<>(asList("file", "file_2"))));
+        /*assertEquals("file_2", RefUtils.computeDefinitionName("http://my.company.com/path/to/file.json"/*, singleton("file")));
+        assertEquals("file_3", RefUtils.computeDefinitionName("http://my.company.com/path/to/file.json"/*, new HashSet<>(asList("file", "file_2"))));*/
     }
 
     private void doComputeDefinitionNameTestCase(String ref, String expectedDefinitionName) {
-        assertEquals(expectedDefinitionName, RefUtils.computeDefinitionName(ref, Collections.<String>emptySet()));
+        assertEquals(expectedDefinitionName, RefUtils.computeDefinitionName(ref));
     }
 
     private Map<String, Model> createMap(String... keys) {

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/RefUtilsTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/RefUtilsTest.java
@@ -64,10 +64,6 @@ public class RefUtilsTest {
         doComputeDefinitionNameTestCase("./path/to/file#/foo", "foo");
         doComputeDefinitionNameTestCase("./path/to/file#/foo/bar", "bar");
         doComputeDefinitionNameTestCase("./path/to/file#/foo/bar/hello", "hello");
-
-        // Name conflicts resolved by adding _number
-        /*assertEquals("file_2", RefUtils.computeDefinitionName("http://my.company.com/path/to/file.json"/*, singleton("file")));
-        assertEquals("file_3", RefUtils.computeDefinitionName("http://my.company.com/path/to/file.json"/*, new HashSet<>(asList("file", "file_2"))));*/
     }
 
     private void doComputeDefinitionNameTestCase(String ref, String expectedDefinitionName) {

--- a/modules/swagger-parser/src/test/resources/issue_643.yaml
+++ b/modules/swagger-parser/src/test/resources/issue_643.yaml
@@ -1,0 +1,25 @@
+---
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Sample Issue
+  description: API
+  termsOfService: TBD
+  contact:
+    name: API Team
+  license:
+    name: MIT
+host: xyz.com
+basePath: ''
+schemes:
+- https
+consumes:
+- application/json
+produces:
+- application/json
+paths:
+  "/xyz":
+    "$ref": "./xyz.yaml#/do_xyz"
+definitions:
+  XYZResponse:
+    "$ref": "./xyz.yaml#/definitions/XYZResponse"

--- a/modules/swagger-parser/src/test/resources/xyz.yaml
+++ b/modules/swagger-parser/src/test/resources/xyz.yaml
@@ -1,0 +1,16 @@
+---
+do_xyz:
+  get:
+    description: do xyz stuff
+    operationId: doXyz
+    produces:
+    - application/json
+    parameters: []
+    responses:
+      '200': {}
+      default: {}
+definitions:
+  XYZResponse:
+    properties:
+      foo:
+        type: string

--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -124,7 +124,7 @@
                 <version>2.7</version>
                 <configuration>
                     <aggregate>true</aggregate>
-                    <source>1.8</source>
+                    <source>1.7</source>
                     <encoding>UTF-8</encoding>
                     <maxmemory>1g</maxmemory>
                     <links>

--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -124,7 +124,7 @@
                 <version>2.7</version>
                 <configuration>
                     <aggregate>true</aggregate>
-                    <source>1.7</source>
+                    <source>1.8</source>
                     <encoding>UTF-8</encoding>
                     <maxmemory>1g</maxmemory>
                     <links>


### PR DESCRIPTION
This PR fixes issue #643 and refactors #590 
It adds a number at the end of a reference definition to avoid duplicates, and adds it to the definitions map.