### PR TITLE
OpenAPIV3Parser#getExtensions() not finding extensions on OSGi #1003

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIV3Parser.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIV3Parser.java
@@ -197,19 +197,36 @@ public class OpenAPIV3Parser implements SwaggerParserExtension {
         return result;
     }
 
+    /**
+     * Locates extensions on the current thread class loader and then, if it differs
+     * from this class classloader (as in OSGi), locates extensions from this
+     * class classloader as well.
+     * 
+     * @return
+     */
     protected List<SwaggerParserExtension> getExtensions() {
-        List<SwaggerParserExtension> extensions = new ArrayList<>();
-
-        ServiceLoader<SwaggerParserExtension> loader = ServiceLoader.load(SwaggerParserExtension.class);
-        Iterator<SwaggerParserExtension> itr = loader.iterator();
-        while (itr.hasNext()) {
-            extensions.add(itr.next());
+	ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        List<SwaggerParserExtension> extensions = getExtensions(tccl);
+        ClassLoader cl = SwaggerParserExtension.class.getClassLoader();
+        if (cl != tccl) {
+            extensions.addAll(getExtensions(cl));
         }
         extensions.add(0, new OpenAPIV3Parser());
         return extensions;
     }
 
-    /**
+    protected List<SwaggerParserExtension> getExtensions(ClassLoader cl) {
+        List<SwaggerParserExtension> extensions = new ArrayList<>();
+
+        ServiceLoader<SwaggerParserExtension> loader = ServiceLoader.load(SwaggerParserExtension.class, cl);
+        Iterator<SwaggerParserExtension> itr = loader.iterator();
+        while (itr.hasNext()) {
+            extensions.add(itr.next());
+        }
+        return extensions;
+    }
+
+   /**
      * Transform the swagger-model version of AuthorizationValue into a parser-specific one, to avoid
      * dependencies across extensions
      *

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIV3Parser.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIV3Parser.java
@@ -202,10 +202,10 @@ public class OpenAPIV3Parser implements SwaggerParserExtension {
      * from this class classloader (as in OSGi), locates extensions from this
      * class classloader as well.
      * 
-     * @return
+     * @return a list of extensions
      */
     protected List<SwaggerParserExtension> getExtensions() {
-	ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
         List<SwaggerParserExtension> extensions = getExtensions(tccl);
         ClassLoader cl = SwaggerParserExtension.class.getClassLoader();
         if (cl != tccl) {

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -1801,6 +1801,19 @@ public class OpenAPIV3ParserTest {
         assertThat(((Schema) modelSchema.getProperties().get("id")).get$ref(), equalTo("#/components/schemas/ValueId"));
     }
 
+    @Test(description = "Test that extensions can be found on the class classloader in addition to tccl.")
+    public void testIssue1003_ExtensionsClassloader() {
+	ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+	try {
+	    // Temporarily switch tccl to an unproductive cl
+	    final ClassLoader tcclTemp = new java.net.URLClassLoader(new java.net.URL[] {}, ClassLoader.getSystemClassLoader());
+	    Thread.currentThread().setContextClassLoader(tcclTemp);
+	    assertNotNull(new OpenAPIV3Parser().read("src/test/resources/test.yaml"));
+	} finally {
+	    Thread.currentThread().setContextClassLoader(tccl);
+	}
+    }
+
     private static int getDynamicPort() {
         return new Random().ints(10000, 20000).findFirst().getAsInt();
     }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -1803,15 +1803,18 @@ public class OpenAPIV3ParserTest {
 
     @Test(description = "Test that extensions can be found on the class classloader in addition to tccl.")
     public void testIssue1003_ExtensionsClassloader() {
-	ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-	try {
-	    // Temporarily switch tccl to an unproductive cl
-	    final ClassLoader tcclTemp = new java.net.URLClassLoader(new java.net.URL[] {}, ClassLoader.getSystemClassLoader());
-	    Thread.currentThread().setContextClassLoader(tcclTemp);
-	    assertNotNull(new OpenAPIV3Parser().read("src/test/resources/test.yaml"));
-	} finally {
-	    Thread.currentThread().setContextClassLoader(tccl);
-	}
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        OpenAPI api = null;
+        try {
+            // Temporarily switch tccl to an unproductive cl
+            final ClassLoader tcclTemp = new java.net.URLClassLoader(new java.net.URL[] {},
+                ClassLoader.getSystemClassLoader());
+            Thread.currentThread().setContextClassLoader(tcclTemp);
+            api = new OpenAPIV3Parser().read("src/test/resources/test.yaml");
+        } finally {
+            Thread.currentThread().setContextClassLoader(tccl);
+        }
+        assertNotNull(api);
     }
 
     private static int getDynamicPort() {


### PR DESCRIPTION
**What is the problem:** When swagger-parser is used in an OSGi bundle, it fails to find extensions because it only looks into the current thread classloader. In an OSGi environment, swagger itself and its extensions (like v2 support) are not available from the tccl.

**What is the solution:** Load extensions from both tccl and the SwaggerParserExtension classloader 