### PR TITLE
Fix NullPointerException when resolving an ApiResponse with no content

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ResolverCache.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ResolverCache.java
@@ -159,8 +159,10 @@ public class ResolverCache {
     protected <T> void updateLocalRefs(String file, T result) {
         if(result instanceof ApiResponse) {
             ApiResponse response = (ApiResponse) result;
-            for(String mediaType : response.getContent().keySet()) {
-                updateLocalRefs(file, response.getContent().get(mediaType).getSchema());
+            if (response.getContent() != null) {
+                for (String mediaType : response.getContent().keySet()) {
+                    updateLocalRefs(file, response.getContent().get(mediaType).getSchema());
+                }
             }
         }
         if(result instanceof Schema && ((Schema)(result)).get$ref() != null) {


### PR DESCRIPTION
This PR fixes a NullPointerException which occurs when an `ApiResponse` is read from an external reference which does not have any content defined.