### PR TITLE
Testcase showing a regression bug from #943.

### DIFF
--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
@@ -1166,6 +1166,16 @@ public class OpenAPIResolverTest {
         }
     }
 
+    @Test
+    public void propertyNameMixup() {
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolveFully(true);
+        OpenAPI openAPI = new OpenAPIV3Parser().read("simple.yaml", null, parseOptions);
+        assertEquals(((StringSchema)openAPI.getComponents().getSchemas().get("Manufacturer").getProperties().get("name")).getExample(), "ACME Corporation");
+        Schema schema = openAPI.getPaths().get("/inventory").getGet().getResponses().get("200").getContent().get("application/json").getSchema();
+        assertEquals(((ObjectSchema) ((ArraySchema) schema).getItems().getProperties().get("manufacturer")).getProperties().get("name").getExample(), "ACME Corporation");
+    }
+
     public String replacePort(String url){
         String pathFile = url.replace("${dynamicPort}", String.valueOf(this.serverPort));
         return pathFile;

--- a/modules/swagger-parser-v3/src/test/resources/simple.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/simple.yaml
@@ -1,0 +1,115 @@
+openapi: 3.0.0
+info:
+  description: This is a simple API
+  version: "1.0.0"
+  title: Simple Inventory API
+  contact:
+    email: you@your-company.com
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+- name: admins
+  description: Secured Admin-only calls
+- name: developers
+  description: Operations available to regular developers
+paths:
+  /inventory:
+    get:
+      tags:
+      - developers
+      summary: searches inventory
+      operationId: searchInventory
+      description: |
+        By passing in the appropriate options, you can search for
+        available inventory in the system
+      parameters:
+      - in: query
+        name: searchString
+        description: pass an optional search string for looking up inventory
+        required: false
+        schema:
+          type: string
+      - in: query
+        name: skip
+        description: number of records to skip for pagination
+        schema:
+          type: integer
+          format: int32
+          minimum: 0
+      - in: query
+        name: limit
+        description: maximum number of records to return
+        schema:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 50
+      responses:
+        '200':
+          description: search results matching criteria
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InventoryItem'
+        '400':
+          description: bad input parameter
+    post:
+      tags:
+      - admins
+      summary: adds an inventory item
+      operationId: addInventory
+      description: Adds an item to the system
+      responses:
+        '201':
+          description: item created
+        '400':
+          description: 'invalid input, object invalid'
+        '409':
+          description: an existing item already exists
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InventoryItem'
+        description: Inventory item to add
+components:
+  schemas:
+    InventoryItem:
+      type: object
+      required:
+      - id
+      - name
+      - manufacturer
+      - releaseDate
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: d290f1ee-6c54-4b01-90e6-d701748f0851
+        name:
+          type: string
+          example: Widget Adapter
+        releaseDate:
+          type: string
+          format: date-time
+          example: '2016-08-29T09:12:33.001Z'
+        manufacturer:
+          $ref: '#/components/schemas/Manufacturer'
+    Manufacturer:
+      required:
+      - name
+      properties:
+        name:
+          type: string
+          example: ACME Corporation
+        homePage:
+          type: string
+          format: url
+          example: 'https://www.acme-corp.com'
+        phone:
+          type: string
+          example: 408-867-5309
+      type: object


### PR DESCRIPTION
The property "name" is used in two places with different example values. They get the same example value after resolveFully.

Introduced in 2.0.6 and exists in 2.0.7 too.