### PR TITLE
Recursion and resolveFully can give infinite loop while serializing

### DIFF
--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
@@ -1134,6 +1134,14 @@ public class OpenAPIResolverTest {
         assertEquals(((Schema) coreSchema.getProperties().get("inner")).get$ref(), "#/components/schemas/innerCore");
     }
 
+    @Test
+    public void recursiveResolving() throws JsonProcessingException {
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolveFully(true);
+        OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/resources/recursive.yaml", null, parseOptions);
+        Json.mapper().writeValueAsString(openAPI);
+    }
+
     public String replacePort(String url){
         String pathFile = url.replace("${dynamicPort}", String.valueOf(this.serverPort));
         return pathFile;

--- a/modules/swagger-parser-v3/src/test/resources/recursive.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/recursive.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  version: "0.0.2"
+paths:
+  /myPath:
+    get:
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Outer"
+components:
+  schemas:
+    Outer:
+      allOf:
+      - $ref: "#/components/schemas/Inner"
+    Inner:
+      properties:
+        myProp:
+          type: array
+          items:
+            $ref: "#/components/schemas/Inner"


### PR DESCRIPTION
I'm not sure if the problem is in resolveFully or in swagger-core for the `Json.mapper().writeValueAsString(openAPI)` part.

This PR contains just a failing test pointing at the problem.