### PR TITLE
Issue with resolving a external $ref in a relative subfolder.

### DIFF
--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -1323,6 +1323,17 @@ public class OpenAPIV3ParserTest {
         assertEquals(refModel.get$ref(), "#/components/schemas/Pet");
     }
 
+    @Test
+    public void testRelativePath() {
+        OpenAPIV3Parser parser = new OpenAPIV3Parser();
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        SwaggerParseResult readResult = parser.readLocation("src/test/resources/relative-issue/api.yaml", null, options);
+        if (readResult.getMessages().size() > 0) {
+            fail(Json.pretty(readResult.getMessages()));
+        }
+    }
+
     private OpenAPI doRelativeFileTest(String location) {
         OpenAPIV3Parser parser = new OpenAPIV3Parser();
         ParseOptions options = new ParseOptions();

--- a/modules/swagger-parser-v3/src/test/resources/relative-issue/api.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/relative-issue/api.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.0
+info:
+  version: '0.0.1'
+  title: 'Parser debug'
+  description: 'Parser debug'
+paths:
+  /scans:
+    get:
+      responses:
+        200:
+          description: Yay
+        500:
+          $ref: './subfolder/domain.yaml#/components/responses/ErrorResponse'

--- a/modules/swagger-parser-v3/src/test/resources/relative-issue/subfolder/domain.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/relative-issue/subfolder/domain.yaml
@@ -1,0 +1,49 @@
+openapi: 3.0.0
+
+info:
+  title: My domain
+  description: My domain
+  version: '0.0.1'
+
+paths: {}
+
+components:
+  responses:
+    ErrorResponse:
+      description: An error has occurred
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorMessage'
+  schemas:
+    ErrorMessage:
+      type: object
+      required:
+        - timestamp
+        - path
+        - status
+      properties:
+        timestamp:
+          description: The timestamp of when the error occurred
+          type: string
+          format: date-time
+        path:
+          description: Requested path
+          type: string
+        status:
+          description: HTTP status code
+          type: integer
+        error:
+          description: HTTP response phrase
+          type: string
+        message:
+          description: Error message
+          type: string
+        requestId:
+          description: Internal request id
+          type: string
+        errors:
+          description: Detailed error descriptions
+          type: array
+          items:
+            type: object


### PR DESCRIPTION
This is not a suggested fix, just a PR to reproduce a problem I ran into with a minimal example.

I have a ref like `$ref: './subfolder/domain.yaml#/components/responses/ErrorResponse`
When resolving I get the following error `Unable to load RELATIVE ref: ./subfolder/subfolder/domain.yaml`
Note the double ./subfolder/subfolder! Where did it come from?