### PR TITLE
Fix for issue 786 (Open API V2 Converter: NPE when flow field is missing in securityDefinitions)

### DIFF
--- a/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
+++ b/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
@@ -295,25 +295,28 @@ public class SwaggerConverter implements SwaggerParserExtension {
         OAuthFlow oAuthFlow = new OAuthFlow();
 
         securityScheme.setType(SecurityScheme.Type.OAUTH2);
+        String flow = oAuth2Definition.getFlow();
 
-        switch (oAuth2Definition.getFlow()) {
-            case "implicit":
-                oAuthFlow.setAuthorizationUrl(oAuth2Definition.getAuthorizationUrl());
-                oAuthFlows.setImplicit(oAuthFlow);
-                break;
-            case "password":
-                oAuthFlow.setTokenUrl(oAuth2Definition.getTokenUrl());
-                oAuthFlows.setPassword(oAuthFlow);
-                break;
-            case "application":
-                oAuthFlow.setTokenUrl(oAuth2Definition.getTokenUrl());
-                oAuthFlows.setClientCredentials(oAuthFlow);
-                break;
-            case "accessCode":
-                oAuthFlow.setAuthorizationUrl(oAuth2Definition.getAuthorizationUrl());
-                oAuthFlow.setTokenUrl(oAuth2Definition.getTokenUrl());
-                oAuthFlows.setAuthorizationCode(oAuthFlow);
-                break;
+        if (flow != null) {
+            switch (flow) {
+                case "implicit":
+                    oAuthFlow.setAuthorizationUrl(oAuth2Definition.getAuthorizationUrl());
+                    oAuthFlows.setImplicit(oAuthFlow);
+                    break;
+                case "password":
+                    oAuthFlow.setTokenUrl(oAuth2Definition.getTokenUrl());
+                    oAuthFlows.setPassword(oAuthFlow);
+                    break;
+                case "application":
+                    oAuthFlow.setTokenUrl(oAuth2Definition.getTokenUrl());
+                    oAuthFlows.setClientCredentials(oAuthFlow);
+                    break;
+                case "accessCode":
+                    oAuthFlow.setAuthorizationUrl(oAuth2Definition.getAuthorizationUrl());
+                    oAuthFlow.setTokenUrl(oAuth2Definition.getTokenUrl());
+                    oAuthFlows.setAuthorizationCode(oAuthFlow);
+                    break;
+            }
         }
 
         Scopes scopes = new Scopes();

--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -77,6 +77,7 @@ public class V2ConverterTest {
     private static final String ISSUE_673_YAML = "issue-673.yaml";
     private static final String ISSUE_676_JSON = "issue-676.json";
     private static final String ISSUE_708_YAML = "issue-708.yaml";
+    private static final String ISSUE_768_JSON = "issue-786.json";
 
     private static final String API_BATCH_PATH = "/api/batch/";
     private static final String PETS_PATH = "/pets";
@@ -648,6 +649,12 @@ public class V2ConverterTest {
         SwaggerParseResult result = converter.readContents(swaggerAsString, null, parseOptions);
 
         assertNotNull(result.getMessages());
+    }
+
+    @Test(description = "OpenAPI v2 converter - Migrate minLength, maxLength and pattern of String property")
+    public void testIssue786() throws Exception {
+        final OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_768_JSON);
+        assertNotNull(oas);
     }
 
     private OpenAPI getConvertedOpenAPIFromJsonFile(String file) throws IOException, URISyntaxException {

--- a/modules/swagger-parser-v2-converter/src/test/resources/issue-786.json
+++ b/modules/swagger-parser-v2-converter/src/test/resources/issue-786.json
@@ -1,0 +1,32 @@
+{
+  "swagger": "2.0",
+  "host" : "localhost",
+  "info": {
+    "version": "1.0.9-abcd",
+    "title": "Swagger Sample API Security Example",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Creative Commons 4.0 International",
+      "url": "http://creativecommons.org/licenses/by/4.0/"
+    }
+  },
+  "basePath": "/v1",
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "securityDefinitions": {
+    "petstoreImplicit": {
+      "type": "oauth2",
+      "scopes": {
+        "user": "Grants read/write access to profile info only. Note that this scope includes user:email and user:follow."
+      },
+      "authorizationUrl": "http://petstore.swagger.io/oauth/dialog"
+    }
+  }
+}


### PR DESCRIPTION
Hi team,

This PR is to solve the issue #786 (Open API V2 Converter: NPE when flow field is missing in securityDefinitions (OAS 2 to 3 conversion))

Please review the PR and merge the same.

Thanks,
Mohammed