### PR TITLE
Use ${project.parent.version} instead of ${parent.version}

### DIFF
--- a/modules/swagger-parser-v2-converter/pom.xml
+++ b/modules/swagger-parser-v2-converter/pom.xml
@@ -30,12 +30,12 @@
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser-core</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser-v3</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/modules/swagger-parser-v3/pom.xml
+++ b/modules/swagger-parser-v3/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser-core</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>

--- a/modules/swagger-parser/pom.xml
+++ b/modules/swagger-parser/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser-v2-converter</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser-v3</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>


### PR DESCRIPTION
This PR fixes following Maven warnings:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.openapitools.swagger.parser:swagger-parser-v3:jar:2.0.5-SNAPSHOT
[WARNING] The expression ${parent.version} is deprecated. Please use ${project.parent.version} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.openapitools.swagger.parser:swagger-parser-v2-converter:jar:2.0.5-SNAPSHOT
[WARNING] The expression ${parent.version} is deprecated. Please use ${project.parent.version} instead.
[WARNING] The expression ${parent.version} is deprecated. Please use ${project.parent.version} instead.
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.openapitools.swagger.parser:swagger-parser:jar:2.0.5-SNAPSHOT
[WARNING] The expression ${parent.version} is deprecated. Please use ${project.parent.version} instead.
[WARNING] The expression ${parent.version} is deprecated. Please use ${project.parent.version} instead.
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```