### PR TITLE
Using specialized schema subclasses

### DIFF
--- a/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
+++ b/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
@@ -32,6 +32,7 @@ import io.swagger.parser.SwaggerParser;
 import io.swagger.parser.SwaggerResolver;
 import io.swagger.parser.util.SwaggerDeserializationResult;
 import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.PrimitiveType;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -692,9 +693,20 @@ public class SwaggerConverter implements SwaggerParserExtension {
             }
             schema = as;
         } else {
-            schema = new Schema();
-            schema.setType(sp.getType());
-            schema.setFormat(sp.getFormat());
+            PrimitiveType ptype = PrimitiveType.fromTypeAndFormat(sp.getType(), sp.getFormat());
+            if (ptype != null) {
+                schema = ptype.createProperty();
+            } else {
+                ptype = PrimitiveType.fromTypeAndFormat(sp.getType(), null);
+                if (ptype != null) {
+                    schema = ptype.createProperty();
+                    schema.setFormat(sp.getFormat());
+                } else {
+                    schema = new Schema();
+                    schema.setType(sp.getType());
+                    schema.setFormat(sp.getFormat());
+                }
+            }
         }
 
         schema.setDescription(sp.getDescription());

--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -7,8 +7,10 @@ import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
@@ -91,6 +93,7 @@ public class V2ConverterTest {
     private static final String ISSUE_820_YAML = "issue-820.yaml";
     private static final String ISSUE_1032_YAML = "issue-1032.yaml";
     private static final String ISSUE_1113_YAML = "issue-1113.yaml";
+    private static final String ISSUE_1164_YAML = "issue-1164.yaml";
 
     private static final String API_BATCH_PATH = "/api/batch/";
     private static final String PETS_PATH = "/pets";
@@ -790,7 +793,37 @@ public class V2ConverterTest {
         assertNotNull(oas.getServers().get(0));
         assertEquals(oas.getServers().get(0).getUrl(), "/test");
     }
-    
+
+    @Test(description = "OpenAPI v2 converter - uses specialized schema subclasses where available")
+    public void testIssue1164() throws Exception {
+        final OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_1164_YAML);
+        assertNotNull(oas);
+        assertNotNull(oas.getPaths());
+        assertNotNull(oas.getPaths().get("/foo"));
+        assertNotNull(oas.getPaths().get("/foo").getGet());
+        assertNotNull(oas.getPaths().get("/foo").getGet().getRequestBody());
+        assertNotNull(oas.getPaths().get("/foo").getGet().getRequestBody().getContent());
+        assertNotNull(oas.getPaths().get("/foo").getGet().getRequestBody().getContent().get("multipart/form-data"));
+        Schema formSchema = oas.getPaths().get("/foo").getGet().getRequestBody().getContent().get("multipart/form-data").getSchema();
+        assertNotNull(formSchema);
+        assertNotNull(formSchema.getProperties());
+        assertEquals(4, formSchema.getProperties().size());
+        assertTrue(formSchema.getProperties().get("first") instanceof StringSchema);
+
+        assertTrue(formSchema.getProperties().get("second") instanceof BooleanSchema);
+
+        assertTrue(formSchema.getProperties().get("third") instanceof StringSchema);
+        StringSchema third = (StringSchema) formSchema.getProperties().get("third");
+        assertNotNull(third.getFormat());
+        assertTrue("password".equals(third.getFormat()));
+
+        assertTrue(formSchema.getProperties().get("fourth") instanceof BooleanSchema);
+        Schema fourth = (Schema) formSchema.getProperties().get("fourth");
+        assertNotNull(fourth.getType());
+        assertNotNull(fourth.getFormat());
+        assertTrue("completely-custom".equals(fourth.getFormat()));
+    }
+
     private OpenAPI getConvertedOpenAPIFromJsonFile(String file) throws IOException, URISyntaxException {
         SwaggerConverter converter = new SwaggerConverter();
         String swaggerAsString = new String(Files.readAllBytes(Paths.get(getClass().getClassLoader().getResource(file).toURI())));

--- a/modules/swagger-parser-v2-converter/src/test/resources/issue-1164.yaml
+++ b/modules/swagger-parser-v2-converter/src/test/resources/issue-1164.yaml
@@ -1,0 +1,30 @@
+swagger: '2.0'
+info:
+  title: Test for Issue 1164
+  version: 1.0.0
+paths:
+  /foo:
+    get:
+      operationId: doFoo
+      parameters:
+        - in: formData
+          name: first
+          type: string
+          required: true
+        - in: formData
+          name: second
+          type: boolean
+          required: true
+        - in: formData
+          name: third
+          type: string
+          format: password
+          required: true
+        - in: formData
+          name: fourth
+          type: boolean
+          format: completely-custom
+          required: true
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
Resolves #1164 

Motivation:
`PrimitiveType` contains a full mapping (and constructors!) for built-in tracked schema subtypes. By using this, the Schemas generated by the 2to3 converter will have a similar shape to the native 3.x schemas, permitting more unified structure handling for clients (permitting relying on `isInstanceOf` exclusively, instead of `isInstanceOf` as well as `getType() == "xyz"`)

Delegating to `fromTypeAndFormat` to get a particular instance, then `createProperty()` to instantiate the particular schema resolves the issue I was running into.

If we can't actually look up the mapping, fall back to the original behaviour.