### PR TITLE
Fix for issue 785 (OpenAPIParser.readLocation fails when fetching valid Swagger 2.0 resource with AuthorizationValues provided)

### DIFF
--- a/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
+++ b/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
@@ -115,6 +115,7 @@ public class SwaggerConverter implements SwaggerParserExtension {
                 v.setType(auth.getType());
                 v.setValue(auth.getValue());
                 v.setKeyName(auth.getKeyName());
+                convertedAuth.add(v);
             }
         }
 

--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.models.security.OAuthFlow;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.tags.Tag;
 import io.swagger.v3.parser.converter.SwaggerConverter;
+import io.swagger.v3.parser.core.models.AuthorizationValue;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import org.testng.annotations.Test;
@@ -26,6 +27,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -614,6 +616,15 @@ public class V2ConverterTest {
         assertEquals(schema.getMinLength(), Integer.valueOf(1));
         assertEquals(schema.getMaxLength(), Integer.valueOf(3));
         assertEquals(schema.getPattern(), "^[0-9]+$");
+    }
+
+    @Test(description = "OpenAPIParser.readLocation fails when fetching valid Swagger 2.0 resource with AuthorizationValues provided")
+    public void testIssue785() {
+        AuthorizationValue apiKey = new AuthorizationValue("api_key", "special-key", "header");
+        List<AuthorizationValue> authorizationValues = Arrays.asList(apiKey);
+        SwaggerConverter converter = new SwaggerConverter();
+        List<io.swagger.models.auth.AuthorizationValue> convertedAuthList = converter.convert(authorizationValues);
+        assertEquals(convertedAuthList.size(), authorizationValues.size());
     }
 
     @Test(description = "OpenAPI v2 converter - Missing Parameter.style property")


### PR DESCRIPTION
Hi team,

This PR is to solve the issue #785  (OpenAPIParser.readLocation fails when fetching valid Swagger 2.0 resource with AuthorizationValues provided (OAS 2 to 3 conversion))

Please review the PR and merge the same.

Thanks,
Mohammed