### PR TITLE
Fix for issue 258 (Code roll-in to Swagger 2.0)

### DIFF
--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -1248,4 +1248,12 @@ public class SwaggerParserTest {
         assertEquals(swagger.getSwagger().getPath("/pets/{id}").getGet().getParameters().get(0).getIn(), "header");
     }
 
+    @Test
+    public void testIssue258() {
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("duplicateOperationId.json", null, true);
+        assertNotNull(result);
+        assertNotNull(result.getSwagger());
+        assertEquals(result.getMessages().get(0), "attribute paths.'/pets/{id}'(post).operationId is repeated");
+    }
+
 }

--- a/modules/swagger-parser/src/test/resources/duplicateOperationId.json
+++ b/modules/swagger-parser/src/test/resources/duplicateOperationId.json
@@ -1,0 +1,27 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.9-abcd",
+    "title": "Duplicate operationID"
+  },
+  "paths": {
+    "/pets/{id}": {
+      "get": {
+        "operationId": "getPetsById",
+        "responses": {
+          "default": {
+            "description": "error payload"
+          }
+        }
+      },
+      "post": {
+        "operationId": "getPetsById",
+        "responses": {
+          "default": {
+            "description": "error payload"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi team,

This PR is to solve the issue #258 (issue warning on duplicate operation ids) in swagger 1.0.40 version parser.

Please review the PR and merge the same.

Thanks,
Mohammed