### PR TITLE
OpenAPIV3Parser#getExtensions() not finding extensions on OSGi #1003. Applying same fix to OpenAPIParser

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIV3Parser.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIV3Parser.java
@@ -204,7 +204,7 @@ public class OpenAPIV3Parser implements SwaggerParserExtension {
      * 
      * @return a list of extensions
      */
-    protected List<SwaggerParserExtension> getExtensions() {
+    public static List<SwaggerParserExtension> getExtensions() {
         ClassLoader tccl = Thread.currentThread().getContextClassLoader();
         List<SwaggerParserExtension> extensions = getExtensions(tccl);
         ClassLoader cl = SwaggerParserExtension.class.getClassLoader();
@@ -215,7 +215,7 @@ public class OpenAPIV3Parser implements SwaggerParserExtension {
         return extensions;
     }
 
-    protected List<SwaggerParserExtension> getExtensions(ClassLoader cl) {
+    protected static List<SwaggerParserExtension> getExtensions(ClassLoader cl) {
         List<SwaggerParserExtension> extensions = new ArrayList<>();
 
         ServiceLoader<SwaggerParserExtension> loader = ServiceLoader.load(SwaggerParserExtension.class, cl);

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/OpenAPIParser.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/OpenAPIParser.java
@@ -6,16 +6,13 @@ import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.ServiceLoader;
 
 public class OpenAPIParser {
     public SwaggerParseResult readLocation(String url, List<AuthorizationValue> auth, ParseOptions options) {
         SwaggerParseResult output = null;
 
-        for(SwaggerParserExtension extension : getExtensions()) {
+        for(SwaggerParserExtension extension : OpenAPIV3Parser.getExtensions()) {
             output = extension.readLocation(url, auth, options);
             if(output != null && output.getOpenAPI() != null) {
                 return output;
@@ -28,7 +25,7 @@ public class OpenAPIParser {
     public SwaggerParseResult readContents(String swaggerAsString, List<AuthorizationValue> auth, ParseOptions options) {
         SwaggerParseResult output = null;
 
-        for(SwaggerParserExtension extension : getExtensions()) {
+        for(SwaggerParserExtension extension : OpenAPIV3Parser.getExtensions()) {
             output = extension.readContents(swaggerAsString, auth, options);
             if(output != null && output.getOpenAPI() != null) {
                 return output;
@@ -38,15 +35,4 @@ public class OpenAPIParser {
         return output;
     }
 
-    protected List<SwaggerParserExtension> getExtensions() {
-        List<SwaggerParserExtension> extensions = new ArrayList<>();
-
-        ServiceLoader<SwaggerParserExtension> loader = ServiceLoader.load(SwaggerParserExtension.class);
-        Iterator<SwaggerParserExtension> itr = loader.iterator();
-        while (itr.hasNext()) {
-            extensions.add(itr.next());
-        }
-        extensions.add(0, new OpenAPIV3Parser());
-        return extensions;
-    }
 }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/OpenAPIParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/OpenAPIParserTest.java
@@ -481,5 +481,21 @@ public class OpenAPIParserTest {
 
     }
 
+    @Test
+    public void testIssue1003_ExtensionsClassloader() {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        SwaggerParseResult api = null;
+        try {
+            // Temporarily switch tccl to an unproductive cl
+            final ClassLoader tcclTemp = new java.net.URLClassLoader(new java.net.URL[] {},
+                ClassLoader.getSystemClassLoader());
+            Thread.currentThread().setContextClassLoader(tcclTemp);
+            api = new OpenAPIParser().readLocation("src/test/resources/petstore.yaml",null,null);
+        } finally {
+            Thread.currentThread().setContextClassLoader(tccl);
+        }
+        assertNotNull(api);
+    }
+  
 }
 


### PR DESCRIPTION
What is the problem: Following #1068 it appears the same getExtensions mechanism is also used by OpenAPIParser. The same fix should therefore be applied

What is the solution: Reuse getExtensions code from OpenAPIV3Parser