### PR TITLE
issue-1133 - Parser does not resolve $ref pointing to relative locations on classpath

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ResolverCache.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ResolverCache.java
@@ -118,8 +118,12 @@ public class ResolverCache {
             if(parentDirectory != null) {
                 contents = RefUtils.readExternalRef(file, refFormat, auths, parentDirectory);
             }
-            else if(rootPath != null) {
+            else if(rootPath != null && rootPath.startsWith("http")) {
                 contents = RefUtils.readExternalUrlRef(file, refFormat, auths, rootPath);
+            }
+            else if (rootPath != null) {
+                contents = RefUtils.readExternalClasspathRef(file, refFormat, auths, rootPath);
+
             }
             externalFileCache.put(file, contents);
         }

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/PathUtils.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/PathUtils.java
@@ -20,17 +20,32 @@ public class PathUtils {
                 file = Paths.get(location).toAbsolutePath();
             }
             if (!Files.exists(file)) {
-                URL url = PathUtils.class.getClassLoader().getResource(location);
-                file = Paths.get((URI.create(url.toExternalForm())));
-                return file.getParent();
+                return getParentDirectoryFromUrl(location);
             }
-
-
 
         } catch (Exception e) {
             e.getMessage();
         }
 
         return file.toAbsolutePath().getParent();
+    }
+
+    private static Path getParentDirectoryFromUrl(String location){
+        try {
+            URL url = PathUtils.class.getResource(location);
+            if (url == null){
+                url = PathUtils.class.getClassLoader().getResource(location);
+            }
+            if(url == null) {
+                url = ClassLoader.getSystemResource(location);
+            }
+
+            Path file = Paths.get((URI.create(url.toExternalForm())));
+            return file.getParent();
+
+        } catch (Exception e) {
+            e.getMessage();
+            return null;
+        }
     }
 }

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/RefUtils.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/RefUtils.java
@@ -2,6 +2,7 @@ package io.swagger.v3.parser.util;
 
 import io.swagger.v3.parser.core.models.AuthorizationValue;
 import io.swagger.v3.parser.models.RefFormat;
+import io.swagger.v3.parser.processors.ExternalRefProcessor;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -109,6 +110,32 @@ public class RefUtils {
                 String url = buildUrl(rootPath, file);
 
                 return readExternalRef(url, RefFormat.URL, auths, null);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to load " + refFormat + " ref: " + file, e);
+        }
+
+        return result;
+
+    }
+
+    public static String readExternalClasspathRef(String file, RefFormat refFormat, List<AuthorizationValue> auths,
+                                                  String rootPath) {
+
+        if (!RefUtils.isAnExternalRefFormat(refFormat)) {
+            throw new RuntimeException("Ref is not external");
+        }
+
+        String result;
+
+        try {
+            if (refFormat == RefFormat.URL) {
+                result = RemoteUrl.urlToString(file, auths);
+            } else {
+                //its assumed to be a relative ref
+                String pathRef = ExternalRefProcessor.join(rootPath, file);
+
+                result = ClasspathHelper.loadFileFromClasspath(pathRef);
             }
         } catch (Exception e) {
             throw new RuntimeException("Unable to load " + refFormat + " ref: " + file, e);

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/PathUtilTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/PathUtilTest.java
@@ -2,19 +2,29 @@ package io.swagger.v3.parser.util;
 
 import org.testng.annotations.Test;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 public class PathUtilTest {
 
     @Test
     public void testGetParentDirectoryOfFile() throws Exception {
 
-        final String actualResult = PathUtils.getParentDirectoryOfFile("src/test/resources/parent.json").toString();
+        final String actualResult = PathUtils.getParentDirectoryOfFile("src/test/resources/test.yaml").toString();
 
         final String expectedResult = Paths.get("src/test/resources").toAbsolutePath().toString();
 
         assertEquals(actualResult, expectedResult);
+    }
+
+    @Test
+    public void testGetParentDirectoryOfNonExistentFile() throws Exception {
+
+        final Path result = PathUtils.getParentDirectoryOfFile("src/test/resources/parent.json");
+
+        assertNull(result);
     }
 }


### PR DESCRIPTION
PathUtils - improve url lookup to find classpath resources not in swagger-parser jars. 
ResolverCache, RefUtils - add lookup by classpath when file path not resolvable.