### PR TITLE
Fix for issue 762

### DIFF
--- a/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
+++ b/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
@@ -812,6 +812,9 @@ public class SwaggerConverter implements SwaggerParserExtension {
     }
 
     private Schema convert(Property schema) {
+        if (schema == null) {
+            return null;
+        }
         Schema result;
 
         if (schema instanceof RefProperty) {

--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -77,6 +77,7 @@ public class V2ConverterTest {
     private static final String ISSUE_673_YAML = "issue-673.yaml";
     private static final String ISSUE_676_JSON = "issue-676.json";
     private static final String ISSUE_708_YAML = "issue-708.yaml";
+    private static final String ISSUE_762_JSON = "issue-762.json";
 
     private static final String API_BATCH_PATH = "/api/batch/";
     private static final String PETS_PATH = "/pets";
@@ -614,6 +615,12 @@ public class V2ConverterTest {
         assertEquals(schema.getMinLength(), Integer.valueOf(1));
         assertEquals(schema.getMaxLength(), Integer.valueOf(3));
         assertEquals(schema.getPattern(), "^[0-9]+$");
+    }
+
+    @Test(description = "OpenAPI v2 Converter: NPE when type is array and 'items' field is missing in array property")
+    public void testIssue762() throws Exception {
+        final OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_762_JSON);
+        assertNotNull(oas);
     }
 
     @Test(description = "OpenAPI v2 converter - Missing Parameter.style property")

--- a/modules/swagger-parser-v2-converter/src/test/resources/issue-762.json
+++ b/modules/swagger-parser-v2-converter/src/test/resources/issue-762.json
@@ -1,0 +1,47 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "PetStore on Heroku",
+    "description": "**This example has a working backend hosted in Heroku**\n\nYou can try all HTTP operation described in this Swagger spec.\n\nFind source code of this API [here](https://github.com/mohsen1/petstore-api)\n"
+  },
+  "host": "petstore-api.herokuapp.com",
+  "basePath": "/pet",
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "paths": {
+    "/": {
+      "put": {
+        "parameters": [
+          {
+            "name": "pet",
+            "in": "body",
+            "description": "The pet JSON you want to post",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updates the pet"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "required" : ["name"],
+      "properties": {
+        "name": {
+          "type": "array"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi team,

This PR is to fix the issue 'OpenAPI v2 Converter: NPE when type is array and 'items' field is missing in array property' [762](https://github.com/swagger-api/swagger-parser/issues/762).

Please review the PR and merge the same.

Thanks,
Mohammed