### PR TITLE
Fix duplicate '.responses' in location string.

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -2669,7 +2669,7 @@ public class OpenAPIDeserializer {
                     apiResponses.setExtensions(extensions);
                 }
             } else {
-                ObjectNode obj = getObject(key, node, false, String.format("%s.%s", location, "responses"), result);
+                ObjectNode obj = getObject(key, node, false, location, result);
                 if (obj != null) {
                     ApiResponse response = getResponse(obj, String.format("%s.%s", location, key), result);
                     if (response != null) {


### PR DESCRIPTION
Issue: https://github.com/swagger-api/swagger-parser/issues/1273