### PR TITLE
Bugfix/issue 673 missing properties body parameter convertion parser

### DIFF
--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -71,11 +71,8 @@ public class V2ConverterTest {
     private static final String ISSUE_540_JSON = "issue-540.json";
     private static final String ISSUE_647_JSON = "issue-647.yaml";
     private static final String ISSUE_662_JSON = "issue-662.yaml";
-<<<<<<< Updated upstream
-    private static final String ISSUE_676_JSON = "issue-676.json";
-=======
     private static final String ISSUE_673_YAML = "issue-673.yaml";
->>>>>>> Stashed changes
+    private static final String ISSUE_676_JSON = "issue-676.json";
 
     private static final String API_BATCH_PATH = "/api/batch/";
     private static final String PETS_PATH = "/pets";
@@ -557,7 +554,6 @@ public class V2ConverterTest {
         assertTrue(oas.getPaths().isEmpty());
     }
 
-<<<<<<< Updated upstream
     @Test(description = "OpenAPI v2 converter - integer elements of enum are converted to String")
     public void testIssue676() throws Exception {
         OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_676_JSON);
@@ -580,15 +576,12 @@ public class V2ConverterTest {
         assertEquals(anEnum.get(1), false);
     }
 
-=======
     @Test(description = "OpenAPI v2 converter - Error in BodyParameter convertion")
     public void testIssue673() throws Exception {
         OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_673_YAML);
         assertNotNull(oas);
     }
 
-
->>>>>>> Stashed changes
     private OpenAPI getConvertedOpenAPIFromJsonFile(String file) throws IOException, URISyntaxException {
         SwaggerConverter converter = new SwaggerConverter();
         String swaggerAsString = new String(Files.readAllBytes(Paths.get(getClass().getClassLoader().getResource(file).toURI())));

--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -383,7 +383,7 @@ public class V2ConverterTest {
         OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_23_JSON);
         assertTrue(oas.getComponents().getSchemas().get(MAP_OBJECTS_MODEL).getAdditionalProperties() instanceof Schema);
         Schema additionalProperties = (Schema) oas.getComponents().getSchemas().get(MAP_OBJECTS_MODEL).getAdditionalProperties();
-        assertEquals(OBJECT_REF,additionalProperties.get$ref());
+        assertEquals(OBJECT_REF, additionalProperties.get$ref());
     }
 
     @Test(description = "Covert path item $refs")
@@ -578,8 +578,22 @@ public class V2ConverterTest {
 
     @Test(description = "OpenAPI v2 converter - Error in BodyParameter convertion")
     public void testIssue673() throws Exception {
-        OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_673_YAML);
+        final OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_673_YAML);
         assertNotNull(oas);
+        Schema schema = oas.getPaths().get("/integer").getPost().getRequestBody().getContent().get("application/json").getSchema();
+        assertNotNull(schema);
+        assertTrue(schema.getUniqueItems());
+        assertTrue(schema.getExclusiveMaximum());
+        assertTrue(schema.getExclusiveMinimum());
+        assertEquals(3, schema.getMultipleOf().toBigInteger().intValue());
+        assertEquals(new BigDecimal(5), schema.getMinimum());
+        assertEquals(new BigDecimal(7), schema.getMaximum());
+
+        schema = oas.getPaths().get("/string").getPost().getRequestBody().getContent().get("application/json").getSchema();
+        assertEquals(2, schema.getMinLength().intValue());
+        assertEquals(7, schema.getMaxLength().intValue());
+        assertEquals("aaa", schema.getPattern());
+
     }
 
     private OpenAPI getConvertedOpenAPIFromJsonFile(String file) throws IOException, URISyntaxException {

--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -71,7 +71,11 @@ public class V2ConverterTest {
     private static final String ISSUE_540_JSON = "issue-540.json";
     private static final String ISSUE_647_JSON = "issue-647.yaml";
     private static final String ISSUE_662_JSON = "issue-662.yaml";
+<<<<<<< Updated upstream
     private static final String ISSUE_676_JSON = "issue-676.json";
+=======
+    private static final String ISSUE_673_YAML = "issue-673.yaml";
+>>>>>>> Stashed changes
 
     private static final String API_BATCH_PATH = "/api/batch/";
     private static final String PETS_PATH = "/pets";
@@ -553,6 +557,7 @@ public class V2ConverterTest {
         assertTrue(oas.getPaths().isEmpty());
     }
 
+<<<<<<< Updated upstream
     @Test(description = "OpenAPI v2 converter - integer elements of enum are converted to String")
     public void testIssue676() throws Exception {
         OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_676_JSON);
@@ -575,6 +580,15 @@ public class V2ConverterTest {
         assertEquals(anEnum.get(1), false);
     }
 
+=======
+    @Test(description = "OpenAPI v2 converter - Error in BodyParameter convertion")
+    public void testIssue673() throws Exception {
+        OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_673_YAML);
+        assertNotNull(oas);
+    }
+
+
+>>>>>>> Stashed changes
     private OpenAPI getConvertedOpenAPIFromJsonFile(String file) throws IOException, URISyntaxException {
         SwaggerConverter converter = new SwaggerConverter();
         String swaggerAsString = new String(Files.readAllBytes(Paths.get(getClass().getClassLoader().getResource(file).toURI())));

--- a/modules/swagger-parser-v2-converter/src/test/resources/issue-673.yaml
+++ b/modules/swagger-parser-v2-converter/src/test/resources/issue-673.yaml
@@ -21,6 +21,7 @@ paths:
           maximum: 7
           exclusiveMinimum: true
           exclusiveMaximum: true
+          uniqueItems: true
   "/array":
     post:
       consumes:

--- a/modules/swagger-parser-v2-converter/src/test/resources/issue-673.yaml
+++ b/modules/swagger-parser-v2-converter/src/test/resources/issue-673.yaml
@@ -1,0 +1,53 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Test
+paths:
+  "/integer":
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          type: integer
+          format: int32
+          multipleOf: 3
+          minimum: 5
+          maximum: 7
+          exclusiveMinimum: true
+          exclusiveMaximum: true
+  "/array":
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
+  "/string":
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          type: string
+          minLength: 2
+          maxLength: 7
+          pattern: aaa

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
         </repository>
     </repositories>
     <properties>
-        <swagger-parser-v2-version>1.0.35</swagger-parser-v2-version>
+        <swagger-parser-v2-version>1.0.36-SNAPSHOT</swagger-parser-v2-version>
         <commons-io-version>2.4</commons-io-version>
         <slf4j-version>1.6.3</slf4j-version>
         <swagger-core-version>2.0.1</swagger-core-version>


### PR DESCRIPTION
Tests in Converter to Check if the new Properties added in the: https://github.com/swagger-api/swagger-core/pull/2768 are being converted. 

There's a dependency in the Swagger Parser Master PR: https://github.com/swagger-api/swagger-parser/pull/687

The SwaggerDeserialize changed to consider this new properties.

Related issue: https://github.com/swagger-api/swagger-parser/issues/673