### PR TITLE
Delegate resolving of relative URLs to Java framework

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
@@ -17,6 +17,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 public class RefUtils {
 
@@ -79,46 +81,8 @@ public class RefUtils {
 
     }
 
-    public static String buildUrl(String rootPath, String relativePath) {
-        String[] rootPathParts = rootPath.split("/");
-        String [] relPathParts = relativePath.split("/");
-
-        if(rootPath == null || relativePath == null) {
-            return null;
-        }
-
-        int trimRoot = 0;
-        int trimRel = 0;
-
-        if(!"".equals(rootPathParts[rootPathParts.length - 1])) {
-            trimRoot = 1;
-        }
-        for(int i = 0; i < rootPathParts.length; i++) {
-            if("".equals(rootPathParts[i])) {
-                trimRel += 1;
-            }
-            else {
-                break;
-            }
-        }
-        for(int i = 0; i < relPathParts.length; i ++) {
-            if(".".equals(relPathParts[i])) {
-                trimRel += 1;
-            }
-            else if ("..".equals(relPathParts[i])) {
-                trimRel += 1;
-            }
-        }
-
-        String [] outputParts = new String[rootPathParts.length + relPathParts.length - trimRoot - trimRel];
-        System.arraycopy(rootPathParts, 0, outputParts, 0, rootPathParts.length - trimRoot);
-        System.arraycopy(relPathParts,
-                trimRel,
-                outputParts,
-                rootPathParts.length - trimRoot + trimRel - 1,
-                relPathParts.length - trimRel);
-
-        return StringUtils.join(outputParts, "/");
+    public static String buildUrl(String rootPath, String relativePath) throws URISyntaxException {
+        return new URI(rootPath).resolve(new URI(relativePath)).toString();
     }
 
 


### PR DESCRIPTION
Delegate resolving of relative URLs to Java framework, instead of solving that in custom code. 

Fix swagger-api/swagger-parser#750

## Repro

```Java
String rootPath = "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/storage/resource-manager/Microsoft.Storage/stable/2018-02-01/storage.json";
String relativePath = "../../../../../common-types/resource-management/v1/types.json";
String expected="https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/common-types/resource-management/v1/types.json";
System.out.println(io.swagger.parser.util.RefUtils.buildUrl(rootPath, relativePath));
```

results in an `ArrayIndexOutOfBoundsException`:

```txt
Exception in thread "main" java.lang.RuntimeException: Unable to load RELATIVE ref: ../../../../../common-types/resource-management/v1/types.json path:https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/storage/resource-manager/Microsoft.Storage/stable/2018-02-01/storage.json
        at io.swagger.parser.util.RefUtils.readExternalUrlRef(RefUtils.java:68)
        at io.swagger.parser.ResolverCache.loadRef(ResolverCache.java:116)
        at io.swagger.parser.processors.ParameterProcessor.processParameters(ParameterProcessor.java:37)
        at io.swagger.parser.processors.OperationProcessor.processOperation(OperationProcessor.java:26)
        at io.swagger.parser.processors.PathsProcessor.processPaths(PathsProcessor.java:101)
        at io.swagger.parser.SwaggerResolver.resolve(SwaggerResolver.java:50)
        at io.swagger.parser.SwaggerParser.read(SwaggerParser.java:71)
        at io.swagger.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:431)
        at io.swagger.codegen.cmd.Generate.run(Generate.java:283)
        at io.swagger.codegen.SwaggerCodegen.main(SwaggerCodegen.java:35)
Caused by: java.lang.ArrayIndexOutOfBoundsException
        at java.lang.System.arraycopy(Native Method)
        at io.swagger.parser.util.RefUtils.buildUrl(RefUtils.java:108)
        at io.swagger.parser.util.RefUtils.readExternalUrlRef(RefUtils.java:63)
```

I experienced that when using the codegen CLI:

```bash
java -jar swagger-codegen-cli.jar generate \
    -l elixir \
    -i "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/storage/resource-manager/Microsoft.Storage/stable/2018-02-01/storage.json"
```