### PR TITLE
Avoid prepending forward slashes to URLs when the URL already starts with a forward slash

### DIFF
--- a/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
+++ b/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
@@ -420,7 +420,7 @@ public class SwaggerConverter implements SwaggerParserExtension {
                 servers.add(server);
             }
         } else {
-            if (!"/".equals(baseUrl)) {
+            if (!StringUtils.startsWith(baseUrl, "/") && !"/".equals(baseUrl)) {
                 baseUrl = "//" + baseUrl;
             }
             Server server = new Server();

--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -781,7 +781,7 @@ public class V2ConverterTest {
         assertEquals(INT64_FORMAT, integerSchema.getFormat());
     }
 
-    @Test(description = "OpenAPI v2 converter - parses URL correctly when no schemas are present")
+    @Test(description = "OpenAPI v2 converter - parses URL correctly when no schemes are present")
     public void testIssue1113() throws Exception {
         final OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_1113_YAML);
         assertNotNull(oas);

--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -90,6 +90,7 @@ public class V2ConverterTest {
     private static final String ISSUE_768_JSON = "issue-786.json";
     private static final String ISSUE_820_YAML = "issue-820.yaml";
     private static final String ISSUE_1032_YAML = "issue-1032.yaml";
+    private static final String ISSUE_1113_YAML = "issue-1113.yaml";
 
     private static final String API_BATCH_PATH = "/api/batch/";
     private static final String PETS_PATH = "/pets";
@@ -778,6 +779,16 @@ public class V2ConverterTest {
         IntegerSchema integerSchema = (IntegerSchema) s;
         assertEquals(INTEGER_TYPE, integerSchema.getType());
         assertEquals(INT64_FORMAT, integerSchema.getFormat());
+    }
+
+    @Test(description = "OpenAPI v2 converter - parses URL correctly when no schemas are present")
+    public void testIssue1113() throws Exception {
+        final OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_1113_YAML);
+        assertNotNull(oas);
+        assertNotNull(oas.getServers());
+        assertFalse(oas.getServers().isEmpty());
+        assertNotNull(oas.getServers().get(0));
+        assertEquals(oas.getServers().get(0).getUrl(), "/test");
     }
     
     private OpenAPI getConvertedOpenAPIFromJsonFile(String file) throws IOException, URISyntaxException {

--- a/modules/swagger-parser-v2-converter/src/test/resources/issue-1113.yaml
+++ b/modules/swagger-parser-v2-converter/src/test/resources/issue-1113.yaml
@@ -1,0 +1,14 @@
+swagger: '2.0'
+info:
+  title: Test for Issue 1113
+  version: 1.0.0
+basePath: /test
+paths:
+  /ping:
+    get:
+      summary: test
+      description: 'test'
+      operationId: pingOp
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
Fixes issue #1113. We no longer prepend `//` to the `basePath` when the `basePath` already begins with a `/`. Fixes (and contains) the failing test added in #1114.