### PR TITLE
Fixing Contact Object vendor Extension was not parsed

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -1306,7 +1306,10 @@ public class SwaggerDeserializer {
         // extra keys
         Set<String> keys = getKeys(node);
         for(String key : keys) {
-            if(!CONTACT_KEYS.contains(key)) {
+            if(key.startsWith("x-")) {
+                contact.setVendorExtension(key, extension(node.get(key)));
+            }
+            else if(!CONTACT_KEYS.contains(key)) {
                 result.extra(location + ".contact", key, node.get(key));
             }
         }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -58,6 +58,15 @@ import static org.testng.Assert.fail;
 public class SwaggerParserTest {
 
     @Test
+    public void testIssue1204() {
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue1204.yaml", null, true);
+        System.out.println(result.getMessages());
+        assertTrue(result.getMessages().size() == 0);
+        assertNotNull(result.getSwagger());
+
+    }
+
+    @Test
     public void testIssue1169() {
         SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue1169.yaml", null, true);
         assertTrue(result.getMessages().size() == 0);

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
@@ -356,8 +356,7 @@ public class SwaggerDeserializerTest {
         assertEquals(contact.getName(), "tony");
         assertEquals(contact.getUrl(), "url");
         assertEquals(contact.getEmail(), "email");
-
-        //assertTrue(messages.contains("attribute info.contact.x-fun is unexpected"));
+        
         assertTrue(messages.contains("attribute info.bad is unexpected"));
         assertTrue(messages.contains("attribute info.contact.invalid is unexpected"));
 

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
@@ -357,7 +357,7 @@ public class SwaggerDeserializerTest {
         assertEquals(contact.getUrl(), "url");
         assertEquals(contact.getEmail(), "email");
 
-        assertTrue(messages.contains("attribute info.contact.x-fun is unexpected"));
+        //assertTrue(messages.contains("attribute info.contact.x-fun is unexpected"));
         assertTrue(messages.contains("attribute info.bad is unexpected"));
         assertTrue(messages.contains("attribute info.contact.invalid is unexpected"));
 

--- a/modules/swagger-parser/src/test/resources/issue1204.yaml
+++ b/modules/swagger-parser/src/test/resources/issue1204.yaml
@@ -1,0 +1,3100 @@
+swagger: '2.0'
+schemes:
+  - https
+host: api.twitter.com
+basePath: /1.1
+info:
+  contact:
+    email: support@twitter.com
+    name: Twitter support
+    url: 'https://dev.twitter.com'
+    x-twitter: twitter
+  title: Twitter
+  version: '1.1'
+  x-apisguru-categories:
+    - social
+  x-logo:
+    url: 'https://api.apis.guru/v2/cache/logo/https_twitter.com_twitter_profile_image.png'
+  x-origin:
+    - converter:
+        url: 'https://github.com/lucybot/api-spec-converter'
+        version: 2.6.0
+      format: wadl
+      url: 'http://api.apigee.com/v1/consoles/twitter/apidescription?format=wadl'
+    - format: swagger
+      url: 'https://raw.githubusercontent.com/APIs-guru/unofficial_openapi_specs/master/twitter.com/1.1/twitter.json'
+      version: '2.0'
+  x-preferred: true
+  x-providerName: twitter.com
+  x-serviceName: legacy
+  x-unofficialSpec: true
+paths:
+  /account/settings.json:
+    get:
+      description: |-
+        Returns settings (including
+        current trend, geo and sleep time information) for the authenticating user.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/account/settings'
+      operationId: account.settings.get
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          The Yahoo! Where On Earth ID to use as the user's default trend location. Global information is
+          available by using 1 as the WOEID. The woeid must be one of the locations returned by GET
+          trends/available.
+
+          Example Values: 1
+        in: query
+        name: trend_location_woeid
+        required: false
+        type: string
+      - description: |-
+          When set to true, t or 1, will enable sleep time for the user. Sleep time is the time when push or
+          SMS notifications should not be sent to the user.
+
+          Example Values: true
+        in: query
+        name: sleep_time_enabled
+        required: false
+        type: string
+      - description: |-
+          The hour that sleep time should begin if it is enabled. The value for this parameter should be
+          provided in ISO8601 format (i.e. 00-23). The time is considered to be in the same timezone as the
+          user's time_zone setting.
+
+          Example Values: 13
+        in: query
+        name: start_sleep_time
+        required: false
+        type: string
+      - description: |-
+          The hour that sleep time should end if it is enabled. The value for this parameter should be
+          provided in ISO8601 format (i.e. 00-23). The time is considered to be in the same timezone as the
+          user's time_zone setting.
+
+          Example Values: 13
+        in: query
+        name: end_sleep_time
+        required: false
+        type: string
+      - description: |-
+          The timezone dates and times should be displayed in for the user. The timezone must be one of the
+          Rails TimeZone names.
+
+          Example Values: Europe/Copenhagen, Pacific/Tongatapu
+        in: query
+        name: time_zone
+        required: false
+        type: string
+      - description: |-
+          The language which Twitter should render in for this user. The language must be specified by the
+          appropriate two letter ISO 639-1 representation. Currently supported languages are provided by GET
+          help/languages.
+
+          Example Values: it, en, es
+        in: query
+        name: lang
+        required: false
+        type: string
+    post:
+      description: |-
+        Updates the
+        authenticating user's settings.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/account/settings'
+      operationId: account.settings.post
+      responses:
+        '200':
+          description: Successful Response
+  /account/update_delivery_device.json:
+    parameters:
+      - description: |-
+          Must be one of: sms, none.
+
+          Example Values: sms
+        in: query
+        name: device
+        required: true
+        type: string
+      - description: |-
+          When set to either true, t or 1, each tweet will include a node called "entities,". This node
+          offers a variety of metadata about the tweet in a discreet structure, including: user_mentions,
+          urls, and hashtags. While entities are opt-in on timelines at present, they will be made a default
+          component of output in the future. See Tweet Entities for more detail on entities.
+
+          Example Values: true
+        in: query
+        name: include_entities
+        required: false
+        type: string
+    post:
+      description: |-
+        Sets which
+        device Twitter delivers updates to for the authenticating user. Sending none as the device parameter
+        will disable SMS updates.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/account/update_delivery_device'
+      operationId: account.update_delivery_device
+      responses:
+        '200':
+          description: Successful Response
+  /account/update_profile.json:
+    parameters:
+      - description: |-
+          Full name associated with the profile. Maximum of 20 characters.
+
+          Example Values: Marcel Molina
+        in: query
+        name: name
+        required: false
+        type: string
+      - description: |-
+          URL associated with the profile. Will be prepended with "http://" if not present. Maximum of 100
+          characters.
+
+          Example Values: http://project.ioni.st
+        in: query
+        name: url
+        required: false
+        type: string
+      - description: |-
+          The city or country describing where the user of the account is located. The contents are not
+          normalized or geocoded in any way. Maximum of 30 characters.
+
+          Example Values: San Francisco, CA
+        in: query
+        name: location
+        required: false
+        type: string
+      - description: |-
+          A description of the user owning the account. Maximum of 160 characters.
+
+          Example Values: Flipped my wig at age 22 and it never grew back. Also: I work at Twitter.
+        in: query
+        name: description
+        required: false
+        type: string
+      - description: |-
+          The entities node will not be included when set to false.
+
+          Example Values: false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: 'When set to either true, t or 1 statuses will not be included in the returned user objects.'
+        in: query
+        name: skip_status
+        required: false
+        type: string
+    post:
+      description: |-
+        Sets values that
+        users are able to set under the Account tab of their settings page. Only the parameters specified
+        will be updated.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/account/update_profile'
+      operationId: account.update_profile
+      responses:
+        '200':
+          description: Successful Response
+  /account/update_profile_background_image.json:
+    parameters:
+      - default: multipart/form-data
+        description: Content type header
+        in: header
+        name: Content-Type
+        required: true
+        type: string
+      - description: |-
+          Whether or not to tile the background image. If set to true, t or 1 the background image will
+          be displayed tiled. The image will not be tiled otherwise.
+        in: query
+        name: tile
+        required: false
+        type: string
+      - description: |-
+          Determines whether to display the profile background image or not. When set to true, t or 1 the
+          background image will be displayed if an image is being uploaded with the request, or has been
+          uploaded previously. An error will be returned if you try to use a background image when one is
+          not being uploaded or does not exist. If this parameter is defined but set to anything other
+          than true, t or 1, the background image will stop being used.
+        in: query
+        name: use
+        required: false
+        type: string
+      - description: |-
+          The entities node will not be included when set to false.
+
+          Example Values: false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: 'When set to either true, t or 1 statuses will not be included in the returned user objects.'
+        in: query
+        name: skip_status
+        required: false
+        type: string
+    post:
+      description: |-
+        Updates the authenticating user's profile background image. This method can also be used to enable
+        or disable the profile background image. Although each parameter is marked as optional, at least one
+        of image, tile or use must be provided when making this request.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/account/update_profile_background_image'
+      operationId: accounts.update_profile_background_image
+      parameters: []
+      responses:
+        '200':
+          description: Successful Response
+  /account/update_profile_colors.json:
+    parameters:
+      - description: 'Profile background color. Example Values: 3D3D3D'
+        in: query
+        name: profile_background_color
+        required: false
+        type: string
+      - description: 'Profile link color.Example Values: 0000FF'
+        in: query
+        name: profile_link_color
+        required: false
+        type: string
+      - description: 'Profile sidebar''s border color. Example Values: 0F0F0F'
+        in: query
+        name: profile_sidebar_border_color
+        required: false
+        type: string
+      - description: 'Profile sidebar''s background color. Example Values: 00FF00'
+        in: query
+        name: profile_sidebar_fill_color
+        required: false
+        type: string
+      - description: 'Profile text color. Example Values: 000000'
+        in: query
+        name: profile_text_color
+        required: false
+        type: string
+      - description: 'The entities node will not be included when set to false. Example Values: false'
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: 'When set to either true, t or 1 statuses will not be included in the returned user objects.'
+        in: query
+        name: skip_status
+        required: false
+        type: string
+    post:
+      description: |-
+        Sets one or
+        more hex values that control the color scheme of the authenticating user's profile page on
+        twitter.com.
+        Each parameter's value must be a valid hexidecimal value, and may be either three or six characters
+        (ex: #fff or #ffffff).
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/account/update_profile_colors'
+      operationId: accounts.update_profile_colors
+      responses:
+        '200':
+          description: Successful Response
+  /account/update_profile_image.json:
+    parameters:
+      - default: multipart/form-data
+        description: Content type header
+        in: header
+        name: Content-Type
+        required: true
+        type: string
+      - description: 'When set to either true, t or 1 statuses will not be included in the returned user objects.'
+        in: query
+        name: skip_status
+        required: false
+        type: string
+    post:
+      description: |-
+        Updates the
+        authenticating user's profile image. Note that this method expects raw multipart data, not a URL to
+        an image. This method asynchronously processes the uploaded file before updating the user's profile
+        image URL. You can either update your local cache the next time you request the user's information,
+        or, at least 5 seconds after uploading the image, ask for the updated URL using GET
+        users/profile_image/:screen_name
+        (https://dev.twitter.com/docs/api/1/get/users/profile_image/:screen_name).
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/account/update_profile_image'
+      operationId: accounts.update_profile_image
+      parameters: []
+      responses:
+        '200':
+          description: Successful Response
+  /application/rate_limit_status.json:
+    get:
+      description: |-
+        Returns the
+        current rate limits for
+        methods belonging to the specified resource families.
+
+        Each 1.1 API resource belongs to a "resource family" which is indicated in its method documentation.
+        You can typically determine a method's resource family from the first component of the path after
+        the resource version.
+
+        This method responds with a map of methods belonging to the families specified by the resources
+        parameter, the current remaining uses for each of those resources within the current rate limiting
+        window, and its expiration time in epoch time. It also includes a rate_limit_context field that
+        indicates the current access token context.
+
+        You may also issue requests to this method without any parameters to receive a map of all rate
+        limited GET methods. If your application only uses a few of methods, please explicitly provide a
+        resources parameter with the specified resource families you work with.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/application/rate_limit_status'
+      operationId: application.rate_limit_status
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          A comma-separated list of resource families you want to know the current rate limit disposition
+          for. For best performance, only specify the resource families pertinent to your application.Example
+          Values: statuses,friends,trends,help
+        in: query
+        name: resources
+        required: false
+        type: string
+  /blocks/create.json:
+    parameters:
+      - description: |-
+          The entities node will not be included when set to false.
+
+          Example Values: false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: 'When set to either true, t or 1 statuses will not be included in the returned user objects.'
+        in: query
+        name: skip_status
+        required: false
+        type: string
+    post:
+      description: |-
+        Blocks the specified user from
+        following the authenticating user. In addition the blocked user will not show in the authenticating
+        users mentions or timeline (unless retweeted by another user). If a follow or friend relationship
+        exists it is destroyed.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/blocks/create'
+      operationId: blocks.create
+      responses:
+        '200':
+          description: Successful Response
+  /blocks/destroy.json:
+    parameters:
+      - description: |-
+          The entities node will not be included when set to false.
+
+          Example Values: false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: 'When set to either true, t or 1 statuses will not be included in the returned user objects.'
+        in: query
+        name: skip_status
+        required: false
+        type: string
+    post:
+      description: |-
+        Un-blocks the user specified
+        in the ID parameter for the authenticating user. Returns the un-blocked user in the requested format
+        when successful. If relationships existed before the block was instated, they will not be restored.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/blocks/destroy'
+      operationId: blocks.destroy
+      responses:
+        '200':
+          description: Successful Response
+  /blocks/ids.json:
+    get:
+      description: |-
+        Returns an array of numeric user
+        ids the authenticating user is blocking.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/blocks/ids'
+      operationId: blocks.ids
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          Many programming environments will not consume our ids due to their size. Provide this option to
+          have ids returned as strings instead. Read more about Twitter IDs, JSON and Snowflake.
+
+          Example Values: true
+        in: query
+        name: stringify_ids
+        required: false
+        type: string
+      - description: |-
+          Causes the list of blocked users to be broken into pages of no more than 5000 IDs at a time. The
+          number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after
+          connections are queried. If no cursor is provided, a value of -1 will be assumed, which is the first
+          "page."
+
+          The response from the API will include a previous_cursor and next_cursor to allow paging back and
+          forth. See Using cursors to navigate collections for more information.
+
+          Example Values: 12893764510938
+        in: query
+        name: cursor
+        required: false
+        type: string
+  /blocks/list.json:
+    get:
+      description: |-
+        Allows one to enable or
+        disable retweets and device notifications from the specified user.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/blocks/list'
+      operationId: blocks.list
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: 'The entities node will not be included when set to false. Example Values: false'
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: 'When set to either true, t or 1 statuses will not be included in the returned user objects.'
+        in: query
+        name: skip_status
+        required: false
+        type: string
+      - description: |-
+          Causes the list of blocked users to be broken into pages of no more than 5000 IDs at a time. The
+          number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after
+          connections are queried. If no cursor is provided, a value of -1 will be assumed, which is the first
+          "page."
+
+          The response from the API will include a previous_cursor and next_cursor to allow paging back and
+          forth. See Using cursors to navigate collections for more information.
+
+          Example Values: 12893764510938
+        in: query
+        name: cursor
+        required: false
+        type: string
+  /direct_messages.json:
+    get:
+      description: |-
+        Returns the 20 most recent
+        direct messages sent to the authenticating user. Includes detailed information about the sender and
+        recipient user. You can request up to 200 direct messages per call, up to a maximum of 800 incoming
+        DMs.
+
+        Important: This method requires an access token with RWD (read, write and direct message)
+        permissions.
+        Consult The Application Permission Model for more information.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/direct_messages'
+      operationId: direct_messages
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          Specifies the number of direct messages to try and retrieve, up to a maximum of 200. The value of
+          count is best thought of as a limit to the number of Tweets to return because suspended or deleted
+          content is removed after the count has been applied.
+
+          Example Values: 5
+        in: query
+        name: count
+        required: false
+        type: string
+      - description: |-
+          Returns results with an ID greater than (that is, more recent than) the specified ID. There are
+          limits to the number of Tweets which can be accessed through the API. If the limit of Tweets has
+          occured since the since_id, the since_id will be forced to the oldest ID available.
+          Example Values: 12345
+        in: query
+        name: since_id
+        required: false
+        type: string
+      - description: |-
+          Returns results with an ID less than (that is, older than) or equal to the specified ID.
+
+          Example Values: 54321
+        in: query
+        name: max_id
+        required: false
+        type: string
+      - description: |-
+          The entities node will not be included when set to false.
+
+          Example Values: false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: |-
+          Specifies the page of results to retrieve.
+
+          Example Values: 3
+        in: query
+        name: page
+        required: false
+        type: string
+      - description: 'When set to either true, t or 1 statuses will not be included in the returned user objects.'
+        in: query
+        name: skip_status
+        required: false
+        type: string
+  /direct_messages/destroy.json:
+    parameters:
+      - description: |-
+          The ID of the direct message to delete.
+
+          Example Values: 1270516771
+        in: query
+        name: id
+        required: true
+        type: string
+      - description: |-
+          The entities node will not be included when set to false.
+
+          Example Values: false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+    post:
+      description: |-
+        Destroys the direct
+        message specified in the required ID parameter. The authenticating user must be the recipient of the
+        specified direct message.
+
+        Important: This method requires an access token with RWD (read, write and direct message)
+        permissions.
+        Consult The Application Permission Model for more information.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/direct_messages/destroy'
+      operationId: direct_messages.destroy
+      responses:
+        '200':
+          description: Successful Response
+  /direct_messages/new.json:
+    parameters:
+      - description: |-
+          The text of your direct message. Be sure to URL encode as necessary, and keep the message under 140
+          characters.
+
+          Example Values: Meet me behind the cafeteria after school
+        in: query
+        name: text
+        required: true
+        type: string
+    post:
+      description: |-
+        Sends a new direct
+        message to the specified user from the authenticating user. Requires both the user and text
+        parameters and must be a POST. Returns the sent message in the requested format if successful.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/direct_messages/new'
+      operationId: direct_messages.new
+      responses:
+        '200':
+          description: Successful Response
+  /direct_messages/sent.json:
+    get:
+      description: |-
+        Returns the 20 most
+        recent direct messages sent by the authenticating user. Includes detailed information about the
+        sender and recipient user. You can request up to 200 direct messages per call, up to a maximum of
+        800 outgoing DMs.
+
+        Important: This method requires an access token with RWD (read, write and direct message)
+        permissions. Consult The Application Permission Model for more information.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/direct_messages/sent'
+      operationId: direct_messages.sent
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          Specifies the number of direct messages to try and retrieve, up to a maximum of 200. The value of
+          count is best thought of as a limit to the number of Tweets to return because suspended or deleted
+          content is removed after the count has been applied.
+
+          Example Values: 5
+        in: query
+        name: count
+        required: false
+        type: string
+      - description: |-
+          Returns results with an ID greater than (that is, more recent than) the specified ID. There are
+          limits to the number of Tweets which can be accessed through the API. If the limit of Tweets has
+          occured since the since_id, the since_id will be forced to the oldest ID available.
+
+          Example Values: 12345
+        in: query
+        name: since_id
+        required: false
+        type: string
+      - description: |-
+          Returns results with an ID less than (that is, older than) or equal to the specified ID.
+
+          Example Values: 54321
+        in: query
+        name: max_id
+        required: false
+        type: string
+      - description: |-
+          The entities node will not be included when set to false.
+
+          Example Values: false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: |-
+          Specifies the page of results to retrieve.
+
+          Example Values: 3
+        in: query
+        name: page
+        required: false
+        type: string
+  /direct_messages/show.json:
+    get:
+      description: |-
+        Returns a single direct
+        message, specified by an id parameter. Like the /1.1/direct_messages.format request, this method
+        will include the user objects of the sender and recipient.
+
+        Important: This method requires an access token with RWD (read, write and direct message)
+        permissions.
+        Consult The Application Permission Model for more information.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/direct_messages/show'
+      operationId: direct_messages.show
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          The ID of the direct message.
+
+          Example Values: 587424932
+        in: query
+        name: id
+        required: true
+        type: string
+  /favorites/create.json:
+    parameters:
+      - description: |-
+          The numerical ID of the desired status.
+
+          Example Values: 123
+        in: query
+        name: id
+        required: true
+        type: string
+      - description: |-
+          The entities node will be omitted when set to false.
+
+          Example Values: false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+    post:
+      description: |-
+        Favorites the status
+        specified in the ID parameter as the authenticating user. Returns the favorite status when
+        successful.
+
+        This process invoked by this method is asynchronous. The immediately returned status may not
+        indicate the resultant favorited status of the tweet. A 200 OK response from this method will
+        indicate whether the intended action was successful or not.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/favorites/create'
+      operationId: favorites.create
+      responses:
+        '200':
+          description: Successful Response
+  /favorites/destroy.json:
+    parameters:
+      - description: |-
+          The numerical ID of the desired status.
+
+          Example Values: 123
+        in: query
+        name: id
+        required: true
+        type: string
+      - description: |-
+          The entities node will be omitted when set to false.
+
+          Example Values: false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+    post:
+      description: |-
+        Un-favorites the status
+        specified in the ID parameter as the authenticating user. Returns the un-favorited status in the
+        requested format when successful.
+
+        This process invoked by this method is asynchronous. The immediately returned status may not
+        indicate the resultant favorited status of the tweet. A 200 OK response from this method will
+        indicate whether the intended action was successful or not.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/favorites/destroy'
+      operationId: favorites.destroy
+      responses:
+        '200':
+          description: Successful Response
+  /favorites/list.json:
+    get:
+      description: |-
+        Returns the 20 most recent
+        Tweets favorited by the authenticating or specified user.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/favorites/list'
+      operationId: favorites.list
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          Specifies the number of records to retrieve. Must be less than or equal to 200. Defaults to 20.
+
+          Example Values: 5
+        in: query
+        name: count
+        required: false
+        type: string
+      - description: |-
+          Returns results with an ID greater than (that is, more recent than) the specified ID. There are
+          limits to the number of Tweets which can be accessed through the API. If the limit of Tweets has
+          occured since the since_id, the since_id will be forced to the oldest ID available.
+
+          Example Values: 12345
+        in: query
+        name: since_id
+        required: false
+        type: string
+      - description: |-
+          Returns results with an ID less than (that is, older than) or equal to the specified ID.
+
+          Example Values: 54321
+        in: query
+        name: max_id
+        required: false
+        type: string
+      - description: |-
+          The entities node will be omitted when set to false.
+
+          Example Values: false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+  /followers/ids.json:
+    get:
+      description: |-
+        Returns a cursored collection
+        of user IDs for every user following the specified user.
+
+        At this time, results are ordered with the most recent following first â€” however, this ordering is
+        subject to unannounced change and eventual consistency issues. Results are given in groups of 5,000
+        user IDs and multiple "pages" of results can be navigated through using the next_cursor value in
+        subsequent requests. See Using cursors to navigate collections for more information.
+
+        This method is especially powerful when used in conjunction with GET users/lookup, a method that
+        allows you to convert user IDs into full user objects in bulk.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/followers/ids'
+      operationId: followers.ids
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          Many programming environments will not consume our Tweet ids due to their size. Provide this option
+          to have ids returned as strings instead. Example Values: true
+        in: query
+        name: stringify_ids
+        required: false
+        type: string
+      - description: |-
+          Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The
+          number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after
+          connections are queried. If no cursor is provided, a value of -1 will be assumed, which is the first
+          "page."
+
+          The response from the API will include a previous_cursor and next_cursor to allow paging back and
+          forth.Example Values: 12893764510938
+        in: query
+        name: cursor
+        required: false
+        type: string
+  /friends/ids.json:
+    get:
+      description: |-
+        Returns a cursored collection of
+        user IDs for every user the specified user is following (otherwise known as their "friends").
+
+        At this time, results are ordered with the most recent following first â€” however, this ordering is
+        subject to unannounced change and eventual consistency issues. Results are given in groups of 5,000
+        user IDs and multiple "pages" of results can be navigated through using the next_cursor value in
+        subsequent requests. See Using cursors to navigate collections for more information.
+
+        This method is especially powerful when used in conjunction with GET users/lookup, a method that
+        allows you to convert user IDs into full user objects in bulk.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/friends/ids'
+      operationId: friends.ids
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          Many programming environments will not consume our Tweet ids due to their size. Provide this option
+          to have ids returned as strings instead. Example Values: true
+        in: query
+        name: stringify_ids
+        required: false
+        type: string
+      - description: |-
+          Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The
+          number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after
+          connections are queried. If no cursor is provided, a value of -1 will be assumed, which is the first
+          "page."
+
+          The response from the API will include a previous_cursor and next_cursor to allow paging back and
+          forth.Example Values: 12893764510938
+        in: query
+        name: cursor
+        required: false
+        type: string
+  /friendships/create.json:
+    parameters:
+      - description: 'Enable notifications for the target user. Example Values: true'
+        in: query
+        name: follow
+        required: false
+        type: string
+    post:
+      description: |-
+        Allows the authenticating
+        users to follow the user specified in the ID parameter.
+
+        Returns the befriended user in the requested format when successful. Returns a string describing the
+        failure condition when unsuccessful. If you are already friends with the user a HTTP 403 may be
+        returned, though for performance reasons you may get a 200 OK message even if the friendship already
+        exists.
+
+        Actions taken in this method are asynchronous and changes will be eventually consistent.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/friendships/create'
+      operationId: friendships.create
+      responses:
+        '200':
+          description: Successful Response
+  /friendships/destroy.json:
+    parameters: []
+    post:
+      description: |-
+        Allows the
+        authenticating
+        user to unfollow the user specified in the ID parameter.
+
+        Returns the unfollowed user in the requested format when successful. Returns a string describing the
+        failure condition when unsuccessful.
+
+        Actions taken in this method are asynchronous and changes will be eventually consistent.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/friendships/destroy'
+      operationId: friendships.destroy
+      responses:
+        '200':
+          description: Successful Response
+  /friendships/incoming.json:
+    get:
+      description: |-
+        Returns the
+        relationships
+        of the authenticating user to the comma-separated list of up to 100 screen_names or user_ids
+        provided. Values for connections can be: following, following_requested, followed_by, none.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/friendships/incoming'
+      operationId: friendships.incoming
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          Many programming environments will not consume our Tweet ids due to their size. Provide this option
+          to have ids returned as strings instead. Example Values: true
+        in: query
+        name: stringify_ids
+        required: false
+        type: string
+      - description: |-
+          Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The
+          number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after
+          connections are queried. If no cursor is provided, a value of -1 will be assumed, which is the first
+          "page."
+
+          The response from the API will include a previous_cursor and next_cursor to allow paging back and
+          forth.Example Values: 12893764510938
+        in: query
+        name: cursor
+        required: false
+        type: string
+  /friendships/lookup.json:
+    get:
+      description: |-
+        Returns the relationships
+        of the authenticating user to the comma-separated list of up to 100 screen_names or user_ids
+        provided. Values for connections can be: following, following_requested, followed_by, none.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/friendships/lookup'
+      operationId: friendships.lookup
+      responses:
+        '200':
+          description: Successful Response
+    parameters: []
+  /friendships/outgoing.json:
+    get:
+      description: |-
+        Returns a collection of
+        numeric IDs for every protected user for whom the authenticating user has a pending follow request.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/friendships/outgoing'
+      operationId: friendships.outgoing
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          Many programming environments will not consume our Tweet ids due to their size. Provide this option
+          to have ids returned as strings instead. Example Values: true
+        in: query
+        name: stringify_ids
+        required: false
+        type: string
+      - description: |-
+          Causes the list of connections to be broken into pages of no more than 5000 IDs at a time. The
+          number of IDs returned is not guaranteed to be 5000 as suspended users are filtered out after
+          connections are queried. If no cursor is provided, a value of -1 will be assumed, which is the first
+          "page."
+
+          The response from the API will include a previous_cursor and next_cursor to allow paging back and
+          forth.Example Values: 12893764510938
+        in: query
+        name: cursor
+        required: false
+        type: string
+  /friendships/show.json:
+    get:
+      description: |-
+        Returns detailed information
+        about the relationship between two arbitrary users.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/friendships/show'
+      operationId: friendships.show
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          The user_id of the subject user.
+
+          Example Values: 3191321
+        in: query
+        name: source_id
+        required: false
+        type: string
+      - description: |-
+          The screen_name of the subject user.
+
+          Example Values: raffi
+        in: query
+        name: source_screen_name
+        required: false
+        type: string
+      - description: |-
+          The user_id of the target user.
+
+          Example Values: 20
+        in: query
+        name: target_id
+        required: true
+        type: string
+      - description: |-
+          The screen_name of the target user.
+
+          Example Values: noradio
+        in: query
+        name: target_screen_name
+        required: true
+        type: string
+  /friendships/update.json:
+    parameters:
+      - description: 'Enable/disable device notifications from the target user. Example Values: true, false'
+        in: query
+        name: device
+        required: true
+        type: string
+      - description: 'Enable/disable retweets from the target user. Example Values: true, false'
+        in: query
+        name: retweets
+        required: true
+        type: string
+    post:
+      description: |-
+        Allows one to enable or
+        disable retweets and device notifications from the specified user.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/friendships/update'
+      operationId: friendships.update
+      responses:
+        '200':
+          description: Successful Response
+  '/geo/id/{place_id}.json':
+    get:
+      description: |-
+        Returns all the
+        information about a known place.Example Values: df51dec6f4ee2b2c
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/geo/id/%3Aplace_id'
+      operationId: geo.place_id
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          A place in the world. These IDs can be retrieved from geo/reverse_geocode.
+
+          Example Values: df51dec6f4ee2b2c
+        in: path
+        name: place_id
+        required: true
+        type: string
+  /geo/places.json:
+    parameters:
+      - description: |-
+          This parameter searches for places which have this given street address. There are other
+          well-known, and application specific attributes available. Custom attributes are also permitted.
+          Learn more about Place Attributes.
+
+          Example Values: 795%20Folsom%20St
+        in: query
+        name: 'attribute:street_address'
+        required: false
+        type: string
+      - description: 'If supplied, the response will use the JSONP format with a callback of the given name.'
+        in: query
+        name: callback
+        required: false
+        type: string
+    post:
+      description: |-
+        Creates a new place object at the
+        given latitude and longitude.
+
+        Before creating a place you need to query GET geo/similar_places with the latitude, longitude and
+        name of the place you wish to create. The query will return an array of places which are similar to
+        the one you wish to create, and a token. If the place you wish to create isn't in the returned array
+        you can use the token with this method to create a new one.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/geo/place'
+      operationId: geo.places
+      responses:
+        '200':
+          description: Successful Response
+  /geo/reverse_geocode.json:
+    get:
+      description: |-
+        Given a latitude and a
+        longitude, searches for up to 20 places that can be used as a place_id when updating a status.
+
+        This request is an informative call and will deliver generalized results about geography
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/geo/reverse_geocode'
+      operationId: geo.reverse_geocode
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          The latitude to search around. This parameter will be ignored unless it is inside the range -90.0
+          to +90.0 (North is positive) inclusive. It will also be ignored if there isn't a corresponding long
+          parameter.
+
+          Example Values: 37.7821120598956
+        in: query
+        name: lat
+        required: true
+        type: string
+      - description: |-
+          The longitude to search around. The valid ranges for longitude is -180.0 to +180.0 (East is
+          positive) inclusive. This parameter will be ignored if outside that range, if it is not a number, if
+          geo_enabled is disabled, or if there not a corresponding lat parameter.
+
+          Example Values: -122.400612831116
+        in: query
+        name: long
+        required: true
+        type: string
+      - description: |-
+          A hint on the "region" in which to search. If a number, then this is a radius in meters, but it can
+          also take a string that is suffixed with ft to specify feet. If this is not passed in, then it is
+          assumed to be 0m. If coming from a device, in practice, this value is whatever accuracy the device
+          has measuring its location (whether it be coming from a GPS, WiFi triangulation, etc.).
+
+          Example Values: 5ft
+        in: query
+        name: accuracy
+        required: false
+        type: string
+      - description: |-
+          This is the minimal granularity of place types to return and must be one of: poi, neighborhood,
+          city, admin or country. If no granularity is provided for the request neighborhood is assumed.
+          Setting this to city, for example, will find places which have a type of city, admin or country.
+
+          Example Values: city
+        in: query
+        name: granularity
+        required: false
+        type: string
+      - description: |-
+          A hint as to the number of results to return. This does not guarantee that the number of results
+          returned will equal max_results, but instead informs how many "nearby" results to return. Ideally,
+          only pass in the number of places you intend to display to the user here.
+
+          Example Values: 3
+        in: query
+        name: max_results
+        required: false
+        type: string
+      - description: 'If supplied, the response will use the JSONP format with a callback of the given name.'
+        in: query
+        name: callback
+        required: false
+        type: string
+  /geo/search.json:
+    get:
+      description: |-
+        Search for places that can be
+        attached to a statuses/update. Given a latitude and a longitude pair, an IP address, or a name, this
+        request will return a list of all the valid places that can be used as the place_id when updating a
+        status.
+
+        Conceptually, a query can be made from the user's location, retrieve a list of places, have the user
+        validate the location he or she is at, and then send the ID of this location with a call to POST
+        statuses/update.
+
+        This is the recommended method to use find places that can be attached to statuses/update. Unlike
+        GET geo/reverse_geocode which provides raw data access, this endpoint can potentially re-order
+        places with regards to the user who is authenticated. This approach is also preferred for
+        interactive place matching with the user.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/geo/search'
+      operationId: geo.search
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          A hint on the "region" in which to search. If a number, then this is a radius in meters, but it can
+          also take a string that is suffixed with ft to specify feet. If this is not passed in, then it is
+          assumed to be 0m. If coming from a device, in practice, this value is whatever accuracy the device
+          has measuring its location (whether it be coming from a GPS, WiFi triangulation, etc.).
+
+          Example Values: 5ft
+        in: query
+        name: accuracy
+        required: false
+        type: string
+      - description: |-
+          This is the minimal granularity of place types to return and must be one of: poi, neighborhood,
+          city, admin or country. If no granularity is provided for the request neighborhood is assumed.
+          Setting this to city, for example, will find places which have a type of city, admin or country.
+
+          Example Values: city
+        in: query
+        name: granularity
+        required: false
+        type: string
+      - description: |-
+          This is the place_id which you would like to restrict the search results to. Setting this value
+          means only places within the given place_id will be found.
+
+          Specify a place_id. For example, to scope all results to places within "San Francisco, CA USA", you
+          would specify a place_id of "5a110d312052166f"
+
+          Example Values: 247f43d441defc03
+        in: query
+        name: contained_within
+        required: false
+        type: string
+      - description: |-
+          This parameter searches for places which have this given street address. There are other
+          well-known, and application specific attributes available. Custom attributes are also permitted.
+          Learn more about Place Attributes.
+
+          Example Values: 795%20Folsom%20St
+        in: query
+        name: 'attribute:street_address'
+        required: false
+        type: string
+      - description: 'If supplied, the response will use the JSONP format with a callback of the given name.'
+        in: query
+        name: callback
+        required: false
+        type: string
+  /geo/similar_places.json:
+    get:
+      description: |-
+        Locates places near the
+        given coordinates which are similar in name.
+
+        Conceptually you would use this method to get a list of known places to choose from first. Then, if
+        the desired place doesn't exist, make a request to POST geo/place to create a new one.
+
+        The token contained in the response is the token needed to be able to create a new place.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/geo/similar_places'
+      operationId: geo.similar_places
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          This is the place_id which you would like to restrict the search results to. Setting this value
+          means only places within the given place_id will be found.
+
+          Specify a place_id. For example, to scope all results to places within "San Francisco, CA USA", you
+          would specify a place_id of "5a110d312052166f"
+
+          Example Values: 247f43d441defc03
+        in: query
+        name: contained_within
+        required: false
+        type: string
+      - description: |-
+          This parameter searches for places which have this given street address. There are other
+          well-known, and application specific attributes available. Custom attributes are also permitted.
+          Learn more about Place Attributes.
+
+          Example Values: 795%20Folsom%20St
+        in: query
+        name: 'attribute:street_address'
+        required: false
+        type: string
+      - description: 'If supplied, the response will use the JSONP format with a callback of the given name.'
+        in: query
+        name: callback
+        required: false
+        type: string
+  /help/configuration.json:
+    get:
+      description: |-
+        Returns the current
+        configuration used by Twitter including twitter.com slugs which are not usernames, maximum photo
+        resolutions, and t.co URL lengths.
+
+        It is recommended applications request this endpoint when they are loaded, but no more than once a
+        day.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/help/configuration'
+      operationId: help.configurations
+      responses:
+        '200':
+          description: Successful Response
+    parameters: []
+  /help/languages.json:
+    get:
+      description: |-
+        Returns the list of languages
+        supported by Twitter along with their ISO 639-1 code. The ISO 639-1 code is the two letter value to
+        use if you include lang with any of your requests.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/help/languages'
+      operationId: help.languages
+      responses:
+        '200':
+          description: Successful Response
+    parameters: []
+  /help/privacy.json:
+    get:
+      description: Returns Twitter's Privacy Policy
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/help/privacy'
+      operationId: help.privacy
+      responses:
+        '200':
+          description: Successful Response
+    parameters: []
+  /help/tos.json:
+    get:
+      description: |-
+        Returns the Twitter Terms of Service
+        in the requested format. These are not the same as the Developer Rules of the Road.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/help/tos'
+      operationId: help.tos
+      responses:
+        '200':
+          description: Successful Response
+    parameters: []
+  /lists/create.json:
+    parameters:
+      - description: |-
+          The name for the list.A list's name must start with a letter and can consist only of 25 or fewer
+          letters, numbers, "-", or "_" characters.
+        in: query
+        name: name
+        required: true
+        type: string
+      - description: |-
+          Whether your list is public or private. Values can be public or private. If no mode is specified
+          the list will be public.
+        in: query
+        name: mode
+        required: false
+        type: string
+      - description: The description to give the list.
+        in: query
+        name: description
+        required: false
+        type: string
+    post:
+      description: |-
+        Creates a new list for the
+        authenticated user. Note that you can't create more than 20 lists per account.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/lists/create'
+      operationId: lists.create
+      responses:
+        '200':
+          description: Successful Response
+  /lists/destroy.json:
+    parameters:
+      - description: The screen name of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_screen_name
+        required: false
+        type: string
+      - description: The user ID of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_id
+        required: false
+        type: string
+    post:
+      description: |-
+        Deletes the specified list.
+        The authenticated user must own the list to be able to destroy it.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/lists/destroy'
+      operationId: lists.destroy
+      responses:
+        '200':
+          description: Successful Response
+  /lists/list.json:
+    get:
+      description: |-
+        Returns all lists the
+        authenticating or specified user subscribes to, including their own. The user is specified using the
+        user_id or screen_name parameters. If no user is given, the authenticating user is used.
+
+        This method used to be GET lists in version 1.0 of the API and has been renamed for consistency with
+        other call.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/lists/list'
+      operationId: lists.list
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          The screen name of the user for whom to return results for. Helpful for disambiguating when a valid
+          screen name is also a user ID.
+
+          Example Values: noradio
+        in: query
+        name: screen_name
+        required: true
+        type: string
+      - description: |-
+          The ID of the user for whom to return results for. Helpful for disambiguating when a valid user ID
+          is also a valid screen name.
+
+          Example Values: 12345
+
+          Note:: Specifies the ID of the user to get lists from. Helpful for disambiguating when a valid user
+          ID is also a valid screen name.
+        in: query
+        name: user_id
+        required: true
+        type: string
+  /lists/members.json:
+    get:
+      description: |-
+        Returns the members of the
+        specified list. Private list members will only be shown if the authenticated user owns the specified
+        list.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/lists/members'
+      operationId: lists.members
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: The screen name of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_screen_name
+        required: false
+        type: string
+      - description: The user ID of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_id
+        required: false
+        type: string
+      - description: |-
+          The entities node will be disincluded when set to false.
+
+          Example Values: false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: 'When set to either true, t or 1 statuses will not be included in the returned user objects.'
+        in: query
+        name: skip_status
+        required: false
+        type: string
+      - description: |-
+          Causes the collection of list members to be broken into "pages" of somewhat consistent size. If no
+          cursor is provided, a value of -1 will be assumed, which is the first "page."
+
+          The response from the API will include a previous_cursor and next_cursor to allow paging back and
+          forth. See Using cursors to navigate collections for more information.
+
+          Example Values: 12893764510938
+        in: query
+        name: cursor
+        required: false
+        type: string
+  /lists/members/create.json:
+    parameters:
+      - description: The screen name of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_screen_name
+        required: false
+        type: string
+      - description: The user ID of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_id
+        required: false
+        type: string
+    post:
+      description: |-
+        Add a member to a list.
+        The authenticated user must own the list to be able to add members to it. Note that lists can't have
+        more than 500 members.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/lists/members/create'
+      operationId: lists.members.create
+      responses:
+        '200':
+          description: Successful Response
+  /lists/members/create_all.json:
+    parameters:
+      - description: The screen name of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_screen_name
+        required: false
+        type: string
+      - description: The user ID of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_id
+        required: false
+        type: string
+      - description: 'A comma separated list of user IDs, up to 100 are allowed in a single request.'
+        in: query
+        name: user_id
+        required: false
+        type: string
+      - description: 'A comma separated list of screen names, up to 100 are allowed in a single request.'
+        in: query
+        name: screen_name
+        required: false
+        type: string
+    post:
+      description: |-
+        Adds multiple
+        members to a list, by specifying a comma-separated list of member ids or screen names. The
+        authenticated user must own the list to be able to add members to it. Note that lists can't have
+        more than 500 members, and you are limited to adding up to 100 members to a list at a time with this
+        method.
+
+        Please note that there can be issues with lists that rapidly remove and add memberships. Take care
+        when using these methods such that you are not too rapidly switching between removals and adds on
+        the same list.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/lists/members/create_all'
+      operationId: lists.members.create_all
+      responses:
+        '200':
+          description: Successful Response
+  /lists/members/destroy.json:
+    parameters:
+      - description: The numerical id of the list.
+        in: query
+        name: list_id
+        required: true
+        type: string
+      - description: |-
+          You can identify a list by its slug instead of its numerical id. If you decide to do so, note
+          that you'll also have to specify the list owner using the owner_id or owner_screen_name
+          parameters.
+        in: query
+        name: slug
+        required: true
+        type: string
+      - description: The screen name of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_screen_name
+        required: false
+        type: string
+      - description: The user ID of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_id
+        required: false
+        type: string
+      - description: |-
+          The ID of the user to remove from the list. Helpful for disambiguating when a valid user ID is also
+          a valid screen name.
+        in: query
+        name: user_id
+        required: false
+        type: string
+      - description: |-
+          The screen name of the user for whom to remove from the list. Helpful for disambiguating when a
+          valid screen name is also a user ID.
+        in: query
+        name: screen_name
+        required: false
+        type: string
+    post:
+      description: |-
+        Removes the specified
+        member from the list. The authenticated user must be the list's owner to remove members from the
+        list.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/lists/members/destroy'
+      operationId: lists.members.destroy
+      responses:
+        '200':
+          description: Successful Response
+  /lists/members/destroy_all.json:
+    parameters:
+      - description: The screen name of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_screen_name
+        required: false
+        type: string
+      - description: The user ID of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_id
+        required: false
+        type: string
+      - description: 'A comma separated list of screen names, up to 100 are allowed in a single request.'
+        in: query
+        name: screen_name
+        required: false
+        type: string
+      - description: 'A comma separated list of user IDs, up to 100 are allowed in a single request.'
+        in: query
+        name: user_id
+        required: false
+        type: string
+    post:
+      description: |-
+        Removes multiple
+        members from a list, by specifying a comma-separated list of member ids or screen names. The
+        authenticated user must own the list to be able to remove members from it. Note that lists can't
+        have more than 500 members, and you are limited to removing up to 100 members to a list at a time
+        with this method.
+
+        Please note that there can be issues with lists that rapidly remove and add memberships. Take care
+        when using these methods such that you are not too rapidly switching between removals and adds on
+        the same list.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/lists/members/destroy_all'
+      operationId: lists.members.destroy_all
+      responses:
+        '200':
+          description: Successful Response
+  /lists/members/show.json:
+    get:
+      description: |-
+        Check if the specified
+        user is a member of the specified list.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/lists/members/show'
+      operationId: lists.members.show
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: The screen name of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_screen_name
+        required: false
+        type: string
+      - description: The user ID of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_id
+        required: false
+        type: string
+      - description: |-
+          When set to either true, t or 1, each tweet will include a node called "entities". This node offers
+          a variety of metadata about the tweet in a discreet structure, including: user_mentions, urls, and
+          hashtags. While entities are opt-in on timelines at present, they will be made a default component
+          of output in the future.
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: 'When set to either true, t or 1 statuses will not be included in the returned user objects.'
+        in: query
+        name: skip_status
+        required: false
+        type: string
+  /lists/memberships.json:
+    get:
+      description: |-
+        Returns the lists the
+        specified user has been added to. If user_id or screen_name are not provided the memberships for the
+        authenticating user are returned.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/lists/memberships'
+      operationId: lists.memberships
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          The ID of the user for whom to return results for. Helpful for disambiguating when a valid user ID
+          is also a valid screen name.
+        in: query
+        name: user_id
+        required: false
+        type: string
+      - description: |-
+          The screen name of the user for whom to return results for. Helpful for disambiguating when a valid
+          screen name is also a user ID.
+        in: query
+        name: screen_name
+        required: false
+        type: string
+      - description: |-
+          Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin
+          paging. Provide values as returned in the response body's next_cursor and previous_cursor attributes
+          to page back and forth in the list.
+        in: query
+        name: cursor
+        required: false
+        type: string
+      - description: |-
+          When set to true, t or 1, will return just lists the authenticating user owns, and the user
+          represented by user_id or screen_name is a member of.
+        in: query
+        name: filter_to_owned_lists
+        required: false
+        type: string
+  /lists/show.json:
+    get:
+      description: |-
+        Returns the specified list.
+        Private lists will only be shown if the authenticated user owns the specified list.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/lists/show'
+      operationId: lists.show
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: The screen name of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_screen_name
+        required: false
+        type: string
+      - description: The user ID of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_id
+        required: false
+        type: string
+  /lists/statuses.json:
+    get:
+      description: |-
+        Returns tweet timeline for
+        members of the specified list. Retweets are included by default. You can use the include_rts=false
+        parameter to omit retweet objects.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/lists/statuses'
+      operationId: lists.statuses
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: The screen name of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_screen_name
+        required: false
+        type: string
+      - description: The user ID of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_id
+        required: false
+        type: string
+      - description: |-
+          Returns results with an ID greater than (that is, more recent than) the specified ID. There are
+          limits to the number of Tweets which can be accessed through the API. If the limit of Tweets has
+          occured since the since_id, the since_id will be forced to the oldest ID available.
+        in: query
+        name: since_id
+        required: false
+        type: string
+      - description: 'Returns results with an ID less than (that is, older than) or equal to the specified ID.'
+        in: query
+        name: max_id
+        required: false
+        type: string
+      - description: Specifies the number of results to retrieve per "page.
+        in: query
+        name: count
+        required: false
+        type: string
+      - description: |-
+          Entities are ON by default in API 1.1, each tweet includes a node called "entities". This node
+          offers a variety of metadata about the tweet in a discreet structure, including: user_mentions,
+          urls, and hashtags. You can omit entities from the result by using include_entities=false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: |-
+          When set to either true, t or 1, the list timeline will contain native retweets (if they exist) in
+          addition to the standard stream of tweets. The output format of retweeted tweets is identical to the
+          representation you see in home_timeline.
+        in: query
+        name: include_rts
+        required: true
+        type: string
+  /lists/subscribers.json:
+    get:
+      description: |-
+        Returns the subscribers of
+        the specified list. Private list subscribers will only be shown if the authenticated user owns the
+        specified list.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/lists/subscribers'
+      operationId: lists.subscribers
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: The screen name of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_screen_name
+        required: false
+        type: string
+      - description: The user ID of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_id
+        required: false
+        type: string
+      - description: |-
+          Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin
+          paging. Provide values as returned in the response body's next_cursor and previous_cursor attributes
+          to page back and forth in the list.
+        in: query
+        name: cursor
+        required: false
+        type: string
+      - description: |-
+          When set to either true, t or 1, each tweet will include a node called "entities". This node offers
+          a variety of metadata about the tweet in a discreet structure, including: user_mentions, urls, and
+          hashtags. While entities are opt-in on timelines at present, they will be made a default component
+          of output in the future. See Tweet Entities for more details.
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: 'When set to either true, t or 1 statuses will not be included in the returned user objects.'
+        in: query
+        name: skip_status
+        required: false
+        type: string
+  /lists/subscribers/create.json:
+    parameters:
+      - description: The screen name of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_screen_name
+        required: false
+        type: string
+      - description: The user ID of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_id
+        required: false
+        type: string
+    post:
+      description: |-
+        Subscribes the
+        authenticated user to the specified list.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/lists/subscribers/create'
+      operationId: lists.subscribers.create
+      responses:
+        '200':
+          description: Successful Response
+  /lists/subscribers/destroy.json:
+    parameters:
+      - description: The screen name of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_screen_name
+        required: false
+        type: string
+      - description: The user ID of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_id
+        required: false
+        type: string
+    post:
+      description: |-
+        Unsubscribes the
+        authenticated user from the specified list.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/lists/subscribers/destroy'
+      operationId: lists.subscribers.destroy
+      responses:
+        '200':
+          description: Successful Response
+  /lists/subscribers/show.json:
+    get:
+      description: |-
+        Check if the specified
+        user is a subscriber of the specified list. Returns the user if they are subscriber.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/lists/subscribers/show'
+      operationId: lists.subscribers.show
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: The screen name of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_screen_name
+        required: false
+        type: string
+      - description: The user ID of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_id
+        required: false
+        type: string
+      - description: |-
+          When set to either true, t or 1, each tweet will include a node called "entities". This node offers
+          a variety of metadata about the tweet in a discreet structure, including: user_mentions, urls, and
+          hashtags. While entities are opt-in on timelines at present, they will be made a default component
+          of output in the future. See Tweet Entities for more details.
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: 'When set to either true, t or 1 statuses will not be included in the returned user objects.'
+        in: query
+        name: skip_status
+        required: false
+        type: string
+  /lists/subscriptions.json:
+    get:
+      description: |-
+        Obtain a collection of
+        the lists the specified user is subscribed to, 20 lists per page by default. Does not include the
+        user's own lists.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/lists/subscriptions'
+      operationId: lists.subscriptions
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: 'The amount of results to return per page. Defaults to 20. Maximum of 1,000 when using cursors.'
+        in: query
+        name: count
+        required: false
+        type: string
+      - description: |-
+          Breaks the results into pages. A single page contains 20 lists. Provide a value of -1 to begin
+          paging. Provide values as returned in the response body's next_cursor and previous_cursor attributes
+          to page back and forth in the list. It is recommended to always use cursors when the method supports
+          them.
+        in: query
+        name: cursor
+        required: false
+        type: string
+  /lists/update.json:
+    parameters:
+      - description: The screen name of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_screen_name
+        required: false
+        type: string
+      - description: The user ID of the user who owns the list being requested by a slug.
+        in: query
+        name: owner_id
+        required: false
+        type: string
+      - description: The name for the list.
+        in: query
+        name: name
+        required: false
+        type: string
+      - description: |-
+          Whether your list is public or private. Values can be public or private. If no mode is specified
+          the list will be public.
+        in: query
+        name: mode
+        required: false
+        type: string
+      - description: The description to give the list.
+        in: query
+        name: description
+        required: false
+        type: string
+    post:
+      description: |-
+        Updates the specified list. The
+        authenticated user must own the list to be able to update it.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/lists/update'
+      operationId: lists.update
+      responses:
+        '200':
+          description: Successful Response
+  /saved_searches/create.json:
+    parameters:
+      - description: The query of the search the user would like to save.
+        in: query
+        name: query
+        required: true
+        type: string
+    post:
+      description: |-
+        Create a new saved
+        search for the authenticated user. A user may only have 25 saved searches.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/saved_searches/create'
+      operationId: saved_searches.create
+      responses:
+        '200':
+          description: Successful Response
+  '/saved_searches/destroy/{id}.json':
+    parameters:
+      - description: |-
+          The ID of the saved search.
+
+          Example Values: 313006
+        in: path
+        name: id
+        required: true
+        type: string
+    post:
+      description: |-
+        Destroys a
+        saved
+        search for the authenticating user. The authenticating user must be the owner of saved search id
+        being destroyed.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/saved_searches/destroy/%3Aid'
+      operationId: saved_searches.destroy
+      responses:
+        '200':
+          description: Successful Response
+  /saved_searches/list.json:
+    get:
+      description: |-
+        Returns the authenticated
+        user's saved search queries.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/saved_searches/list'
+      operationId: saved_searches.list
+      responses:
+        '200':
+          description: Successful Response
+    parameters: []
+  '/saved_searches/show/{id}.json':
+    get:
+      description: |-
+        Returns the
+        authenticated user's saved search queries.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/saved_searches/show/%3Aid'
+      operationId: savedsearchesid
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          The ID of the saved search.
+
+          Example Values: 313006
+        in: path
+        name: id
+        required: true
+        type: string
+  /search/tweets.json:
+    get:
+      description: |-
+        Returns a collection of
+        relevant Tweets matching a specified query.
+
+        Please note that Twitter's search service and, by extension, the Search API is not meant to be an
+        exhaustive source of Tweets. Not all Tweets will be indexed or made available via the search
+        interface.
+
+        In API v1.1, the response format of the Search API has been improved to return Tweet objects more
+        similar to the objects you'll find across the REST API and platform. You may need to tolerate some
+        inconsistencies and variance in perspectival values (fields that pertain to the perspective of the
+        authenticating user) and embedded user objects.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/search/tweets'
+      operationId: search.tweets
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          A UTF-8, URL-encoded search query of 1,000 characters maximum, including operators. Queries may
+          additionally be limited by complexity.Example: @noradio.
+        in: query
+        name: q
+        required: true
+        type: string
+      - description: |-
+          Returns tweets by users located within a given radius of the given latitude/longitude. The location
+          is preferentially taking from the Geotagging API, but will fall back to their Twitter profile. The
+          parameter value is specified by "latitude,longitude,radius", where radius units must be specified as
+          either "mi" (miles) or "km" (kilometers). Note that you cannot use the near operator via the API to
+          geocode arbitrary locations; however you can use this geocode parameter to search near geocodes
+          directly. A maximum of 1,000 distinct "sub-regions" will be considered when using the radius
+          modifier.
+        in: query
+        name: geocode
+        required: false
+        type: string
+      - description: |-
+          Restricts tweets to the given language, given by an ISO 639-1 code. Language detection is
+          best-effort.Example Values: eu
+        in: query
+        name: lang
+        required: false
+        type: string
+      - description: |-
+          Specify the language of the query you are sending (only ja is currently effective). This is
+          intended for language-specific consumers and the default should work in the majority of
+          cases.Example Values: ja
+        in: query
+        name: locale
+        required: false
+        type: string
+      - description: |-
+          Optional. Specifies what type of search results you would prefer to receive. The current default is
+          "mixed." Valid values include:
+          * mixed: Include both popular and real time results in the response.
+          * recent: return only the most recent results in the response
+          * popular: return only the most popular results in the response. Example Values: mixed, recent,
+          popular
+        in: query
+        name: result_type
+        required: false
+        type: string
+      - description: |-
+          The number of tweets to return per page, up to a maximum of 100. Defaults to 15. This was formerly
+          the "rpp" parameter in the old Search API. Example Values: 100
+        in: query
+        name: count
+        required: false
+        type: string
+      - description: |-
+          Returns tweets generated before the given date. Date should be formatted as YYYY-MM-DD. Keep in
+          mind that the search index may not go back as far as the date you specify here. Example Values:
+          2012-09-01
+        in: query
+        name: until
+        required: false
+        type: string
+      - description: |-
+          Returns results with an ID greater than (that is, more recent than) the specified ID. There are
+          limits to the number of Tweets which can be accessed through the API. If the limit of Tweets has
+          occured since the since_id, the since_id will be forced to the oldest ID available. Example Values:
+          12345
+        in: query
+        name: since_id
+        required: false
+        type: string
+      - description: |-
+          Returns results with an ID less than (that is, older than) or equal to the specified ID. Example
+          Values: 12345
+        in: query
+        name: max_id
+        required: false
+        type: string
+      - description: 'The entities node will be disincluded when set to false. Example Values: false'
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: |-
+          If supplied, the response will use the JSONP format with a callback of the given name. The
+          usefulness of this parameter is somewhat diminished by the requirement of authentication for
+          requests to this endpoint. Example Values: processTweets
+        in: query
+        name: callback
+        required: false
+        type: string
+  '/statuses/destroy/{id}.json':
+    parameters:
+      - description: The numerical ID of the desired status.
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: |-
+          When set to either true, t or 1, each tweet returned in a timeline will include a user object
+          including only the status authors numerical ID. Omit this parameter to receive the complete user
+          object.
+        in: query
+        name: trim_user
+        required: false
+        type: string
+    post:
+      description: |-
+        Destroys the status
+        specified by the required ID parameter. The authenticating user must be the author of the specified
+        status. Returns the destroyed status if successful.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/statuses/destroy/:id'
+      operationId: statuses.destroy
+      responses:
+        '200':
+          description: Successful Response
+  /statuses/home_timeline.json:
+    get:
+      description: |-
+        Returns a collection
+        of the most recent Tweets and retweets posted by the authenticating user and the users they follow.
+        The home timeline is central to how most users interact with the Twitter service.
+
+        Up to 800 Tweets are obtainable on the home timeline. It is more volatile for users that follow many
+        users or follow users who tweet frequently.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/statuses/home_timeline'
+      operationId: statuses.home_timeline
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: Specifies the number of records to retrieve. Must be less than or equal to 200.
+        in: query
+        name: count
+        required: false
+        type: integer
+      - description: 'Returns results with an ID less than (that is, older than) or equal to the specified ID.'
+        format: int64
+        in: query
+        name: max_id
+        required: false
+        type: integer
+      - description: |-
+          Returns results with an ID greater than (that is, more recent than) the specified ID. There are
+          limits to the number of Tweets which can be accessed through the API. If the limit of Tweets has
+          occured since the since_id, the since_id will be forced to the oldest ID available.
+        format: int64
+        in: query
+        name: since_id
+        required: false
+        type: integer
+      - description: |-
+          When set to either true, t or 1, each tweet returned in a timeline will include a user object
+          including only the status authors numerical ID. Omit this parameter to receive the complete user
+          object.
+        in: query
+        name: trim_user
+        required: false
+        type: string
+      - description: |-
+          This parameter will prevent replies from appearing in the returned timeline. Using exclude_replies
+          with the count parameter will mean you will receive up-to count tweets â€” this is because the count
+          parameter retrieves that many tweets before filtering out retweets and replies.
+        in: query
+        name: exclude_replies
+        required: false
+        type: string
+      - description: |-
+          This parameter enhances the contributors element of the status response to include the screen_name
+          of the contributor. By default only the user_id of the contributor is included.
+        in: query
+        name: contributor_details
+        required: false
+        type: string
+  /statuses/mentions_timeline.json:
+    get:
+      description: |-
+        Returns the 20
+        most recent mentions (tweets containing a users's @screen_name) for the authenticating user.The
+        timeline returned is the equivalent of the one seen when you view your mentions on twitter.com.This
+        method can only return up to 800 statuses.This method will include retweets in the JSON response
+        regardless of whether the include_rts parameter is set.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/statuses/mentions_timeline'
+      operationId: statuses.mentions.timeline
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          Specifies the number of tweets to try and retrieve, up to a maximum of 200. The value of count is
+          best thought of as a limit to the number of tweets to return because suspended or deleted content is
+          removed after the count has been applied. We include retweets in the count, even if include_rts is
+          not supplied. It is recommended you always send include_rts=1 when using this API method.
+        in: query
+        name: count
+        required: false
+        type: integer
+      - description: |-
+          Returns results with an ID greater than (that is, more recent than) the specified ID. There are
+          limits to the number of Tweets which can be accessed through the API. If the limit of Tweets has
+          occured since the since_id, the since_id will be forced to the oldest ID available.
+        format: int64
+        in: query
+        name: since_id
+        required: false
+        type: integer
+      - description: 'Returns results with an ID less than (that is, older than) or equal to the specified ID.'
+        format: int64
+        in: query
+        name: max_id
+        required: false
+        type: integer
+      - description: |-
+          When set to either true, t or 1, each tweet returned in a timeline will include a user object
+          including only the status authors numerical ID. Omit this parameter to receive the complete user
+          object.
+        in: query
+        name: trim_user
+        required: false
+        type: string
+      - description: |-
+          This parameter enhances the contributors element of the status response to include the screen_name
+          of the contributor. By default only the user_id of the contributor is included.
+        in: query
+        name: contributor_details
+        required: false
+        type: string
+      - description: The entities node will be disincluded when set to false.
+        in: query
+        name: include_entities
+        required: false
+        type: boolean
+  /statuses/oembed.json:
+    get:
+      description: |-
+        Returns information allowing
+        the creation of an embedded representation of a Tweet on third party sites. See the oEmbed
+        specification (http://oembed.com) for information about the response format. Either the id or url
+        parameters must be specified in a request, it is not necessary to include both. While this endpoint
+        allows a bit of customization for the final appearance of the embedded Tweet, be aware that the
+        appearance of the rendered Tweet may change over time to be consistent with Twitter's Display
+        Guidelines (https://dev.twitter.com/terms/display-guidelines). Do not rely on any class or id
+        parameters to stay constant in the returned markup.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/statuses/oembed'
+      operationId: statuses.oembed
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          The maximum width in pixels that the embed should be rendered at. This value is constrained to be
+          between 250 and 550 pixels. Note that Twitter does not support the oEmbed maxheight parameter.
+          Tweets are fundamentally text, and are therefore of unpredictable height that cannot be scaled like
+          an image or video. Relatedly, the oEmbed response will not provide a value for height.
+          Implementations that need consistent heights for Tweets should refer to the hide_thread and
+          hide_media parameters below.
+        in: query
+        name: maxwidth
+        required: false
+        type: integer
+      - description: |-
+          Specifies whether the embedded Tweet should automatically expand images which were uploaded via
+          POST statuses/update_with_media. When set to either true, t or
+          1 images will not be expanded. Defaults to false.
+        in: query
+        name: hide_media
+        required: false
+        type: string
+      - description: |-
+          Specifies whether the embedded Tweet should automatically show the original message in the case
+          that the embedded Tweet is a reply. When set to either true, t or 1 the original Tweet will not be
+          shown. Defaults to false.
+        in: query
+        name: hide_thread
+        required: false
+        type: string
+      - description: |-
+          Specifies whether the embedded Tweet HTML should include a
+          'script' element pointing to widgets.js. In cases where a page already includes widgets.js, setting
+          this
+          value to true will prevent a redundant script element from being included. When set to either true,
+          t or 1 the 'script'element will not be included in the embed HTML, meaning that pages must include a
+          reference to
+          widgets.js manually. Defaults to false.
+        in: query
+        name: omit_script
+        required: false
+        type: string
+      - description: |-
+          Specifies whether the embedded Tweet should be left aligned, right aligned, or centered in the
+          page. Valid values are left, right, center, and none. Defaults to none, meaning no alignment styles
+          are specified for the Tweet.
+        enum:
+          - left
+          - right
+          - center
+          - none
+        in: query
+        name: align
+        required: false
+        type: string
+      - description: |-
+          A value for the TWT related parameter, as described in Web Intents
+          (https://dev.twitter.com/docs/intents). This value will be forwarded to all Web Intents calls.
+          Example values: twitterapi, twittermedia, twitter.
+        in: query
+        name: related
+        required: false
+        type: string
+      - description: |-
+          Language code for the rendered embed. This will affect the text and localization of the rendered
+          HTML. Example value: fr
+        in: query
+        name: lang
+        required: false
+        type: string
+  '/statuses/retweet/{id}.json':
+    parameters:
+      - description: The numerical ID of the desired status.
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: |-
+          When set to either true, t or 1, each tweet returned in a timeline will include a user object
+          including only the status authors numerical ID. Omit this parameter to receive the complete user
+          object.
+        in: query
+        name: trim_user
+        required: false
+        type: string
+    post:
+      description: |-
+        Retweets a tweet.
+        Returns
+        the original tweet with retweet details embedded.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/statuses/retweet/:id'
+      operationId: statusesretweetid
+      responses:
+        '200':
+          description: Successful Response
+  '/statuses/retweets/{id}.json':
+    get:
+      description: |-
+        Returns up to 100 of
+        the
+        first retweets of a given tweet.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/statuses/retweets/:id'
+      operationId: statuses.retweets
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: The numerical ID of the desired status.
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Specifies the number of records to retrieve. Must be less than or equal to 100.
+        in: query
+        name: count
+        required: false
+        type: string
+      - description: |-
+          When set to either true, t or 1, each tweet returned in a timeline will include a user object
+          including only the status authors numerical ID. Omit this parameter to receive the complete user
+          object.
+        in: query
+        name: trim_user
+        required: false
+        type: string
+  '/statuses/show/{id}.json':
+    get:
+      description: |-
+        Returns a single status,
+        specified by the id parameter below. The status's author will be returned inline.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/statuses/show/:id'
+      operationId: statuses.show
+      parameters:
+        - in: path
+          name: id
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: The numerical ID of the desired status.
+        in: query
+        name: id
+        required: true
+        type: string
+      - description: |-
+          When set to either true, t or 1, each tweet returned in a timeline will include a user object
+          including only the status authors numerical ID. Omit this parameter to receive the complete user
+          object.
+        in: query
+        name: trim_user
+        required: false
+        type: string
+      - description: |-
+          When set to either true, t or 1, any Tweets returned that have been retweeted by the authenticating
+          user will include an additional current_user_retweet node, containing the ID of the source status
+          for the retweet.
+        in: query
+        name: include_my_retweet
+        required: false
+        type: string
+      - description: The entities node will be disincluded when set to false.
+        in: query
+        name: include_entities
+        required: false
+        type: string
+  /statuses/update.json:
+    parameters:
+      - default: 'Posting from @apigee''s API test console. It''s like a command line for the Twitter API! #apitools'
+        description: |-
+          The text of your status update, typically up to 140 characters. URL encode as necessary. t.co link
+          short-url wrapping (https://dev.twitter.com/docs/tco-link-wrapper/faq) may effect character counts.
+        in: query
+        name: status
+        required: true
+        type: string
+      - description: |-
+          The ID of an existing status that the update is in reply to. Note: This parameter will be ignored
+          unless the author of the tweet this parameter references is mentioned within the status text.
+          Therefore, you must include @username, where username is the author of the referenced tweet, within
+          the update.
+        in: query
+        name: in_reply_to_status_id
+        required: false
+        type: string
+      - default: '37.426363'
+        description: |-
+          The latitude of the location this tweet refers to. This parameter will be ignored unless it is
+          inside the range -90.0 to +90.0 (North is positive) inclusive. It will also be ignored if there
+          isn't a corresponding long parameter.
+        in: query
+        name: lat
+        required: false
+        type: string
+      - default: '-122.141114'
+        description: |-
+          The longitude of the location this tweet refers to. The valid ranges for longitude is -180.0 to
+          +180.0 (East is positive) inclusive. This parameter will be ignored if outside that range, if it is
+          not a number, if geo_enabled is disabled, or if there not a corresponding lat parameter.
+        in: query
+        name: long
+        required: false
+        type: string
+      - description: |-
+          A place in the world. These IDs can be retrieved from GET geo/reverse_geocode
+          (https://dev.twitter.com/docs/api/1/get/geo/reverse_geocode).
+        in: query
+        name: place_id
+        required: false
+        type: string
+      - default: 'false'
+        description: Whether or not to put a pin on the exact coordinates a tweet has been sent from.
+        enum:
+          - 'false'
+          - 'true'
+          - ''
+        in: query
+        name: display_coordinates
+        required: false
+        type: string
+      - description: |-
+          When set to either true, t or 1, each tweet returned in a timeline will include a user object
+          including only the status authors numerical ID. Omit this parameter to receive the complete user
+          object.
+        in: query
+        name: trim_user
+        required: false
+        type: string
+    post:
+      description: |-
+        Updates the authenticating
+        user's status, also known as tweeting. To upload an image to accompany the tweet, use POST
+        statuses/update_with_media (https://dev.twitter.com/docs/api/1/post/statuses/update_with_media). For
+        each update attempt, the update text is compared with the authenticating user's recent tweets. Any
+        attempt that would result in duplication will be blocked, resulting in a 403 error. Therefore, a
+        user cannot submit the same status twice in a row. While not rate limited by the API a user is
+        limited in the number of tweets they can create at a time. If the number of updates posted by the
+        user reaches the current allowed limit this method will return an HTTP 403 error.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/statuses/update'
+      operationId: statuses.update
+      responses:
+        '200':
+          description: Successful Response
+  /statuses/update_with_media.json:
+    parameters:
+      - description: |-
+          The text of your status update. URL encode as necessary. t.co link wrapping
+          (https://dev.twitter.com/docs/tco-link-wrapper/faq) may affect character counts if the post contains
+          URLs. You must additionally account for the characters_reserved_per_media per uploaded media,
+          additionally accounting for space characters in between finalized URLs. Note: Request the GET
+          help/configuration (https://dev.twitter.com/docs/api/1.1/get/help/configuration) endpoint to get the
+          current characters_reserved_per_media and max_media_per_upload values.
+        in: query
+        name: status
+        required: true
+        type: string
+      - description: |-
+          Up to max_media_per_upload files may be specified in the request, each named media[]. Supported
+          image formats are PNG, JPG and GIF. Animated GIFs are not supported. Note: Request the GET
+          help/configuration (https://dev.twitter.com/docs/api/1.1/get/help/configuration) endpoint to get the
+          current max_media_per_upload and photo_size_limit values.
+        in: query
+        name: media
+        required: true
+        type: string
+      - description: Set to true for content which may not be suitable for every audience.
+        in: query
+        name: possibly_sensitive
+        required: false
+        type: string
+      - description: |-
+          The ID of an existing status that the update is in reply to. Note: This parameter will be ignored
+          unless the author of the tweet this parameter references is mentioned within the status text.
+          Therefore, you must include @username, where username is the author of the referenced tweet, within
+          the update.
+        in: query
+        name: in_reply_to_status_id
+        required: false
+        type: string
+      - description: |-
+          The latitude of the location this tweet refers to. This parameter will be ignored unless it is
+          inside the range -90.0 to +90.0 (North is positive) inclusive. It will also be ignored if there
+          isn't a corresponding long parameter. Example value: 37.7821120598956.
+        in: query
+        name: lat
+        required: false
+        type: string
+      - description: |-
+          The longitude of the location this tweet refers to. The valid ranges for longitude is -180.0 to
+          +180.0 (East is positive) inclusive. This parameter will be ignored if outside that range, not a
+          number, geo_enabled is disabled, or if there not a corresponding lat parameter. Example value:
+          -122.400612831116.
+        in: query
+        name: long
+        required: false
+        type: string
+      - description: |-
+          A place in the world identified by a Twitter place ID. Place IDs can be retrieved from
+          geo/reverse_geocode.
+        in: query
+        name: place_id
+        required: false
+        type: string
+      - description: Whether or not to put a pin on the exact coordinates a tweet has been sent from.
+        in: query
+        name: display_coordinates
+        required: false
+        type: string
+    post:
+      description: |-
+        Updates the
+        authenticating user's status and attaches media for upload. Unlike POST statuses/update
+        (https://dev.twitter.com/docs/api/1.1/post/statuses/update), this method expects raw multipart data.
+        Your POST request's Content-Type should be set to multipart/form-data with the media[] parameter.
+        The Tweet text will be rewritten to include the media URL(s), which will reduce the number of
+        characters allowed in the Tweet text. If the URL(s) cannot be appended without text truncation, the
+        tweet will be rejected and this method will return an HTTP 403 error. Important: Make sure that
+        you're using upload.twitter.com as your host while posting statuses with media. It is strongly
+        recommended to use SSL with this method.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/statuses/update_with_media'
+      operationId: statuses.update_with_media
+      parameters:
+        - default: multipart/form-data
+          description: Content type.
+          in: header
+          name: Content-Type
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Successful Response
+  /statuses/user_timeline.json:
+    get:
+      description: |-
+        Returns the 20 most
+        recent statuses posted by the authenticating user. It is also possible to request another user's
+        timeline by using the screen_name or user_id parameter. The other users timeline will only be
+        visible if they are not protected, or if the authenticating user's follow request was accepted by
+        the protected user. The timeline returned is the equivalent of the one seen when you view a user's
+        profile on twitter.com. This method can only return up to 3,200 of a user's most recent statuses.
+        Native retweets of other statuses by the user is included in this total, regardless of whether
+        include_rts is specified when requesting this resource. This method will not include retweets in the
+        XML and JSON responses unless the include_rts parameter is set. The RSS and Atom responses will
+        always include retweets as statuses prefixed with RT, regardless of provided parameters. Always
+        specify either an user_id or screen_name when requesting a user timeline.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/statuses/user_timeline'
+      operationId: statuses.user_timeline
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          Specifies the number of tweets to try and retrieve, up to a maximum of 200. The value of count is
+          best thought of as a limit to the number of tweets to return because suspended or deleted content is
+          removed after the count has been applied. We include retweets in the count, even if include_rts is
+          not supplied. It is recommended you always send include_rts=1 when using this API method.
+        in: query
+        name: count
+        required: false
+        type: integer
+      - description: |-
+          Returns results with an ID greater than (that is, more recent than) the specified ID. There are
+          limits to the number of Tweets which can be accessed through the API. If the limit of Tweets has
+          occured since the since_id, the since_id will be forced to the oldest ID available.
+        format: int64
+        in: query
+        name: since_id
+        required: false
+        type: integer
+      - description: 'Returns results with an ID less than (that is, older than) or equal to the specified ID.'
+        format: int64
+        in: query
+        name: max_id
+        required: false
+        type: integer
+      - description: |-
+          When set to either true, t or 1, each tweet returned in a timeline will include a user object
+          including only the status authors numerical ID. Omit this parameter to receive the complete user
+          object.
+        in: query
+        name: trim_user
+        required: false
+        type: string
+      - description: |-
+          This parameter will prevent replies from appearing in the returned timeline. Using exclude_replies
+          with the count parameter will mean you will receive up-to count tweets â€” this is because the count
+          parameter retrieves that many tweets before filtering out retweets and replies. This parameter is
+          only supported for JSON and XML responses.
+        in: query
+        name: exclude_replies
+        required: false
+        type: boolean
+      - description: |-
+          This parameter enhances the contributors element of the status response to include the screen_name
+          of the contributor. By default only the user_id of the contributor is included.
+        in: query
+        name: contributor_details
+        required: false
+        type: boolean
+      - description: |-
+          When set to false, the timeline will strip any native retweets (though they will still count toward
+          both the maximal length of the timeline and the slice selected by the count parameter). Note: If
+          you're using the trim_user parameter in conjunction with include_rts, the retweets will still
+          contain a full user object.
+        in: query
+        name: include_rts
+        required: false
+        type: boolean
+  /trends/available.json:
+    get:
+      description: |-
+        Returns the locations that
+        Twitter has trending topic information for.
+
+        The response is an array of "locations" that encode the location's WOEID and some other
+        human-readable information such as a canonical name and country the location belongs in.
+
+        A WOEID is a Yahoo! Where On Earth ID.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/trends/available'
+      operationId: trends.available
+      responses:
+        '200':
+          description: Successful Response
+    parameters: []
+  /trends/closest.json:
+    get:
+      description: |-
+        Returns the locations that
+        Twitter has trending topic information for, closest to a specified location.
+
+        The response is an array of "locations" that encode the location's WOEID and some other
+        human-readable information such as a canonical name and country the location belongs in.
+
+        A WOEID is a Yahoo! Where On Earth ID.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/trends/closest'
+      operationId: trends.closest
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          If provided with a long parameter the available trend locations will be sorted by distance, nearest
+          to furthest, to the co-ordinate pair. The valid ranges for longitude is -180.0 to +180.0 (West is
+          negative, East is positive) inclusive.
+
+          Example Values: 37.781157
+        in: query
+        name: lat
+        required: false
+        type: string
+      - description: |-
+          If provided with a lat parameter the available trend locations will be sorted by distance, nearest
+          to furthest, to the co-ordinate pair. The valid ranges for longitude is -180.0 to +180.0 (West is
+          negative, East is positive) inclusive.
+
+          Example Values: -122.400612831116
+        in: query
+        name: long
+        required: false
+        type: string
+  /trends/place.json:
+    get:
+      description: |-
+        Returns the top 10 trending
+        topics for a specific WOEID, if trending information is available for it.
+
+        The response is an array of "trend" objects that encode the name of the trending topic, the query
+        parameter that can be used to search for the topic on Twitter Search, and the Twitter Search URL.
+
+        This information is cached for 5 minutes. Requesting more frequently than that will not return any
+        more data, and will count against your rate limit usage.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/trends/place'
+      operationId: trends.place
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          The Yahoo! Where On Earth ID of the location to return trending information for. Global information
+          is available by using 1 as the WOEID.
+        in: query
+        name: id
+        required: true
+        type: string
+      - description: Setting this equal to hashtags will remove all hashtags from the trends list.
+        in: query
+        name: exclude
+        required: false
+        type: string
+  /users/contributees.json:
+    get:
+      description: |-
+        Returns a collection of
+        users that the specified user can contribute to.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/users/contributees'
+      operationId: users.contributees
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: 'The entities node will be disincluded when set to false. Example Values: false'
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: 'When set to either true, t or 1 statuses will not be included in the returned user objects.'
+        in: query
+        name: skip_status
+        required: false
+        type: string
+  /users/contributors.json:
+    get:
+      description: |-
+        Returns a collection of
+        users who can contribute to the specified account.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/users/contributors'
+      operationId: users.contributors
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: 'The entities node will be disincluded when set to false. Example Values: false'
+        in: query
+        name: include_entities
+        required: false
+        type: string
+      - description: 'When set to either true, t or 1 statuses will not be included in the returned user objects.'
+        in: query
+        name: skip_status
+        required: false
+        type: string
+  /users/lookup.json:
+    get:
+      description: |-
+        Returns fully-hydrated user
+        objects for up to 100 users per request, as specified by comma-separated values passed to the
+        user_id and/or screen_name parameters.
+
+        This method is especially useful when used in conjunction with collections of user IDs returned from
+        GET friends/ids and GET followers/ids.
+
+        GET users/show is used to retrieve a single user object.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/users/lookup'
+      operationId: users.lookup
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          A comma separated list of screen names, up to 100 are allowed in a single request. You are strongly
+          encouraged to use a POST for larger (up to 100 screen names) requests.
+
+          Example Values: twitterapi,twitter
+        in: query
+        name: screen_name
+        required: false
+        type: string
+      - description: |-
+          A comma separated list of user IDs, up to 100 are allowed in a single request. You are strongly
+          encouraged to use a POST for larger requests.
+
+          Example Values: 783214,6253282
+        in: query
+        name: user_id
+        required: false
+        type: string
+      - description: |-
+          The entities node that may appear within embedded statuses will be disincluded when set to false.
+
+          Example Values: false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+  /users/report_spam.json:
+    parameters: []
+    post:
+      description: |-
+        The user
+        specified in the id is blocked by the authenticated user and reported as a spammer.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/post/report_spam'
+      operationId: users.report_spam
+      responses:
+        '200':
+          description: Successful Response
+  /users/search.json:
+    get:
+      description: |-
+        Provides a simple,
+        relevance-based search interface to public user accounts on Twitter. Try querying by topical
+        interest, full name, company name, location, or other criteria. Exact match searches are not
+        supported.
+
+        Only the first 1,000 matching results are available.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/users/search'
+      operationId: users.search
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          The search query to run against people search.
+
+          Example Values: Twitter%20API
+        in: query
+        name: q
+        required: true
+        type: string
+      - description: |-
+          Specifies the page of results to retrieve.
+
+          Example Values: 3
+        in: query
+        name: page
+        required: false
+        type: string
+      - description: |-
+          The number of potential user results to retrieve per page. This value has a maximum of 20.
+
+          Example Values: 5
+        in: query
+        name: count
+        required: false
+        type: string
+      - description: |-
+          The entities node will be disincluded when set to false.
+
+          Example Values: false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+  /users/show.json:
+    get:
+      description: |-
+        Returns a variety of information
+        about the user specified by the required user_id or screen_name parameter. The author's most recent
+        Tweet will be returned inline when possible.
+
+        GET users/lookup is used to retrieve a bulk collection of user objects.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/users/show'
+      operationId: users.show
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          The screen name of the user for whom to return results for. Either a id or screen_name is required
+          for this method.
+
+          Example Values: noradio
+        in: query
+        name: screen_name
+        required: true
+        type: string
+      - description: |-
+          The ID of the user for whom to return results for. Either an id or screen_name is required for this
+          method.
+
+          Example Values: 12345
+        in: query
+        name: user_id
+        required: true
+        type: string
+      - description: |-
+          The entities node will be disincluded when set to false.
+
+          Example Values: false
+        in: query
+        name: include_entities
+        required: false
+        type: string
+  /users/suggestions.json:
+    get:
+      description: |-
+        Access to Twitter's
+        suggested user list. This returns the list of suggested user categories. The category can be used in
+        GET users/suggestions/:slug to get the users in that category.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/users/suggestions'
+      operationId: users.suggestions
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          Restricts the suggested categories to the requested language. The language must be specified by the
+          appropriate two letter ISO 639-1 representation. Currently supported languages are provided by the
+          GET help/languages API request. Unsupported language codes will receive English (en) results. If you
+          use lang in this request, ensure you also include it when requesting the GET users/suggestions/:slug
+          list.
+        in: query
+        name: lang
+        required: false
+        type: string
+  '/users/suggestions/{slug}.json':
+    get:
+      description: |-
+        Access the users in
+        a given category of the Twitter suggested user list. It is recommended that applications cache this
+        data for no more than one hour.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/users/suggestions/%3Aslug'
+      operationId: users.suggestions.slug
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          The short name of list or a category
+
+          Example Values: twitter
+        in: path
+        name: slug
+        required: true
+        type: string
+      - description: |-
+          Restricts the suggested categories to the requested language. The language must be specified by the
+          appropriate two letter ISO 639-1 representation. Currently supported languages are provided by the
+          GET help/languages API request. Unsupported language codes will receive English (en) results. If you
+          use lang in this request, ensure you also include it when requesting the GET users/suggestions/:slug
+          list.
+        in: query
+        name: lang
+        required: false
+        type: string
+  '/users/suggestions/{slug}/members.json':
+    get:
+      description: |-
+        Access the
+        users in a given category of the Twitter suggested user list and return their most recent status if
+        they are not a protected user.
+      externalDocs:
+        url: 'https://dev.twitter.com/docs/api/1.1/get/users/suggestions/%3Aslug/members'
+      operationId: users.suggestionsslugmembers
+      responses:
+        '200':
+          description: Successful Response
+    parameters:
+      - description: |-
+          The short name of list or a category
+
+          Example Values: twitter
+        in: path
+        name: slug
+        required: true
+        type: string


### PR DESCRIPTION
refs - issue #1204 
Reading the spec for 2.0 swagger version, https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#contact-object has the vendor extension as valid.

The fix was made in  https://github.com/swagger-api/swagger-core/pull/3320, which need to be reviewed and merged before this PR.