### PR TITLE
Support attribute 'required' in composedModel

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -983,6 +983,22 @@ public class SwaggerDeserializer {
 
                     value = getString("description", node, false, location, result);
                     model.setDescription(value);
+                    
+                    ArrayNode required = getArray("required", node, false, location, result);
+                    if(required != null) {
+                        List<String> requiredProperties = new ArrayList<String>();
+                        for (JsonNode n : required) {
+                            if(n.getNodeType().equals(JsonNodeType.STRING)) {
+                                requiredProperties.add(((TextNode) n).textValue());
+                            }
+                            else {
+                                result.invalidType(location, "required", "string", n);
+                            }
+                        }
+                        if(requiredProperties.size() > 0) {
+                            model.setRequired(requiredProperties);
+                        }
+                    }
                 }
             }
 

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -1,5 +1,6 @@
 package io.swagger.parser;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.models.ArrayModel;
 import io.swagger.models.ComposedModel;
@@ -1504,5 +1505,12 @@ public class SwaggerParserTest {
         Assert.assertNotNull(swagger);
         Assert.assertNotNull(swagger.getDefinitions().get("indicatorType"));
         Assert.assertEquals(swagger.getDefinitions().get("indicatorType").getProperties().size(),1);
+    }
+
+    @Test
+    public void testAllOfRequired() throws JsonProcessingException {
+        Swagger swagger = new SwaggerParser().read("allOf-required/file.yaml");
+        assertTrue(swagger.getDefinitions().get("composed") instanceof ComposedModel);
+        assertEquals(Arrays.asList("field", "field2"), ((ComposedModel) swagger.getDefinitions().get("composed")).getRequired());
     }
 }

--- a/modules/swagger-parser/src/test/resources/allOf-required/file.yaml
+++ b/modules/swagger-parser/src/test/resources/allOf-required/file.yaml
@@ -1,0 +1,34 @@
+---
+swagger: "2.0"
+info:
+  version: "2.0"
+  title: "API"
+basePath: "/api"
+produces:
+- "application/json"
+paths:
+  /:
+    get:
+      description: path
+      responses:
+        200:
+          description: "ok"
+          schema:
+            $ref: "#/definitions/composed"
+definitions:
+  common:
+    type: "object"
+    properties:
+      field:
+        type: "string"
+  composed:
+    type: "object"
+    required:
+      - field
+      - field2
+    allOf:
+      - $ref: "#/definitions/common"
+      - type: "object"
+        properties:
+          field2:
+            type: "string"


### PR DESCRIPTION
This PR adds support for the 'required' attribute in ComposedModel, allowing to specify fields defined in referenced definitions as mandatory for this definition.

It requires https://github.com/swagger-api/swagger-core/pull/3068