### PR TITLE
Fix for issue 758

### DIFF
--- a/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
+++ b/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
@@ -1007,7 +1007,7 @@ public class SwaggerConverter implements SwaggerParserExtension {
 
             if (sp.getEnum() != null) {
                 for (String e : sp.getEnum()) {
-                    switch (sp.getType()) {
+                    switch (sp.getType() == null ? SchemaTypeUtil.OBJECT_TYPE : sp.getType()) {
                         case SchemaTypeUtil.INTEGER_TYPE:
                             schema.addEnumItemObject(Integer.parseInt(e));
                             break;

--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -77,6 +77,7 @@ public class V2ConverterTest {
     private static final String ISSUE_673_YAML = "issue-673.yaml";
     private static final String ISSUE_676_JSON = "issue-676.json";
     private static final String ISSUE_708_YAML = "issue-708.yaml";
+    private static final String ISSUE_758_JSON = "issue-758.json";
 
     private static final String API_BATCH_PATH = "/api/batch/";
     private static final String PETS_PATH = "/pets";
@@ -614,6 +615,12 @@ public class V2ConverterTest {
         assertEquals(schema.getMinLength(), Integer.valueOf(1));
         assertEquals(schema.getMaxLength(), Integer.valueOf(3));
         assertEquals(schema.getPattern(), "^[0-9]+$");
+    }
+
+    @Test(description = "OpenAPI v2 converter - NPE when 'enum' field is available and 'type' field is missing in query parameter")
+    public void testIssue758() throws Exception {
+        final OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_758_JSON);
+        assertNotNull(oas);
     }
 
     @Test(description = "OpenAPI v2 converter - Missing Parameter.style property")

--- a/modules/swagger-parser-v2-converter/src/test/resources/issue-758.json
+++ b/modules/swagger-parser-v2-converter/src/test/resources/issue-758.json
@@ -1,0 +1,29 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "version" : "1",
+    "title" : "EchoSoap"
+  },
+  "paths" : {
+    "/echo" : {
+      "post" : {
+        "parameters" : [           {
+          "name": "sort",
+          "in": "query",
+          "required": false,
+          "enum": [
+            "forks",
+            "stars",
+            "updated"
+          ],
+          "description": "If not provided, results are sorted by best match."
+        }],
+        "responses" : {
+          "200" : {
+            "description" : "Dummy response"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi team,

This PR is to solve the issue 'OpenAPI v2 Converter: NPE when 'enum' field is available and 'type' field is missing in query parameter' as mentioned in #758 

Please review the PR and merge the same.

Thanks,
Mohammed