### PR TITLE
Fix issue #783: update internal refs in external files

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -674,7 +674,7 @@ public final class ExternalRefProcessor {
         RefFormat format = computeRefFormat(subRef.get$ref());
 
         if (!isAnExternalRefFormat(format)) {
-            processRefToExternalSchema(externalFile + subRef.get$ref(), RefFormat.RELATIVE);
+            subRef.set$ref(processRefToExternalSchema(externalFile + subRef.get$ref(), RefFormat.RELATIVE));
             return;
         }
         String $ref = subRef.get$ref();

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
@@ -1102,6 +1102,21 @@ public class OpenAPIResolverTest {
         assertEquals(qp.getName(), "page");
     }
 
+    @Test(description = "update internal references of external files")
+    public void testUpdateInternalReferencesOfExternalFiles() {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+
+        OpenAPI openAPI = new OpenAPIV3Parser().read("internal-references-in-external-files/main.yaml", null, options);
+
+        ComposedSchema commonSchema = (ComposedSchema) openAPI.getComponents().getSchemas().get("common");
+
+        assertEquals(commonSchema.getAllOf().get(0).get$ref(), "#/components/schemas/core");
+        assertEquals(((Schema) commonSchema.getAllOf().get(1).getProperties().get("direct")).get$ref(), "#/components/schemas/core");
+        assertEquals(((ArraySchema) commonSchema.getAllOf().get(1).getProperties().get("referenced")).getItems().get$ref(), "#/components/schemas/core");
+        Schema coreSchema = openAPI.getComponents().getSchemas().get("core");
+        assertEquals(((Schema) coreSchema.getProperties().get("inner")).get$ref(), "#/components/schemas/innerCore");
+    }
 
     public String replacePort(String url){
         String pathFile = url.replace("${dynamicPort}", String.valueOf(this.serverPort));

--- a/modules/swagger-parser-v3/src/test/resources/internal-references-in-external-files/external.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/internal-references-in-external-files/external.yaml
@@ -1,0 +1,27 @@
+common:
+  allOf:
+  - $ref: "#/core"
+  - type: object
+    properties:
+      attribute:
+        type: string
+      direct:
+        $ref: "#/core"
+      referenced:
+        type: array
+        items:
+          $ref: "#/core"
+
+core:
+  type: object
+  properties:
+    coreAttribute:
+      type: string
+    inner:
+      $ref: "#/innerCore"
+
+innerCore:
+  type: object
+  properties:
+    innerCoreAttribute:
+      type: string

--- a/modules/swagger-parser-v3/src/test/resources/internal-references-in-external-files/main.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/internal-references-in-external-files/main.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  version: 0.0.1
+  title: API
+paths:
+  /:
+    post:
+      summary: Create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/create'
+      responses:
+        '200':
+          description: Successful response
+components:
+  schemas:
+    create:
+      type: object
+      properties:
+        attribute:
+          type: string
+        direct:
+          $ref: "./external.yaml#/common"
+        referenced:
+          type: array
+          items:
+            $ref: "./external.yaml#/common"


### PR DESCRIPTION
This fixes issue #783 where internal references in elements originally located in external files were not properly updated once included in the main definition.

Also add a corresponding unit test (thanks to @Tiller for this, I used the unit test from his/her PR : #788 ).