### PR TITLE
fixed a NPE occurred during processing discriminator in an empty model,

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/processors/ExternalRefProcessor.java
@@ -199,6 +199,9 @@ public final class ExternalRefProcessor {
     }
 
     private void processDiscriminator(String discriminator, Map<String, Property> properties, String file) {
+    	if (properties == null || properties.isEmpty()) {
+    		return;
+    	}
         for (Map.Entry<String, Property> prop : properties.entrySet()) {
             if (prop.getKey().equals(discriminator)){
                 if (prop.getValue() instanceof StringProperty){


### PR DESCRIPTION
e.g. properties of Contact model is empty.

Contact:
  type: object
  discriminator: jsi_type
  properties: {}
ContactEmail:
  allOf:
    - $ref: '#/definitions/Contact'
    - type: object
      required:
        - emailAddress
      properties:
        emailAddress:
          type: string
