### PR TITLE
Properties order lost while converting from v2 to v3 #997

### DIFF
--- a/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
+++ b/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
@@ -71,6 +71,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -921,7 +922,7 @@ public class SwaggerConverter implements SwaggerParserExtension {
             result.setExample(schema.getExample());
 
             if ("object".equals(schema.getType()) && (result.getProperties() != null) && (result.getProperties().size() > 0)) {
-                Map<String, Schema> properties = new HashMap<>();
+                Map<String, Schema> properties = new LinkedHashMap<>();
 
                 ((ObjectProperty) schema).getProperties().forEach((k, v) -> properties.put(k, convert(v)));
 


### PR DESCRIPTION
**What is the problem:** In our unit tests,  properties need to appear in a specific order. We are having issues when these tests are run with different JDKs because HashMap ordering is not guaranteed.

**What is the solution:** Replace HashMap with LinkedHashMap in SwaggerConverter.java.

Please note that a unit test for this PR would be subject to the same JDK issue mentioned here, so no unit test is provided.