### PR TITLE
ResolveFully creates array example for allOf

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -406,7 +405,11 @@ public class ResolverFully {
                         }
                     }
                 }
-                model.setExample(examples);
+                if (schema.getExample() != null) {
+                    model.setExample(schema.getExample());
+                } else if (!examples.isEmpty()) {
+                    model.setExample(examples);
+                }
                 return model;
             } else {
                 // User don't want to aggregate composed schema, we only solve refs

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
@@ -1,11 +1,13 @@
 package io.swagger.v3.parser.test;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -740,6 +742,20 @@ public class OpenAPIResolverTest {
         Assert.assertTrue(examples.size() == 2);
     }
 
+    @Test
+    public void allOfExampleGeneration(@Injectable final List<AuthorizationValue> auths) throws JsonProcessingException {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        options.setResolveFully(true);
+        OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/resources/simpleAllOf.yaml", null, options);
+
+        Assert.assertNotNull(openAPI);
+        Object withoutExample = openAPI.getPaths().get("/foo").getGet().getResponses().get("200").getContent().get("application/json").getSchema().getExample();
+        Assert.assertNull(withoutExample);
+
+        Object withExample = openAPI.getPaths().get("/bar").getGet().getResponses().get("200").getContent().get("application/json").getSchema().getExample();
+        Assert.assertEquals("{\"someProperty\":\"ABC\",\"someOtherProperty\":42}", Json.mapper().writeValueAsString(withExample));
+    }
 
     @Test
     public void testSwaggerResolver(@Injectable final OpenAPI swagger,

--- a/modules/swagger-parser-v3/src/test/resources/simpleAllOf.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/simpleAllOf.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  version: "1.0.0"
+paths:
+  /foo:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/FirstType'
+                - $ref: '#/components/schemas/SecondType'
+  /bar:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/FirstType'
+                - $ref: '#/components/schemas/SecondType'
+                example:
+                  someProperty: ABC
+                  someOtherProperty: 42
+components:
+  schemas:
+    FirstType:
+      type: object
+      properties:
+        someProperty:
+          type: string
+          example: abc
+    SecondType:
+      type: object
+      properties:
+        someOtherProperty:
+          type: integer
+          example: 10


### PR DESCRIPTION
I have gotten bit how resolveFully treats examples for allOf. Currently it makes an array of all the examples of the items in the allOf list. This will not generate a valid example in most cases.

**Given this spec:**
```
openapi: 3.0.0
info:
  version: "1.0.0"
paths:
  /foo:
    get:
      responses:
        '200':
          content:
            application/json:
              schema:
                allOf:
                - $ref: '#/components/schemas/FirstType'
                - $ref: '#/components/schemas/SecondType'
  /bar:
    get:
      responses:
        '200':
          content:
            application/json:
              schema:
                allOf:
                - $ref: '#/components/schemas/FirstType'
                - $ref: '#/components/schemas/SecondType'
                example:
                  someProperty: ABC
                  someOtherProperty: 42
components:
  schemas:
    FirstType:
      type: object
      properties:
        someProperty:
          type: string
          example: abc
    SecondType:
      type: object
      properties:
        someOtherProperty:
          type: integer
          example: 10
```

**Expected /foo schema example**
```
null
```

**Expected /bar schema example**
```
{
  "someProperty" : "ABC",
  "someOtherProperty" : 100
}
```

**Actual /foo and /bar schema example**
```
[]
```

In this PR I change this behavior in two cases.
* If the allOf contains an example the resolved version of the allOf will contain the same example.
* If non of the items in the allOf contains examples the resolved version of the allOf won't contain any example either.

This will help applications using the resolved specification that now believes `[]` example is the correct example for the allOf.
