### PR TITLE
Preserve parameter name as extension

### DIFF
--- a/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
+++ b/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
@@ -808,6 +808,9 @@ public class SwaggerConverter implements SwaggerParserExtension {
         }
         convertExamples(((BodyParameter) param).getExamples(), content);
         body.content(content);
+        if(param.getName() != null) {
+            body.addExtension("x-name", param.getName());
+        }
         return body;
     }
 

--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -680,6 +680,13 @@ public class V2ConverterTest {
         assertNotNull(oas);
     } 
   
+    @Test(description = "OpenAPI v2 Converter: Ensure body name is preserved in x-name extension of the requestBody")
+    public void testBodyParameterNameConvertedAsExtension() throws Exception {
+        final OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_762_JSON);
+        assertNotNull(oas);
+        assertEquals(oas.getPaths().get("/").getPut().getRequestBody().getExtensions().get("x-name"), "pet");
+    }
+
     @Test(description = "requestBody not correctly populated when Parameters is a list of $refs (OAS 2 to 3 conversion)")
     public void testIssue765() throws Exception {
         final OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_765_YAML);


### PR DESCRIPTION
Fixes #748

Given this input spec:

https://github.com/swagger-api/swagger-parser/blob/97865f6976acd0ed00f3f36c7d0c2e0ba579f4ae/modules/swagger-parser-v2-converter/src/test/resources/issue-762.json#L17-L27


When converted to OAS3 (yaml) we get this output:

```yaml
      requestBody:
        description: The pet JSON you want to post
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Pet'
        required: true
```

But the information about the OAS2 parameter name `"name": "pet"` is lost.

The idea of this change is to add an `x-name` extension to the converted request body, with the parameter name of the OAS2 spec:

```yaml
      requestBody:
        x-name: pet
        description: The pet JSON you want to post
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Pet'
        required: true
```