### PR TITLE
Add maven-enforcer-plugin to prevent SNAPSHOT usage in releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,28 @@
                     </rules>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <id>enforce-no-snapshots</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireReleaseDeps>
+                                    <message>No Snapshots Allowed!</message>
+                                    <onlyWhenRelease>true</onlyWhenRelease>
+                                </requireReleaseDeps>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencyManagement>


### PR DESCRIPTION
To prevent having SNAPSHOT versions in the dependency tree in released versions, I propose to add the `maven-enforcer-plugin` to the build with the `requireReleaseDeps` activated for release build.

Because this project is using SNAPSHOT versions during development, I think that using `onlyWhenRelease = true` is the appropriate setting for this project.

Documentation: https://maven.apache.org/enforcer/enforcer-rules/requireReleaseDeps.html

Related:
* https://github.com/swagger-api/swagger-parser/issues/1053
* https://github.com/swagger-api/swagger-parser/pull/829#issuecomment-418793197