### PR TITLE
xml information in array models

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -793,7 +793,13 @@ public class SwaggerDeserializer {
 
             Integer minItems = getInteger("minItems", node, false, location, result);
             am.setMinItems(minItems);
-
+            
+            // add xml specific information if available 
+            JsonNode xml = node.get("xml");
+            if(xml != null) {
+                am.setXml(Json.mapper().convertValue(xml, Xml.class));
+            }
+            
             // extra keys
             Set<String> keys = getKeys(node);
             for(String key : keys) {


### PR DESCRIPTION
The xml information was ignored while creation of array models... So I added them. 

This is e.g. relevant when using openapi-generator (3.3.4 in my case) to generate custom java classes from swagger2.0 descriptions with correct xml annotations.