### PR TITLE
Fix #760: Travis change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,9 @@ script: mvn verify
 jdk:
   - oraclejdk8
   - oraclejdk9
-after_success:
-  - if [ $SONATYPE_USERNAME ] && [ -z $TRAVIS_TAG ] && [ $TRAVIS_PULL_REQUEST == false ]; then
-      mvn clean deploy --settings .travis/settings.xml;
-    fi;
-branches:
-  only:
-  - master
-  - 2.0
+jobs:
+  include:
+    - stage: deploy
+      if: env(SONATYPE_USERNAME) IS present AND type IN (push, api) AND branch IN (master, 2.0) AND tag IS blank
+      jdk: oraclejdk8
+      script: mvn clean deploy --settings .travis/settings.xml


### PR DESCRIPTION
See the explanations in #760.

This PR changes the travis file.

* Create a new stage named `"deploy"` instead of `after_success` for the `mvn clean deploy` command
* Remove global "branches" filter (at the end of the file) => This way Travis also runs on PRs
* Use travis condition on the `"deploy"` stage to replace:
   - the filter at the end of the file `branch IN (master, 2.0)`
   - the if in the bash script
        - `if [ $SONATYPE_USERNAME ]` replaced by travis condition: `env(SONATYPE_USERNAME) IS present`
        - `[ -z $TRAVIS_TAG ]` replaced by travis condition: `tag IS blank`
        - `[ $TRAVIS_PULL_REQUEST == false ]` replaced by travis condition: `type IN (push, api)` (to exclude types `cron` and `pull_request`)