### PR TITLE
Support for empty string as default schema value

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -2125,7 +2125,7 @@ public class OpenAPIDeserializer {
         }
 
         value = getString("default", node, false, location, result);
-        if (StringUtils.isNotBlank(value)) {
+        if (value != null) {
             schema.setDefault(value);
         }
 


### PR DESCRIPTION
Fix #814

`isBlank` resulted in the default value not being parsed, when the field was in fact explicitly set.

Now we would only consider null as the absence of a field in the specification.