### PR TITLE
Add ResolverCache to SwaggerParserResult

### DIFF
--- a/modules/swagger-parser-core/pom.xml
+++ b/modules/swagger-parser-core/pom.xml
@@ -16,6 +16,11 @@
             <artifactId>swagger-models</artifactId>
             <version>${swagger-core-version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser-v3</artifactId>
+            <version>${parent.version}</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/modules/swagger-parser-core/src/main/java/io/swagger/v3/parser/core/models/SwaggerParseResult.java
+++ b/modules/swagger-parser-core/src/main/java/io/swagger/v3/parser/core/models/SwaggerParseResult.java
@@ -1,11 +1,14 @@
 package io.swagger.v3.parser.core.models;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.parser.ResolverCache;
+
 import java.util.List;
 
 public class SwaggerParseResult {
     private List<String> messages = null;
     private OpenAPI openAPI;
+    private ResolverCache refsCache;
 
     public SwaggerParseResult messages(List<String> messages) {
         this.messages = messages;
@@ -26,5 +29,13 @@ public class SwaggerParseResult {
 
     public void setOpenAPI(OpenAPI openAPI) {
         this.openAPI = openAPI;
+    }
+
+    public ResolverCache getRefsCache() {
+        return refsCache;
+    }
+
+    public void setRefsCache(ResolverCache refsCache) {
+        this.refsCache = refsCache;
     }
 }

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIResolver.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIResolver.java
@@ -41,6 +41,10 @@ public class OpenAPIResolver {
         operationsProcessor = new OperationProcessor(cache, openApi);
     }
 
+    public ResolverCache getCache() {
+        return cache;
+    }
+
     public OpenAPI resolve() {
         if (openApi == null) {
             return null;

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIV3Parser.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIV3Parser.java
@@ -50,6 +50,7 @@ public class OpenAPIV3Parser implements SwaggerParserExtension {
                 if (version != null && version.startsWith("3.0")) {
                     if (options != null) {
                         OpenAPIResolver resolver = new OpenAPIResolver(result.getOpenAPI(), auth, url);
+                        result.setRefsCache(resolver.getCache());
                         if (options.isResolve()) {
                             result.setOpenAPI(resolver.resolve());
                         }
@@ -174,7 +175,7 @@ public class OpenAPIV3Parser implements SwaggerParserExtension {
                         result = deserializer.deserialize(rootNode);
                         OpenAPIResolver resolver = new OpenAPIResolver(result.getOpenAPI(), auth, null);
                         result.setOpenAPI(resolver.resolve());
-
+                        result.setRefsCache(resolver.getCache());
                     } catch (Exception e) {
                         result.setMessages(Arrays.asList(e.getMessage()));
                     }
@@ -187,7 +188,9 @@ public class OpenAPIV3Parser implements SwaggerParserExtension {
                         result.setMessages(Arrays.asList(e.getMessage()));
                     }
                 }if (options.isResolveFully()){
-                    result.setOpenAPI(new OpenAPIResolver(result.getOpenAPI(), auth, null).resolve());
+                    OpenAPIResolver resolver = new OpenAPIResolver(result.getOpenAPI(), auth, null);
+                    result.setOpenAPI(resolver.resolve());
+                    result.setRefsCache(resolver.getCache());
                     new ResolverFully(options.isResolveCombinators()).resolveFully(result.getOpenAPI());
 
                 }if (options.isFlatten()){

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
@@ -108,13 +108,17 @@ public class ResolverFully {
                 }
             }
 
-            if (op.getRequestBody() != null && op.getRequestBody().getContent() != null){
-                Map<String,MediaType> content = op.getRequestBody().getContent();
-                for (String key: content.keySet()){
-                    if (content.get(key) != null && content.get(key).getSchema() != null ){
-                        Schema resolved = resolveSchema(content.get(key).getSchema());
-                        if (resolved != null) {
-                            content.get(key).setSchema(resolved);
+            if (op.getRequestBody() != null) {
+                if (op.getRequestBody().get$ref() != null)
+
+                if (op.getRequestBody().getContent() != null){
+                    Map<String,MediaType> content = op.getRequestBody().getContent();
+                    for (String key: content.keySet()){
+                        if (content.get(key) != null && content.get(key).getSchema() != null ){
+                            Schema resolved = resolveSchema(content.get(key).getSchema());
+                            if (resolved != null) {
+                                content.get(key).setSchema(resolved);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Added ResolverCache to SwaggerParserResult, avoiding reusing the actual cache of references without creating a new one. Refeers to #669 