### PR TITLE
Issue 1299 Swagger 2.0 external parameters broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ target/
 .classpath
 .project
 .settings/
-**/test-output/*
+**/test-output/

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/ResolverCache.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/ResolverCache.java
@@ -169,8 +169,10 @@ public class ResolverCache {
 	}
 
 	private void loadRef(String ref, RefFormat refFormat, final RefModel refModel) {
-		final String rootRef = ref.substring(0, ref.indexOf('#')); 
-		final Model derefModel = loadRef(rootRef + refModel.getReference(), refFormat, Model.class);
+		final String rootRef = ref.substring(0, ref.indexOf('#'));
+		final String externalRef = RefUtils.isAnExternalRefFormat(refModel.getRefFormat()) ? refModel.getReference()
+				: rootRef + refModel.getReference();
+		final Model derefModel = loadRef(externalRef, refFormat, Model.class);
 		swagger.addDefinition(refModel.getSimpleRef(), derefModel);
 	}
 

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -57,1269 +57,1179 @@ import static org.testng.Assert.fail;
 public class SwaggerParserTest {
 
     @Test
-	public void testIssue1143() {
-		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue1143.json", null, true);
-		assertNotNull(result.getSwagger().getDefinitions().get("RedisResource"));
-		assertNotNull(result.getSwagger().getDefinitions().get("identificacion_usuario_aplicacion"));
-	}
-
-	@Test
-	public void testIssue1204() {
-		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue1204.yaml", null, true);
-		System.out.println(result.getMessages());
-		assertTrue(result.getMessages().size() == 0);
-		assertNotNull(result.getSwagger());
-
-	}
-
-	@Test
-	public void testIssue1169() {
-		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue1169.yaml", null, true);
-		assertTrue(result.getMessages().size() == 0);
-		assertNotNull(result.getSwagger());
-	}
-
-	@Test
-	public void testIssueRelativeRefs2() {
-		String location = "exampleSpecs/specs/my-domain/test-api/v1/test-api-swagger_v1.json";
-		Swagger swagger = new SwaggerParser().read(location, null, true);
-		assertNotNull(swagger);
-		Map<String, Model> definitions = swagger.getDefinitions();
-		Assert.assertTrue(
-				definitions.get("confirmMessageType_v01").getProperties().get("resources") instanceof ArrayProperty);
-		ArrayProperty arraySchema = (ArrayProperty) definitions.get("confirmMessageType_v01").getProperties()
-				.get("resources");
-		ObjectProperty prop = (ObjectProperty) arraySchema.getItems();
-		RefProperty refProperty = (RefProperty) prop.getProperties().get("resourceID");
-		assertEquals(refProperty.get$ref(), "#/definitions/simpleIDType_v01");
-	}
-
-	@Test
-	public void testIssue111() {
-		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue-111.yaml", null, true);
-		assertTrue(result.getMessages().get(0).equals("attribute definitions.Filter.items is missing"));
-		assertNotNull(result.getSwagger());
-	}
-
-	@Test
-	public void testIssue1146() {
-		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue-1146.yaml", null, true);
-		assertEquals(0, result.getMessages().size());
-	}
-
-	@Test
-	public void testIssueDefinitionWithDots_2() {
-		Swagger swagger = new SwaggerParser().read("SimpleAPI.yaml");
-		assertNotNull(swagger);
-	}
-
-	@Test
-	public void testIssueDefinitionWithDots() {
-		Swagger swagger = new SwaggerParser().read("API-Service-2.0.0-swagger.yaml");
-		assertNotNull(swagger);
-	}
-
-	@Test
-	public void testIssue995() {
-		Swagger swagger = new SwaggerParser().read("issue-995/digitalExp-Product-Unresolved.yaml");
-		assertNotNull(swagger);
-		assertTrue(swagger.getDefinitions().size() == 6);
-		assertNotNull(swagger.getDefinitions().get("MobileProduct"));
-		assertNotNull(swagger.getDefinitions().get("FixedVoiceProduct"));
-		assertNotNull(swagger.getDefinitions().get("InternetProduct"));
-	}
-
-	@Test
-	public void testIssue927() {
-		Swagger swagger = new SwaggerParser().read("issue-927/issue-927.yaml");
-		assertNotNull(swagger);
-		assertTrue(swagger.getDefinitions().size() == 3);
-		assertNotNull(swagger.getDefinitions().get("Pet"));
-		assertNotNull(swagger.getDefinitions().get("Cat"));
-		assertNotNull(swagger.getDefinitions().get("Dog"));
-	}
-
-	@Test
-	public void testIssue901_2() {
-		Swagger swagger = new SwaggerParser().read("issue-901/spec2.yaml");
-		assertNotNull(swagger);
-		assertNotNull(swagger.getDefinitions());
-		ArrayProperty arraySchema = (ArrayProperty) swagger.getDefinitions().get("Test.Definition").getProperties()
-				.get("stuff");
-		String internalRef = ((RefProperty) arraySchema.getItems()).get$ref();
-		assertEquals(internalRef, "#/definitions/TEST.THING.OUT.Stuff");
-	}
-
-	@Test
-	public void testIssue901() {
-		Swagger swagger = new SwaggerParser().read("issue-901/spec.yaml");
-		assertNotNull(swagger);
-		String internalRef = ((RefModel) swagger.getPaths().get("/test").getPut().getResponses().get("200")
-				.getResponseSchema()).get$ref();
-		assertEquals(internalRef, "#/definitions/Test.Definition");
-		assertNotNull(swagger.getDefinitions());
-
-	}
-
-	@Test
-	public void testIssue435() {
-		Swagger swagger = new SwaggerParser().read("issue-435/main.yaml");
-		assertNotNull(swagger.getDefinitions().get("sub"));
-		assertNotNull(swagger.getDefinitions().get("subsub"));
-	}
-
-	@Test
-	public void testIssue845() {
-		SwaggerDeserializationResult swaggerDeserializationResult = new SwaggerParser().readWithInfo("");
-		assertEquals(swaggerDeserializationResult.getMessages().get(0), "empty or null swagger supplied");
-	}
-
-	@Test
-	public void testIssue834() {
-		Swagger swagger = new SwaggerParser().read("issue-834/index.yaml", null, true);
-		assertNotNull(swagger);
-
-		Response foo200 = swagger.getPaths().get("/foo").getGet().getResponses().get("200");
-		assertNotNull(foo200);
-		RefModel model200 = (RefModel) foo200.getResponseSchema();
-		String foo200SchemaRef = model200.get$ref();
-		assertEquals(foo200SchemaRef, "#/definitions/schema");
-
-		Response foo300 = swagger.getPaths().get("/foo").getGet().getResponses().get("300");
-		assertNotNull(foo300);
-		RefModel model300 = (RefModel) foo300.getResponseSchema();
-		String foo300SchemaRef = model300.get$ref();
-		assertEquals(foo300SchemaRef, "#/definitions/schema");
-
-		Response bar200 = swagger.getPaths().get("/bar").getGet().getResponses().get("200");
-		assertNotNull(bar200);
-		RefModel modelBar200 = (RefModel) bar200.getResponseSchema();
-		String bar200SchemaRef = modelBar200.get$ref();
-		assertEquals(bar200SchemaRef, "#/definitions/schema");
-	}
-
-	@Test
-	public void testIssue811_RefSchema_ToRefSchema() {
-		final Swagger swagger = new SwaggerParser().read("oapi-reference-test2/index.yaml", null, true);
-		Assert.assertNotNull(swagger);
-		RefModel model = (RefModel) swagger.getPaths().get("/").getGet().getResponses().get("200").getResponseSchema();
-		Assert.assertEquals(model.get$ref(), "#/definitions/schema-with-reference");
-	}
-
-	@Test
-	public void testIssue811() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/oapi-reference-test/index.yaml");
-		Assert.assertNotNull(swagger);
-		assertTrue(
-				swagger.getPaths().get("/").getGet().getResponses().get("200").getResponseSchema() instanceof RefModel);
-		RefModel model = (RefModel) swagger.getPaths().get("/").getGet().getResponses().get("200").getResponseSchema();
-		Assert.assertEquals(model.get$ref(), "#/definitions/schema-with-reference");
-
-	}
-
-	@Test
-	public void testIssue727() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/issue-714/serviceA.yaml");
-		Assert.assertNotNull(swagger);
-		assertNotNull(swagger.getPaths().get("/test").getGet().getParameters().get(0));
-		assertTrue(swagger.getDefinitions().size() == 1);
-		assertNotNull(swagger.getDefinitions().get("refA"));
-	}
-
-	@Test
-	public void testIssue704() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/sample/swagger.json");
-		Assert.assertNotNull(swagger);
-
-		assertNotNull(swagger.getPaths().get("/api/Address").getGet());
-		assertTrue(swagger.getDefinitions().size() == 1);
-		assertNotNull(swagger.getDefinitions().get("AddressEx"));
-	}
-
-	@Test
-	public void testIssue697() throws Exception {
-		String yaml = "{\n" + "    \"swagger\": \"2.0\",\n" + "    \"info\": {\n" + "        \"version\": \"1.0\",\n"
-				+ "        \"title\": \"x-example\"\n" + "    },\n" + "    \"host\": \"httpbin.org\",\n"
-				+ "    \"basePath\": \"/anything\",\n" + "    \"schemes\": [\n" + "        \"http\"\n" + "    ],\n"
-				+ "    \"paths\": {\n" + "        \"/{foo}\": {\n" + "            \"get\": {\n"
-				+ "                \"responses\": {\n" + "                    \"200\": {\n"
-				+ "                        \"description\": \"OK\"\n" + "                    }\n"
-				+ "                },\n" + "                \"deprecated\": false\n" + "            }\n" + "        }\n"
-				+ "    }\n" + "}";
-
-		SwaggerParser parser = new SwaggerParser();
-
-		Swagger swagger = parser.parse(yaml);
-		assertFalse(swagger.getPaths().get("/{foo}").getGet().isDeprecated());
-
-	}
-
-	@Test
-	public void testNPEIssue684() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/issue-684.json");
-		Assert.assertNotNull(swagger);
-		assertTrue(swagger.getParameters().get("ParamDef3") instanceof RefParameter);
-	}
-
-	@Test
-	public void testRefPaths() throws Exception {
-		String yaml = "swagger: '2.0'\n" + "info:\n" + "  version: 0.0.0\n" + "  title: Path item $ref test\n"
-				+ "paths:\n" + "  /foo:\n" + "    get:\n" + "      responses:\n" + "        200:\n"
-				+ "          description: OK\n" + "  /foo2:\n" + "    $ref: '#/paths/~1foo'";
-
-		SwaggerParser parser = new SwaggerParser();
-
-		Swagger swagger = parser.parse(yaml);
-
-		assertEquals(swagger.getPaths().get("foo"), swagger.getPaths().get("foo2"));
-
-	}
-
-	@Test
-	public void testModelParameters() throws Exception {
-		String yaml = "swagger: '2.0'\n" + "info:\n" + "  version: \"0.0.0\"\n" + "  title: test\n" + "paths:\n"
-				+ "  /foo:\n" + "    get:\n" + "      parameters:\n" + "      - name: amount\n" + "        in: body\n"
-				+ "        schema:\n" + "          type: integer\n" + "          format: int64\n"
-				+ "          description: amount of money\n" + "          default: 1000\n"
-				+ "          maximum: 100000\n" + "      responses:\n" + "        200:\n" + "          description: ok";
-
-		SwaggerParser parser = new SwaggerParser();
-
-		Swagger swagger = parser.parse(yaml);
-
-	}
-
-	@Test
-	public void testParseSharedPathParameters() throws Exception {
-		String yaml = "swagger: '2.0'\n" + "info:\n" + "  version: \"0.0.0\"\n" + "  title: test\n" + "paths:\n"
-				+ "  /persons/{id}:\n" + "    parameters:\n" + "      - in: path\n" + "        name: id\n"
-				+ "        type: string\n" + "        required: true\n" + "        description: \"no\"\n" + "    get:\n"
-				+ "      parameters:\n" + "        - name: id\n" + "          in: path\n" + "          required: true\n"
-				+ "          type: string\n" + "          description: \"yes\"\n" + "        - name: name\n"
-				+ "          in: query\n" + "          type: string\n" + "      responses:\n" + "        200:\n"
-				+ "          description: ok\n";
-
-		SwaggerParser parser = new SwaggerParser();
-
-		Swagger swagger = parser.parse(yaml);
-		List<Parameter> parameters = swagger.getPath("/persons/{id}").getGet().getParameters();
-		assertTrue(parameters.size() == 2);
-		Parameter id = parameters.get(0);
-		assertEquals(id.getDescription(), "yes");
-	}
-
-	@Test
-	public void testParseRefPathParameters() throws Exception {
-		String yaml = "swagger: '2.0'\n" + "info:\n" + "  title: test\n" + "  version: '0.0.0'\n" + "parameters:\n"
-				+ "  report-id:\n" + "    name: id\n" + "    in: path\n" + "    type: string\n" + "    required: true\n"
-				+ "paths:\n" + "  /reports/{id}:\n" + "    parameters:\n" + "        - $ref: '#/parameters/report-id'\n"
-				+ "    put:\n" + "      parameters:\n" + "        - name: id\n" + "          in: body\n"
-				+ "          required: true\n" + "          schema:\n" + "            $ref: '#/definitions/report'\n"
-				+ "      responses:\n" + "        200:\n" + "          description: ok\n" + "definitions:\n"
-				+ "  report:\n" + "    type: object\n" + "    properties:\n" + "      id:\n" + "        type: string\n"
-				+ "      name:\n" + "        type: string\n" + "    required:\n" + "    - id\n" + "    - name\n";
-		SwaggerParser parser = new SwaggerParser();
-		Swagger swagger = parser.parse(yaml);
-	}
-
-	@Test
-	public void testUniqueParameters() throws Exception {
-		String yaml = "swagger: '2.0'\n" + "info:\n" + "  title: test\n" + "  version: '0.0.0'\n" + "parameters:\n"
-				+ "  foo-id:\n" + "    name: id\n" + "    in: path\n" + "    type: string\n" + "    required: true\n"
-				+ "paths:\n" + "  /foos/{id}:\n" + "    parameters:\n" + "        - $ref: '#/parameters/foo-id'\n"
-				+ "    get:\n" + "      responses:\n" + "        200:\n" + "          schema:\n"
-				+ "            $ref: '#/definitions/foo'\n" + "    put:\n" + "      parameters:\n"
-				+ "        - name: foo\n" + "          in: body\n" + "          required: true\n"
-				+ "          schema:\n" + "            $ref: '#/definitions/foo'\n" + "      responses:\n"
-				+ "        200:\n" + "          schema:\n" + "            $ref: '#/definitions/foo'\n"
-				+ "definitions:\n" + "  foo:\n" + "    type: object\n" + "    properties:\n" + "      id:\n"
-				+ "        type: string\n" + "    required:\n" + "      - id\n";
-		SwaggerParser parser = new SwaggerParser();
-		Swagger swagger = parser.parse(yaml);
-		List<Parameter> parameters = swagger.getPath("/foos/{id}").getPut().getParameters();
-		assertTrue(parameters.size() == 2);
-	}
-
-	@Test
-	public void testLoadRelativeFileTree_Json() throws Exception {
-		final Swagger swagger = doRelativeFileTest("src/test/resources/relative-file-references/json/parent.json");
-		// Json.mapper().writerWithDefaultPrettyPrinter().writeValue(new
-		// File("resolved.json"), swagger);
-	}
-
-	@Test
-	public void testPetstore() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		SwaggerDeserializationResult result = parser.readWithInfo("src/test/resources/petstore.json", null, true);
-
-		assertNotNull(result);
-		assertTrue(result.getMessages().isEmpty());
-
-		Swagger swagger = result.getSwagger();
-		Map<String, Model> definitions = swagger.getDefinitions();
-		Set<String> expectedDefinitions = new HashSet<String>();
-		expectedDefinitions.add("User");
-		expectedDefinitions.add("Category");
-		expectedDefinitions.add("Pet");
-		expectedDefinitions.add("Tag");
-		expectedDefinitions.add("Order");
-		expectedDefinitions.add("PetArray");
-		assertEquals(definitions.keySet(), expectedDefinitions);
-
-		Model petModel = definitions.get("Pet");
-		Set<String> expectedPetProps = new HashSet<String>();
-		expectedPetProps.add("id");
-		expectedPetProps.add("category");
-		expectedPetProps.add("name");
-		expectedPetProps.add("photoUrls");
-		expectedPetProps.add("tags");
-		expectedPetProps.add("status");
-		assertEquals(petModel.getProperties().keySet(), expectedPetProps);
-
-		ArrayModel petArrayModel = (ArrayModel) definitions.get("PetArray");
-		assertEquals(petArrayModel.getType(), "array");
-		RefProperty refProp = (RefProperty) petArrayModel.getItems();
-		assertEquals(refProp.get$ref(), "#/definitions/Pet");
-		assertNull(petArrayModel.getProperties());
-	}
-
-	@Test
-	public void testFileReferenceWithVendorExt() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/file-reference-with-vendor-ext/b.yaml");
-		Map<String, Model> definitions = swagger.getDefinitions();
-		assertTrue(definitions.get("z").getVendorExtensions().get("x-foo") instanceof Map);
-		assertEquals(((Map) definitions.get("z").getVendorExtensions().get("x-foo")).get("bar"), "baz");
-		assertTrue(definitions.get("x").getVendorExtensions().get("x-foo") instanceof Map);
-		assertEquals(((Map) definitions.get("x").getVendorExtensions().get("x-foo")).get("bar"), "baz");
-	}
-
-	@Test
-	public void testTroublesomeFile() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/troublesome.yaml");
-	}
-
-	@Test
-	public void testLoadRelativeFileTree_Yaml() throws Exception {
-		JsonToYamlFileDuplicator.duplicateFilesInYamlFormat("src/test/resources/relative-file-references/json",
-				"src/test/resources/relative-file-references/yaml");
-		final Swagger swagger = doRelativeFileTest("src/test/resources/relative-file-references/yaml/parent.yaml");
-		assertNotNull(Yaml.mapper().writeValueAsString(swagger));
-		assertTrue(swagger.getParameters().get("param2") instanceof HeaderParameter);
-	}
-
-	@Test
-	public void testLoadnestedExternalResponseReferencesFile_Yaml() throws Exception {
-		final Swagger swagger = doRelativeResponseFileTest(
-				"src/test/resources/nested-external-response-references/swagger-root.yaml");
-		assertNotNull(Yaml.mapper().writeValueAsString(swagger));
-	}
-
-	@Test
-	public void testLoadRecursiveExternalDef() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/file-reference-to-recursive-defs/b.yaml");
-
-		Map<String, Model> definitions = swagger.getDefinitions();
-		assertEquals(((RefProperty) ((ArrayProperty) definitions.get("v").getProperties().get("children")).getItems())
-				.get$ref(), "#/definitions/v");
-		assertTrue(definitions.containsKey("y"));
-		assertEquals(((RefProperty) ((ArrayProperty) definitions.get("x").getProperties().get("children")).getItems())
-				.get$ref(), "#/definitions/y");
-	}
-
-	@Test
-	public void testLoadNestedItemsReferences() {
-		SwaggerParser parser = new SwaggerParser();
-		SwaggerDeserializationResult result = parser.readWithInfo("src/test/resources/nested-items-references/b.yaml",
-				null, true);
-		Swagger swagger = result.getSwagger();
-		Map<String, Model> definitions = swagger.getDefinitions();
-		assertTrue(definitions.containsKey("z"));
-		assertTrue(definitions.containsKey("w"));
-	}
-
-	@Test
-	public void testIssue75() {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/issue99.json");
-
-		BodyParameter param = (BodyParameter) swagger.getPaths().get("/albums").getPost().getParameters().get(0);
-		Model model = param.getSchema();
-
-		assertNotNull(model);
-		assertTrue(model instanceof ArrayModel);
-
-		ArrayModel am = (ArrayModel) model;
-		assertTrue(am.getItems() instanceof ByteArrayProperty);
-		assertEquals(am.getItems().getFormat(), "byte");
-	}
-
-	@Test(enabled = false, description = "see https://github.com/swagger-api/swagger-parser/issues/337")
-	public void testIssue62() {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read(
-				"https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/fixtures/v2.0/json/resources/resourceWithLinkedDefinitions.json");
-
-		assertNotNull(swagger.getPaths().get("/pets/{petId}").getGet());
-	}
-
-	@Test
-	public void testIssue146() {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/issue_146.yaml");
-		assertNotNull(swagger);
-		QueryParameter p = ((QueryParameter) swagger.getPaths().get("/checker").getGet().getParameters().get(0));
-		StringProperty pp = (StringProperty) p.getItems();
-		assertTrue("registration".equalsIgnoreCase(pp.getEnum().get(0)));
-	}
-
-	@Test(description = "Test (path & form) parameter's required attribute")
-	public void testParameterRequired() {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/petstore.json");
-		final List<Parameter> operationParams = swagger.getPath("/pet/{petId}").getPost().getParameters();
-
-		final PathParameter pathParameter = (PathParameter) operationParams.get(0);
-		Assert.assertTrue(pathParameter.getRequired());
-
-		final FormParameter formParameter = (FormParameter) operationParams.get(1);
-		Assert.assertFalse(formParameter.getRequired());
-	}
-
-	@Test(description = "Test consumes and produces in top level and operation level")
-	public void testConsumesAndProduces() {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/consumes_and_produces");
-		Assert.assertNotNull(swagger);
-
-		// test consumes and produces at spec level
-		Assert.assertEquals(swagger.getConsumes(), Arrays.asList("application/json"));
-		Assert.assertEquals(swagger.getProduces(), Arrays.asList("application/xml"));
-
-		// test consumes and produces at operation level
-		Assert.assertEquals(swagger.getPath("/pets").getPost().getConsumes(), Arrays.asList("image/jpeg"));
-		Assert.assertEquals(swagger.getPath("/pets").getPost().getProduces(), Arrays.asList("image/png"));
-
-		// test empty consumes and produces at operation level
-		Assert.assertEquals(swagger.getPath("/pets").getGet().getConsumes(), Collections.<String>emptyList());
-		Assert.assertEquals(swagger.getPath("/pets").getGet().getProduces(), Collections.<String>emptyList());
-
-		// test consumes and produces not defined at operation level
-		Assert.assertNull(swagger.getPath("/pets").getPatch().getConsumes());
-		Assert.assertNull(swagger.getPath("/pets").getPatch().getProduces());
-
-	}
-
-	@Test
-	public void testIssue108() {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/issue_108.json");
-
-		assertNotNull(swagger);
-	}
-
-	@Test
-	public void testIssue() {
-		String yaml = "swagger: '2.0'\n" + "info:\n" + "  description: 'No description provided.'\n"
-				+ "  version: '2.0'\n" + "  title: 'My web service'\n" + "  x-endpoint-name: 'default'\n" + "paths:\n"
-				+ "  x-nothing: 'sorry not supported'\n" + "  /foo:\n" + "    x-something: 'yes, it is supported'\n"
-				+ "    get:\n" + "      parameters: []\n" + "      responses:\n" + "        200:\n"
-				+ "          description: 'Swagger API document for this service'\n" + "x-some-vendor:\n"
-				+ "  sometesting: 'bye!'";
-		SwaggerParser parser = new SwaggerParser();
-		SwaggerDeserializationResult result = parser.readWithInfo(yaml);
-
-		Swagger swagger = result.getSwagger();
-
-		assertEquals(((Map) swagger.getVendorExtensions().get("x-some-vendor")).get("sometesting"), "bye!");
-		assertEquals(swagger.getPath("/foo").getVendorExtensions().get("x-something"), "yes, it is supported");
-		assertTrue(result.getMessages().size() == 1);
-		assertEquals(result.getMessages().get(0), "attribute paths.x-nothing is unsupported");
-	}
-
-	@Test
-	public void testIssue292WithNoCollectionFormat() {
-		String yaml = "swagger: '2.0'\n" + "info:\n" + "  version: '0.0.0'\n" + "  title: nada\n" + "paths:\n"
-				+ "  /persons:\n" + "    get:\n" + "      parameters:\n" + "      - name: testParam\n"
-				+ "        in: query\n" + "        type: array\n" + "        items:\n" + "          type: string\n"
-				+ "      responses:\n" + "        200:\n" + "          description: Successful response";
-		SwaggerParser parser = new SwaggerParser();
-		SwaggerDeserializationResult result = parser.readWithInfo(yaml);
-
-		Swagger swagger = result.getSwagger();
-
-		Parameter param = swagger.getPaths().get("/persons").getGet().getParameters().get(0);
-		QueryParameter qp = (QueryParameter) param;
-		assertNull(qp.getCollectionFormat());
-	}
-
-	@Test
-	public void testIssue292WithCSVCollectionFormat() {
-		String yaml = "swagger: '2.0'\n" + "info:\n" + "  version: '0.0.0'\n" + "  title: nada\n" + "paths:\n"
-				+ "  /persons:\n" + "    get:\n" + "      parameters:\n" + "      - name: testParam\n"
-				+ "        in: query\n" + "        type: array\n" + "        items:\n" + "          type: string\n"
-				+ "        collectionFormat: csv\n" + "      responses:\n" + "        200:\n"
-				+ "          description: Successful response";
-		SwaggerParser parser = new SwaggerParser();
-		SwaggerDeserializationResult result = parser.readWithInfo(yaml);
-
-		Swagger swagger = result.getSwagger();
-
-		Parameter param = swagger.getPaths().get("/persons").getGet().getParameters().get(0);
-		QueryParameter qp = (QueryParameter) param;
-		assertEquals(qp.getCollectionFormat(), "csv");
-	}
-
-	@Test
-	public void testIssue286() {
-		SwaggerParser parser = new SwaggerParser();
-
-		Swagger swagger = parser.read("issue_286.yaml");
-		Property response = swagger.getPath("/").getGet().getResponses().get("200").getSchema();
-		assertTrue(response instanceof RefProperty);
-		assertEquals(((RefProperty) response).getSimpleRef(), "issue_286_PetList");
-		assertNotNull(swagger.getDefinitions().get("issue_286_Allergy"));
-	}
-
-	@Test
-	public void testIssue286WithModel() {
-		SwaggerParser parser = new SwaggerParser();
-
-		Swagger swagger = parser.read("issue_286.yaml");
-		Model response = swagger.getPath("/").getGet().getResponses().get("200").getResponseSchema();
-		assertTrue(response instanceof RefModel);
-		assertEquals("issue_286_PetList", ((RefModel) response).getSimpleRef());
-		assertNotNull(swagger.getDefinitions().get("issue_286_Allergy"));
-	}
-
-	@Test
-	public void testIssue360() {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/issue_360.yaml");
-		assertNotNull(swagger);
-
-		Parameter parameter = swagger.getPath("/pets").getPost().getParameters().get(0);
-		assertNotNull(parameter);
-		assertTrue(parameter instanceof BodyParameter);
-
-		BodyParameter bp = (BodyParameter) parameter;
-
-		assertNotNull(bp.getSchema());
-		Model model = bp.getSchema();
-		assertTrue(model instanceof ModelImpl);
-
-		ModelImpl impl = (ModelImpl) model;
-		assertNotNull(impl.getProperties().get("foo"));
-
-		Map<String, Object> extensions = bp.getVendorExtensions();
-		assertNotNull(extensions);
-
-		assertNotNull(extensions.get("x-examples"));
-		Object o = extensions.get("x-examples");
-		assertTrue(o instanceof Map);
-
-		Map<String, Object> on = (Map<String, Object>) o;
-
-		Object jn = on.get("application/json");
-		assertTrue(jn instanceof Map);
-
-		Map<String, Object> objectNode = (Map<String, Object>) jn;
-		assertEquals(objectNode.get("foo"), "bar");
-
-		Parameter stringBodyParameter = swagger.getPath("/otherPets").getPost().getParameters().get(0);
-
-		assertTrue(stringBodyParameter instanceof BodyParameter);
-		BodyParameter sbp = (BodyParameter) stringBodyParameter;
-		assertTrue(sbp.getRequired());
-		assertEquals(sbp.getName(), "simple");
-
-		Model sbpModel = sbp.getSchema();
-		assertTrue(sbpModel instanceof ModelImpl);
-		ModelImpl sbpModelImpl = (ModelImpl) sbpModel;
-
-		assertEquals(sbpModelImpl.getType(), "string");
-		assertEquals(sbpModelImpl.getFormat(), "uuid");
-
-		Parameter refBodyParameter = swagger.getPath("/evenMorePets").getPost().getParameters().get(0);
-
-		assertTrue(refBodyParameter instanceof BodyParameter);
-		BodyParameter ref = (BodyParameter) refBodyParameter;
-		assertTrue(ref.getRequired());
-		assertEquals(ref.getName(), "simple");
-
-		Model refModel = ref.getSchema();
-		assertTrue(refModel instanceof RefModel);
-		RefModel refModelImpl = (RefModel) refModel;
-
-		assertEquals(refModelImpl.getSimpleRef(), "Pet");
-	}
-
-	private Swagger doRelativeFileTest(String location) {
-		SwaggerParser parser = new SwaggerParser();
-		SwaggerDeserializationResult readResult = parser.readWithInfo(location, null, true);
-		if (readResult.getMessages().size() > 0) {
-			Json.prettyPrint(readResult.getMessages());
-		}
-		final Swagger swagger = readResult.getSwagger();
-
-		final Path path = swagger.getPath("/health");
-		assertEquals(path.getClass(), Path.class); // we successfully converted the RefPath to a Path
-
-		final List<Parameter> parameters = path.getParameters();
-		assertParamDetails(parameters, 0, QueryParameter.class, "param1", "query");
-		assertParamDetails(parameters, 1, HeaderParameter.class, "param2", "header");
-
-		final Operation operation = path.getGet();
-		final List<Parameter> operationParams = operation.getParameters();
-		assertParamDetails(operationParams, 0, PathParameter.class, "param3", "path");
-		assertParamDetails(operationParams, 1, HeaderParameter.class, "param4", "header");
-		assertParamDetails(operationParams, 2, BodyParameter.class, "body", "body");
-		final BodyParameter bodyParameter = (BodyParameter) operationParams.get(2);
-		assertEquals(((RefModel) bodyParameter.getSchema()).get$ref(), "#/definitions/health");
-
-		final Map<String, Response> responsesMap = operation.getResponses();
-
-		assertResponse(swagger, responsesMap, "200", "Health information from the server", "#/definitions/health");
-		assertResponse(swagger, responsesMap, "400", "Your request was not valid", "#/definitions/error");
-		assertResponse(swagger, responsesMap, "500", "An unexpected error occur during processing",
-				"#/definitions/error");
-
-		final Map<String, Model> definitions = swagger.getDefinitions();
-		final ModelImpl refInDefinitions = (ModelImpl) definitions.get("refInDefinitions");
-		assertEquals(refInDefinitions.getDescription(), "The example model");
-		expectedPropertiesInModel(refInDefinitions, "foo", "bar");
-
-		final ArrayModel arrayModel = (ArrayModel) definitions.get("arrayModel");
-		final RefProperty arrayModelItems = (RefProperty) arrayModel.getItems();
-		assertEquals(arrayModelItems.get$ref(), "#/definitions/foo");
-
-		final ModelImpl fooModel = (ModelImpl) definitions.get("foo");
-		assertEquals(fooModel.getDescription(), "Just another model");
-		expectedPropertiesInModel(fooModel, "hello", "world");
-
-		final ComposedModel composedCat = (ComposedModel) definitions.get("composedCat");
-		final ModelImpl child = (ModelImpl) composedCat.getChild();
-		expectedPropertiesInModel(child, "huntingSkill", "prop2", "reflexes", "reflexMap");
-		final ArrayProperty reflexes = (ArrayProperty) child.getProperties().get("reflexes");
-		final RefProperty reflexItems = (RefProperty) reflexes.getItems();
-		assertEquals(reflexItems.get$ref(), "#/definitions/reflex");
-		assertTrue(definitions.containsKey(reflexItems.getSimpleRef()));
-
-		final MapProperty reflexMap = (MapProperty) child.getProperties().get("reflexMap");
-		final RefProperty reflexMapAdditionalProperties = (RefProperty) reflexMap.getAdditionalProperties();
-		assertEquals(reflexMapAdditionalProperties.get$ref(), "#/definitions/reflex");
-
-		assertEquals(composedCat.getInterfaces().size(), 2);
-		assertEquals(composedCat.getInterfaces().get(0).get$ref(), "#/definitions/pet");
-		assertEquals(composedCat.getInterfaces().get(1).get$ref(), "#/definitions/foo_2");
-
-		return swagger;
-	}
-
-	private Swagger doRelativeResponseFileTest(String location) {
-		SwaggerParser parser = new SwaggerParser();
-		SwaggerDeserializationResult readResult = parser.readWithInfo(location, null, true);
-
-		if (readResult.getMessages().size() > 0) {
-			Json.prettyPrint(readResult.getMessages());
-		}
-		final Swagger swagger = readResult.getSwagger();
-
-		Json.prettyPrint(swagger);
-
-		final Path path = swagger.getPath("/users");
-		assertEquals(path.getClass(), Path.class); // we successfully converted the RefPath to a Path
-
-		final Operation operation = path.getGet();
-
-		final Map<String, Response> responsesMap = operation.getResponses();
-
-		assertResponse(swagger, responsesMap, "200", "OK", "#/definitions/User");
-
-		final Map<String, Model> definitions = swagger.getDefinitions();
-		final ModelImpl refInDefinitions = (ModelImpl) definitions.get("UserX");
-		expectedPropertiesInModel(refInDefinitions, "address");
-
-		final ModelImpl refInDefinitionsAddress = (ModelImpl) definitions.get("Address");
-		expectedPropertiesInModel(refInDefinitionsAddress, "postal", "country");
-
-		final ModelImpl refInDefinitionsCountry = (ModelImpl) definitions.get("Country");
-		expectedPropertiesInModel(refInDefinitionsCountry, "name");
-
-		final ModelImpl refInDefinitionsAddress_2 = (ModelImpl) definitions.get("Address_2");
-		expectedPropertiesInModel(refInDefinitionsAddress_2, "postal", "country");
-
-		final ModelImpl refInDefinitionsCountry_2 = (ModelImpl) definitions.get("Country_2");
-		expectedPropertiesInModel(refInDefinitionsCountry_2, "name");
-
-		return swagger;
-	}
-
-	private void expectedPropertiesInModel(ModelImpl model, String... expectedProperties) {
-		assertEquals(model.getProperties().size(), expectedProperties.length);
-		for (String expectedProperty : expectedProperties) {
-			assertTrue(model.getProperties().containsKey(expectedProperty));
-		}
-	}
-
-	private void assertResponse(Swagger swagger, Map<String, Response> responsesMap, String responseCode,
-			String expectedDescription, String expectedSchemaRef) {
-		final Response response = responsesMap.get(responseCode);
-		final RefProperty schema = (RefProperty) response.getSchema();
-		assertEquals(response.getDescription(), expectedDescription);
-		assertEquals(schema.getClass(), RefProperty.class);
-		assertEquals(schema.get$ref(), expectedSchemaRef);
-		assertTrue(swagger.getDefinitions().containsKey(schema.getSimpleRef()));
-	}
-
-	private void assertParamDetails(List<Parameter> parameters, int index, Class<?> expectedType, String expectedName,
-			String expectedIn) {
-		final Parameter param1 = parameters.get(index);
-		assertEquals(param1.getClass(), expectedType);
-		assertEquals(param1.getName(), expectedName);
-		assertEquals(param1.getIn(), expectedIn);
-	}
-
-	@Test
-	public void testNestedReferences() {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/relative-file-references/json/parent.json");
-		assertTrue(swagger.getDefinitions().containsKey("externalArray"));
-		assertTrue(swagger.getDefinitions().containsKey("referencedByLocalArray"));
-		assertTrue(swagger.getDefinitions().containsKey("externalObject"));
-		assertTrue(swagger.getDefinitions().containsKey("referencedByLocalElement"));
-		assertTrue(swagger.getDefinitions().containsKey("referencedBy"));
-		assertEquals(
-				((RefProperty) swagger.getDefinitions().get("externalObject").getProperties().get("hello1")).get$ref(),
-				"#/definitions/referencedByLocalElement"); // issue #434
-	}
-
-	@Test
-	public void testCodegenPetstore() {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/petstore-codegen.yaml");
-		ModelImpl enumModel = (ModelImpl) swagger.getDefinitions().get("Enum_Test");
-		assertNotNull(enumModel);
-		Property enumProperty = enumModel.getProperties().get("enum_integer");
-		assertNotNull(enumProperty);
-
-		assertTrue(enumProperty instanceof IntegerProperty);
-		IntegerProperty enumIntegerProperty = (IntegerProperty) enumProperty;
-		List<Integer> integers = enumIntegerProperty.getEnum();
-		assertEquals(integers.get(0), new Integer(1));
-		assertEquals(integers.get(1), new Integer(-1));
-
-		Operation getOrderOperation = swagger.getPath("/store/order/{orderId}").getGet();
-		assertNotNull(getOrderOperation);
-		Parameter orderId = getOrderOperation.getParameters().get(0);
-		assertTrue(orderId instanceof PathParameter);
-		PathParameter orderIdPathParam = (PathParameter) orderId;
-		assertNotNull(orderIdPathParam.getMinimum());
-
-		BigDecimal minimum = orderIdPathParam.getMinimum();
-		assertEquals(minimum.toString(), "1");
-
-		FormParameter formParam = (FormParameter) swagger.getPath("/fake").getPost().getParameters().get(3);
-
-		assertEquals(formParam.getMinimum().toString(), "32.1");
-	}
-
-	@Test
-	public void testIssue339() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/issue-339.json");
-
-		Parameter param = swagger.getPath("/store/order/{orderId}").getGet().getParameters().get(0);
-		assertTrue(param instanceof PathParameter);
-		PathParameter pp = (PathParameter) param;
-
-		assertTrue(pp.getMinimum().toString().equals("1"));
-		assertTrue(pp.getMaximum().toString().equals("5"));
-	}
-
-	@Test
-	public void testCodegenIssue4555() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		String yaml = "swagger: '2.0'\n" + "\n" + "info:\n" + "  title: test\n" + "  version: \"0.0.1\"\n" + "\n"
-				+ "schemes:\n" + "  - http\n" + "produces:\n" + "  - application/json\n" + "\n" + "paths:\n"
-				+ "  /contents/{id}:\n" + "    parameters:\n" + "      - name: id\n" + "        in: path\n"
-				+ "        description: test\n" + "        required: true\n" + "        type: integer\n" + "\n"
-				+ "    get:\n" + "      description: test\n" + "      responses:\n" + "        200:\n"
-				+ "          description: OK\n" + "          schema:\n" + "            $ref: '#/definitions/Content'\n"
-				+ "\n" + "definitions:\n" + "  Content:\n" + "    type: object\n" + "    title: \t\ttest";
-		final SwaggerDeserializationResult result = parser.readWithInfo(yaml);
-
-		// can't parse with tabs!
-		assertNull(result.getSwagger());
-	}
-
-	@Test
-	public void testConverterIssue17() throws Exception {
-		String yaml = "swagger: '2.0'\n" + "info:\n" + "  version: '0.0.0'\n" + "  title: nada\n" + "paths:\n"
-				+ "  /persons:\n" + "    get:\n" + "      parameters:\n" + "      - name: testParam\n"
-				+ "        in: query\n" + "        type: array\n" + "        items:\n" + "          type: string\n"
-				+ "        collectionFormat: csv\n" + "      responses:\n" + "        200:\n"
-				+ "          description: Successful response\n" + "          schema:\n"
-				+ "            $ref: '#/definitions/Content'\n" + "definitions:\n" + "  Content:\n"
-				+ "    type: object";
-		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml, Boolean.FALSE);
-
-		assertNotNull(result.getSwagger());
-		assertEquals(((RefProperty) result.getSwagger().getPaths().get("/persons").getGet().getResponses().get("200")
-				.getSchema()).get$ref(), "#/definitions/Content");
-	}
-
-	@Test
-	public void testIssue393() {
-		SwaggerParser parser = new SwaggerParser();
-
-		String yaml = "swagger: '2.0'\n" + "info:\n" + "  title: x\n" + "  version: 1.0.0\n" + "paths:\n" + "  /test:\n"
-				+ "    get:\n" + "      parameters: []\n" + "      responses:\n" + "        '400':\n"
-				+ "          description: |\n"
-				+ "            The account could not be created because a credential didn't meet the complexity requirements.\n"
-				+ "          x-error-refs:\n" + "            - '$ref': '#/x-error-defs/credentialTooShort'\n"
-				+ "            - '$ref': '#/x-error-defs/credentialTooLong'\n" + "x-error-defs:\n"
-				+ "  credentialTooShort:\n" + "    errorID: credentialTooShort";
-		final SwaggerDeserializationResult result = parser.readWithInfo(yaml);
-
-		assertNotNull(result.getSwagger());
-		Swagger swagger = result.getSwagger();
-
-		assertNotNull(swagger.getVendorExtensions().get("x-error-defs"));
-	}
-
-	@Test
-	public void testBadFormat() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/bad_format.yaml");
-
-		Path path = swagger.getPath("/pets");
-
-		Parameter parameter = path.getGet().getParameters().get(0);
-		assertNotNull(parameter);
-		assertTrue(parameter instanceof QueryParameter);
-		QueryParameter queryParameter = (QueryParameter) parameter;
-		assertEquals(queryParameter.getName(), "query-param-int32");
-		assertNotNull(queryParameter.getEnum());
-		assertEquals(queryParameter.getEnum().size(), 3);
-		List<Object> enumValues = queryParameter.getEnumValue();
-		assertEquals(enumValues.get(0), 1);
-		assertEquals(enumValues.get(1), 2);
-		assertEquals(enumValues.get(2), 7);
-
-		parameter = path.getGet().getParameters().get(1);
-		assertNotNull(parameter);
-		assertTrue(parameter instanceof QueryParameter);
-		queryParameter = (QueryParameter) parameter;
-		assertEquals(queryParameter.getName(), "query-param-invalid-format");
-		assertNotNull(queryParameter.getEnum());
-		assertEquals(queryParameter.getEnum().size(), 3);
-		enumValues = queryParameter.getEnumValue();
-		assertEquals(enumValues.get(0), 1);
-		assertEquals(enumValues.get(1), 2);
-		assertEquals(enumValues.get(2), 7);
-
-		parameter = path.getGet().getParameters().get(2);
-		assertNotNull(parameter);
-		assertTrue(parameter instanceof QueryParameter);
-		queryParameter = (QueryParameter) parameter;
-		assertEquals(queryParameter.getName(), "query-param-collection-format-and-uniqueItems");
-		assertEquals(queryParameter.getCollectionFormat(), "multi");
-		assertEquals(queryParameter.isUniqueItems(), true);
-	}
-
-	@Test
-	public void testNumberAttributes() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		Swagger swagger = parser.read(TestUtils.getResourceAbsolutePath("/number_attributes.yaml"));
-
-		ModelImpl numberType = (ModelImpl) swagger.getDefinitions().get("NumberType");
-		assertNotNull(numberType);
-		assertNotNull(numberType.getEnum());
-		assertEquals(numberType.getEnum().size(), 2);
-		List<String> numberTypeEnumValues = numberType.getEnum();
-		assertEquals(numberTypeEnumValues.get(0), "1.0");
-		assertEquals(numberTypeEnumValues.get(1), "2.0");
-		assertEquals(numberType.getDefaultValue(), new BigDecimal("1.0"));
-		assertEquals(numberType.getMinimum(), new BigDecimal("1.0"));
-		assertEquals(numberType.getMaximum(), new BigDecimal("2.0"));
-
-		ModelImpl numberDoubleType = (ModelImpl) swagger.getDefinitions().get("NumberDoubleType");
-		assertNotNull(numberDoubleType);
-		assertNotNull(numberDoubleType.getEnum());
-		assertEquals(numberDoubleType.getEnum().size(), 2);
-		List<String> numberDoubleTypeEnumValues = numberDoubleType.getEnum();
-		assertEquals(numberDoubleTypeEnumValues.get(0), "1.0");
-		assertEquals(numberDoubleTypeEnumValues.get(1), "2.0");
-		assertEquals(numberDoubleType.getDefaultValue(), new BigDecimal("1.0"));
-		assertEquals(numberDoubleType.getMinimum(), new BigDecimal("1.0"));
-		assertEquals(numberDoubleType.getMaximum(), new BigDecimal("2.0"));
-
-		ModelImpl integerType = (ModelImpl) swagger.getDefinitions().get("IntegerType");
-		assertNotNull(integerType);
-		assertNotNull(integerType.getEnum());
-		assertEquals(integerType.getEnum().size(), 2);
-		List<String> integerTypeEnumValues = integerType.getEnum();
-		assertEquals(integerTypeEnumValues.get(0), "1");
-		assertEquals(integerTypeEnumValues.get(1), "2");
-		assertEquals(integerType.getDefaultValue(), new Integer("1"));
-		assertEquals(integerType.getMinimum(), new BigDecimal("1"));
-		assertEquals(integerType.getMaximum(), new BigDecimal("2"));
-
-		ModelImpl integerInt32Type = (ModelImpl) swagger.getDefinitions().get("IntegerInt32Type");
-		assertNotNull(integerInt32Type);
-		assertNotNull(integerInt32Type.getEnum());
-		assertEquals(integerInt32Type.getEnum().size(), 2);
-		List<String> integerInt32TypeEnumValues = integerInt32Type.getEnum();
-		assertEquals(integerInt32TypeEnumValues.get(0), "1");
-		assertEquals(integerInt32TypeEnumValues.get(1), "2");
-		assertEquals(integerInt32Type.getDefaultValue(), new Integer("1"));
-		assertEquals(integerInt32Type.getMinimum(), new BigDecimal("1"));
-		assertEquals(integerInt32Type.getMaximum(), new BigDecimal("2"));
-
-	}
-
-	@Test
-	public void testDefinitionExample() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read(TestUtils.getResourceAbsolutePath("/definition_example.yaml"));
-
-		ModelImpl model;
-		ArrayModel arrayModel;
-
-		model = (ModelImpl) swagger.getDefinitions().get("NumberType");
-		assertEquals((Double) model.getExample(), 2.0d, 0d);
-
-		model = (ModelImpl) swagger.getDefinitions().get("IntegerType");
-		assertEquals((int) model.getExample(), 2);
-
-		model = (ModelImpl) swagger.getDefinitions().get("StringType");
-		assertEquals((String) model.getExample(), "2");
-
-		model = (ModelImpl) swagger.getDefinitions().get("ObjectType");
-		assertTrue(model.getExample() instanceof Map);
-		Map objectExample = (Map) model.getExample();
-		assertEquals((String) objectExample.get("propertyA"), "valueA");
-		assertEquals((Integer) objectExample.get("propertyB"), new Integer(123));
-
-		arrayModel = (ArrayModel) swagger.getDefinitions().get("ArrayType");
-		assertTrue(arrayModel.getExample() instanceof List);
-		List<Map> arrayExample = (List<Map>) arrayModel.getExample();
-		assertEquals((String) arrayExample.get(0).get("propertyA"), "valueA1");
-		assertEquals((Integer) arrayExample.get(0).get("propertyB"), new Integer(123));
-		assertEquals((String) arrayExample.get(1).get("propertyA"), "valueA2");
-		assertEquals((Integer) arrayExample.get(1).get("propertyB"), new Integer(456));
-
-		model = (ModelImpl) swagger.getDefinitions().get("NumberTypeStringExample");
-		assertEquals((String) model.getExample(), "2.0");
-
-		model = (ModelImpl) swagger.getDefinitions().get("IntegerTypeStringExample");
-		assertEquals((String) model.getExample(), "2");
-
-		model = (ModelImpl) swagger.getDefinitions().get("StringTypeStringExample");
-		assertEquals((String) model.getExample(), "2");
-
-		model = (ModelImpl) swagger.getDefinitions().get("ObjectTypeStringExample");
-		assertEquals((String) model.getExample(), "{\"propertyA\": \"valueA\", \"propertyB\": 123}");
-
-		arrayModel = (ArrayModel) swagger.getDefinitions().get("ArrayTypeStringExample");
-		assertEquals((String) arrayModel.getExample(),
-				"[{\"propertyA\": \"valueA1\", \"propertyB\": 123}, {\"propertyA\": \"valueA2\", \"propertyB\": 456}]");
-	}
-
-	@Test
-	public void testIssue357() {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/issue_357.yaml");
-		assertNotNull(swagger);
-		List<Parameter> getParams = swagger.getPath("/testApi").getGet().getParameters();
-		assertEquals(2, getParams.size());
-		for (Parameter param : getParams) {
-			SerializableParameter sp = (SerializableParameter) param;
-			switch (param.getName()) {
-			case "pathParam1":
-				assertEquals(sp.getType(), "integer");
-				break;
-			case "pathParam2":
-				assertEquals(sp.getType(), "string");
-				break;
-			default:
-				fail("Unexpected parameter named " + sp.getName());
-				break;
-			}
-		}
-	}
-
-	@Test
-	public void testIssue358() {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/issue_358.yaml");
-		assertNotNull(swagger);
-		List<Parameter> parms = swagger.getPath("/testApi").getGet().getParameters();
-		assertEquals(1, parms.size());
-		assertEquals("pathParam", parms.get(0).getName());
-		assertEquals("string", ((SerializableParameter) parms.get(0)).getType());
-	}
-
-	@Test
-	public void testIncompatibleRefs() {
-		String yaml = "swagger: '2.0'\n" + "paths:\n" + "  /test:\n" + "    post:\n" + "      parameters:\n"
-				+ "        # this is not the correct reference type\n" + "        - $ref: '#/definitions/Model'\n"
-				+ "        - in: body\n" + "          name: incorrectType\n" + "          required: true\n"
-				+ "          schema:\n" + "            $ref: '#/definitions/Model'\n" + "      responses:\n"
-				+ "        200:\n" + "          # this is not the correct reference type\n"
-				+ "          $ref: '#/definitions/Model'\n" + "        400:\n"
-				+ "          definitions: this is right\n" + "          schema:\n"
-				+ "            $ref: '#/definitions/Model'\n" + "definitions:\n" + "  Model:\n" + "    type: object";
-		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
-		assertNotNull(result.getSwagger());
-	}
-
-	@Test
-	public void testIssue243() {
-		String yaml = "swagger: \"2.0\"\n" + "info:\n" + "  version: 0.0.0\n" + "  title: Simple API\n" + "paths:\n"
-				+ "  /:\n" + "    get:\n" + "      responses:\n" + "        '200':\n" + "          description: OK\n"
-				+ "          schema:\n" + "            $ref: \"#/definitions/Simple\"\n" + "definitions:\n"
-				+ "  Simple:\n" + "    type: string";
-		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
-		assertNotNull(result.getSwagger());
-	}
-
-	@Test
-	public void testIssue594() {
-		String yaml = "swagger: '2.0'\n" + "paths:\n" + "  /test:\n" + "    post:\n" + "      parameters:\n"
-				+ "        - name: body\n" + "          in: body\n" + "          description: Hello world\n"
-				+ "          schema:\n" + "            type: array\n" + "            minItems: 1\n"
-				+ "            maxItems: 1\n" + "            items: \n" + "              $ref: \"#/definitions/Pet\"\n"
-				+ "      responses:\n" + "        200:\n" + "          description: 'OK'\n";
-		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
-		assertNotNull(result.getSwagger());
-		ArrayModel schema = (ArrayModel) ((BodyParameter) result.getSwagger().getPaths().get("/test").getPost()
-				.getParameters().get(0)).getSchema();
-		assertEquals(((RefProperty) schema.getItems()).get$ref(), "#/definitions/Pet");
-		assertNotNull(schema.getMaxItems());
-		assertNotNull(schema.getMinItems());
-
-	}
-
-	@Test
-	public void testIssue450() {
-		String desc = "An array of Pets";
-		String xTag = "x-my-tag";
-		String xVal = "An extension tag";
-		String yaml = "swagger: \"2.0\"\n" + "info:\n" + "  version: 0.0.0\n" + "  title: Simple API\n" + "paths:\n"
-				+ "  /:\n" + "    get:\n" + "      responses:\n" + "        '200':\n" + "          description: OK\n"
-				+ "definitions:\n" + "  PetArray:\n" + "    type: array\n" + "    items:\n"
-				+ "      $ref: \"#/definitions/Pet\"\n" + "    description: " + desc + "\n" + "    " + xTag + ": "
-				+ xVal + "\n" + "  Pet:\n" + "    type: object\n" + "    properties:\n" + "      id:\n"
-				+ "        type: string";
-		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
-		assertNotNull(result.getSwagger());
-		final Swagger swagger = result.getSwagger();
-
-		Model petArray = swagger.getDefinitions().get("PetArray");
-		assertNotNull(petArray);
-		assertTrue(petArray instanceof ArrayModel);
-		assertEquals(petArray.getDescription(), desc);
-		assertNotNull(petArray.getVendorExtensions());
-		assertNotNull(petArray.getVendorExtensions().get(xTag));
-		assertEquals(petArray.getVendorExtensions().get(xTag), xVal);
-	}
-
-	@Test
-	public void testIssue480() {
-		final Swagger swagger = new SwaggerParser().read("src/test/resources/issue-480.yaml");
-
-		for (String key : swagger.getSecurityDefinitions().keySet()) {
-			SecuritySchemeDefinition definition = swagger.getSecurityDefinitions().get(key);
-			if ("petstore_auth".equals(key)) {
-				assertTrue(definition instanceof OAuth2Definition);
-				OAuth2Definition oauth = (OAuth2Definition) definition;
-				assertEquals("This is a description", oauth.getDescription());
-			}
-			if ("api_key".equals(key)) {
-				assertTrue(definition instanceof ApiKeyAuthDefinition);
-				ApiKeyAuthDefinition auth = (ApiKeyAuthDefinition) definition;
-				assertEquals("This is another description", auth.getDescription());
-			}
-		}
-	}
-
-	@Test
-	public void checkAllOfAreTaken() {
-		Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-example/allOf.json");
-		assertEquals(2, swagger.getDefinitions().size());
-
-	}
-
-	@Test(description = "Issue #616 Relative references inside of 'allOf'")
-	public void checkAllOfWithRelativeReferencesAreFound() {
-		Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-relative-file-references/parent.json");
-		assertEquals(4, swagger.getDefinitions().size());
-	}
-
-	@Test(description = "Issue #616 Relative references inside of 'allOf'")
-	public void checkAllOfWithRelativeReferencesIssue604() {
-		Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-relative-file-references/swagger.yaml");
-		assertEquals(2, swagger.getDefinitions().size());
-	}
-
-	@Test(description = "Test that validate resolution of external references in allOf of property")
-	public void checkExtRefResolveInPropertiesWithAllOf() {
-		Swagger swagger = new SwaggerParser()
-				.read("src/test/resources/allOf-property-relative-file-references/parent.yaml");
-		assertEquals(2, swagger.getDefinitions().size());
-		assertEquals(1, swagger.getDefinitions().get("test").getProperties().size());
-
-		ComposedProperty property = (ComposedProperty) swagger.getDefinitions().get("test").getProperties()
-				.get("property");
-		assertEquals(1, property.getVendorExtensions().size());
-		assertEquals(1, property.getAllOf().size());
-
-		RefProperty refProperty = (RefProperty) property.getAllOf().get(0);
-		assertEquals("#/definitions/def.def", refProperty.get$ref());
-
-	}
-
-	@Test(description = "A string example should not be over quoted when parsing a yaml string")
-	public void readingSpecStringShouldNotOverQuotingStringExample() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/over-quoted-example.yaml", null, false);
-
-		Map<String, Model> definitions = swagger.getDefinitions();
-		assertEquals("NoQuotePlease", definitions.get("CustomerType").getExample());
-	}
-
-	@Test(description = "A string example should not be over quoted when parsing a yaml node")
-	public void readingSpecNodeShouldNotOverQuotingStringExample() throws Exception {
-		String yaml = Files.readFile(new File("src/test/resources/over-quoted-example.yaml"));
-		JsonNode rootNode = Yaml.mapper().readValue(yaml, JsonNode.class);
-		SwaggerParser parser = new SwaggerParser();
-		Swagger swagger = parser.read(rootNode, true);
-
-		Map<String, Model> definitions = swagger.getDefinitions();
-		assertEquals("NoQuotePlease", definitions.get("CustomerType").getExample());
-	}
-
-	@Test
-	public void testRefNameConflicts() throws Exception {
-		Swagger swagger = new SwaggerParser().read("name-conflicts/refs-name-conflict/a.yaml");
-
-		assertTrue(swagger.getDefinitions().size() == 2);
-
-		assertEquals("#/definitions/PersonObj",
-				((RefProperty) swagger.getPath("/newPerson").getPost().getResponses().get("200").getSchema())
-						.get$ref());
-		assertEquals("#/definitions/PersonObj_2",
-				((RefProperty) swagger.getPath("/oldPerson").getPost().getResponses().get("200").getSchema())
-						.get$ref());
-		assertEquals("#/definitions/PersonObj_2",
-				((RefProperty) swagger.getPath("/yetAnotherPerson").getPost().getResponses().get("200").getSchema())
-						.get$ref());
-		assertEquals("local", swagger.getDefinitions().get("PersonObj").getProperties().get("location").getExample());
-		assertEquals("referred",
-				swagger.getDefinitions().get("PersonObj_2").getProperties().get("location").getExample());
-	}
-
-	@Test
-	public void testRefAdditionalProperties() throws Exception {
-		Swagger swagger = new SwaggerParser().read("src/test/resources/additionalProperties.yaml");
-
-		Assert.assertNotNull(swagger);
-
-		Assert.assertTrue(swagger.getDefinitions().size() == 3);
-
-		Assert.assertNotNull(swagger.getDefinitions().get("link-object"));
-		Assert.assertNotNull(swagger.getDefinitions().get("rel-data"));
-		Assert.assertNotNull(swagger.getDefinitions().get("result"));
-	}
-
-	@Test
-	public void testRefEnum() throws Exception {
-		Swagger swagger = new SwaggerParser().read("src/test/resources/refEnum.yaml");
-
-		Assert.assertNotNull(swagger);
-
-		Assert.assertTrue(swagger.getDefinitions().size() == 5);
-
-		Assert.assertNotNull(swagger.getDefinitions().get("PrintInfo"));
-		Assert.assertNotNull(swagger.getDefinitions().get("SomeEnum"));
-		Assert.assertNotNull(swagger.getDefinitions().get("ShippingInfo"));
-	}
-
-	@Test
-	public void testIssue643() throws Exception {
-		Swagger swagger = new SwaggerParser().read("src/test/resources/issue_643.yaml");
-
-		Assert.assertNotNull(swagger);
-
-		Assert.assertTrue(swagger.getDefinitions().size() == 1);
-
-		Assert.assertNotNull(swagger.getDefinitions().get("XYZResponse"));
-
-	}
-
-	@Test
-	public void testIssueGrace() throws Exception {
-		Swagger swagger = new SwaggerParser().read("src/test/resources/issue_657/issue_657.json");
-
-		Assert.assertNotNull(swagger);
-
-		Assert.assertTrue(swagger.getDefinitions().size() == 2);
-
-		Assert.assertNotNull(swagger.getDefinitions().get("Person"));
-		Assert.assertNotNull(swagger.getDefinitions().get("Persons"));
-
-	}
-
-	@Test
-	public void testLoadExternalNestedDefinitions() throws Exception {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/nested-references/b.yaml");
-
-		Map<String, Model> definitions = swagger.getDefinitions();
-		assertTrue(definitions.containsKey("x"));
-		assertTrue(definitions.containsKey("y"));
-		assertTrue(definitions.containsKey("z"));
-		assertTrue(definitions.containsKey("referencedByLocalElement"));
-		assertEquals("#/definitions/k_2", ((RefModel) definitions.get("i")).get$ref());
-		assertEquals("k-definition", definitions.get("k").getTitle());
-		assertEquals("k-definition", definitions.get("k_2").getTitle());
-		assertEquals(((RefModel) definitions.get("l")).get$ref(), "#/definitions/referencedByLocalElement"); // issue
-																												// #434
-	}
-
-	@Test(description = "Parser not honoring redirect responses")
-	public void testIssue844() {
-		SwaggerParser parser = new SwaggerParser();
-		final SwaggerDeserializationResult swagger = parser
-				.readWithInfo("src/test/resources/reusableParametersWithExternalRef.json", null, true);
-		assertNotNull(swagger.getSwagger());
-		assertEquals(swagger.getSwagger().getPath("/pets/{id}").getGet().getParameters().get(0).getIn(), "header");
-	}
-
-	@Test
-	public void testIssue258() {
-		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("duplicateOperationId.json", null, true);
-		assertNotNull(result);
-		assertNotNull(result.getSwagger());
-		assertEquals(result.getMessages().get(0), "attribute paths.'/pets/{id}'(post).operationId is repeated");
-	}
-
-	@Test
-	public void testIssue913() {
-		SwaggerParser parser = new SwaggerParser();
-		final Swagger swagger = parser.read("src/test/resources/issue-913/BS/ApiSpecification.yaml");
-		Assert.assertNotNull(swagger);
-		Assert.assertNotNull(swagger.getDefinitions().get("indicatorType"));
-		Assert.assertEquals(swagger.getDefinitions().get("indicatorType").getProperties().size(), 1);
-	}
+    public void testIssue1143(){
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue1143.json", null, true);
+        assertNotNull(result.getSwagger().getDefinitions().get("RedisResource"));
+        assertNotNull(result.getSwagger().getDefinitions().get("identificacion_usuario_aplicacion"));
+    }
+
+    @Test
+    public void testIssue1204() {
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue1204.yaml", null, true);
+        System.out.println(result.getMessages());
+        assertTrue(result.getMessages().size() == 0);
+        assertNotNull(result.getSwagger());
+
+    }
+
+    @Test
+    public void testIssue1169() {
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue1169.yaml", null, true);
+        assertTrue(result.getMessages().size() == 0);
+        assertNotNull(result.getSwagger());
+    }
+
+
+    @Test
+    public void testIssueRelativeRefs2(){
+        String location = "exampleSpecs/specs/my-domain/test-api/v1/test-api-swagger_v1.json";
+        Swagger swagger = new SwaggerParser().read(location, null, true);
+        assertNotNull(swagger);
+        Map<String, Model> definitions = swagger.getDefinitions();
+        Assert.assertTrue(definitions.get("confirmMessageType_v01").getProperties().get("resources") instanceof ArrayProperty);
+        ArrayProperty arraySchema = (ArrayProperty) definitions.get("confirmMessageType_v01").getProperties().get("resources");
+        ObjectProperty prop = (ObjectProperty) arraySchema.getItems();
+        RefProperty refProperty = (RefProperty) prop.getProperties().get("resourceID");
+        assertEquals(refProperty.get$ref(),"#/definitions/simpleIDType_v01");
+    }
+
+    @Test
+    public void testIssue111() {
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue-111.yaml", null, true);
+        assertTrue(result.getMessages().get(0).equals("attribute definitions.Filter.items is missing"));
+        assertNotNull(result.getSwagger());
+    }
+
+    @Test
+    public void testIssue1146() {
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue-1146.yaml", null, true);
+        assertEquals(0, result.getMessages().size());
+    }
+
+    @Test
+    public void testIssueDefinitionWithDots_2() {
+        Swagger swagger = new SwaggerParser().read("SimpleAPI.yaml");
+        assertNotNull(swagger);
+    }
+
+    @Test
+    public void testIssueDefinitionWithDots() {
+        Swagger swagger = new SwaggerParser().read("API-Service-2.0.0-swagger.yaml");
+        assertNotNull(swagger);
+    }
+
+    @Test
+    public void testIssue995() {
+        Swagger swagger = new SwaggerParser().read("issue-995/digitalExp-Product-Unresolved.yaml");
+        assertNotNull(swagger);
+        assertTrue(swagger.getDefinitions().size() == 6);
+        assertNotNull(swagger.getDefinitions().get("MobileProduct"));
+        assertNotNull(swagger.getDefinitions().get("FixedVoiceProduct"));
+        assertNotNull(swagger.getDefinitions().get("InternetProduct"));
+    }
+
+    @Test
+    public void testIssue927() {
+        Swagger swagger = new SwaggerParser().read("issue-927/issue-927.yaml");
+        assertNotNull(swagger);
+        assertTrue(swagger.getDefinitions().size() == 3);
+        assertNotNull(swagger.getDefinitions().get("Pet"));
+        assertNotNull(swagger.getDefinitions().get("Cat"));
+        assertNotNull(swagger.getDefinitions().get("Dog"));
+    }
+
+    @Test
+    public void testIssue901_2() {
+        Swagger swagger = new SwaggerParser().read("issue-901/spec2.yaml");
+        assertNotNull(swagger);
+        assertNotNull(swagger.getDefinitions());
+        ArrayProperty arraySchema = (ArrayProperty) swagger.getDefinitions().get("Test.Definition").getProperties().get("stuff");
+        String internalRef = ((RefProperty) arraySchema.getItems()).get$ref();
+        assertEquals(internalRef,"#/definitions/TEST.THING.OUT.Stuff");
+    }
+
+    @Test
+    public void testIssue901() {
+        Swagger swagger = new SwaggerParser().read("issue-901/spec.yaml");
+        assertNotNull(swagger);
+        String internalRef = ((RefModel)swagger.getPaths().get("/test").getPut().getResponses().get("200").getResponseSchema()).get$ref();
+        assertEquals(internalRef,"#/definitions/Test.Definition");
+        assertNotNull(swagger.getDefinitions());
+
+    }
+
+    @Test
+    public void testIssue435() {
+        Swagger swagger = new SwaggerParser().read("issue-435/main.yaml");
+        assertNotNull(swagger.getDefinitions().get("sub"));
+        assertNotNull(swagger.getDefinitions().get("subsub"));
+    }
+
+
+    @Test
+    public void testIssue845() {
+        SwaggerDeserializationResult swaggerDeserializationResult = new SwaggerParser().readWithInfo("");
+        assertEquals(swaggerDeserializationResult.getMessages().get(0), "empty or null swagger supplied");
+    }
+  
+    @Test
+    public void testIssue834() {
+        Swagger swagger = new SwaggerParser().read("issue-834/index.yaml", null, true);
+        assertNotNull(swagger);
+
+        Response foo200 =swagger.getPaths().get("/foo").getGet().getResponses().get("200");
+        assertNotNull(foo200);
+        RefModel model200 = (RefModel) foo200.getResponseSchema();
+        String foo200SchemaRef = model200.get$ref();
+        assertEquals(foo200SchemaRef, "#/definitions/schema");
+
+        Response foo300 = swagger.getPaths().get("/foo").getGet().getResponses().get("300");
+        assertNotNull(foo300);
+        RefModel model300 = (RefModel) foo300.getResponseSchema();
+        String foo300SchemaRef = model300.get$ref();
+        assertEquals(foo300SchemaRef, "#/definitions/schema");
+
+        Response bar200 = swagger.getPaths().get("/bar").getGet().getResponses().get("200");
+        assertNotNull(bar200);
+        RefModel modelBar200 = (RefModel) bar200.getResponseSchema();
+        String bar200SchemaRef = modelBar200.get$ref();
+        assertEquals(bar200SchemaRef, "#/definitions/schema");
+    }
+
+    @Test
+    public void testIssue811_RefSchema_ToRefSchema() {
+        final Swagger swagger = new SwaggerParser().read("oapi-reference-test2/index.yaml", null, true);
+        Assert.assertNotNull(swagger);
+        RefModel model = (RefModel) swagger.getPaths().get("/").getGet().getResponses().get("200").getResponseSchema();
+        Assert.assertEquals(model.get$ref() ,"#/definitions/schema-with-reference");
+    }
+
+    @Test
+    public void testIssue811() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/oapi-reference-test/index.yaml");
+        Assert.assertNotNull(swagger);
+        assertTrue(swagger.getPaths().get("/").getGet().getResponses().get("200").getResponseSchema() instanceof RefModel);
+        RefModel model = (RefModel) swagger.getPaths().get("/").getGet().getResponses().get("200").getResponseSchema();
+        Assert.assertEquals(model.get$ref(),"#/definitions/schema-with-reference");
+
+    }
+
+    @Test
+    public void testIssue727() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/issue-714/serviceA.yaml");
+        Assert.assertNotNull(swagger);
+        assertNotNull(swagger.getPaths().get("/test").getGet().getParameters().get(0));
+        assertTrue(swagger.getDefinitions().size() == 1);
+        assertNotNull(swagger.getDefinitions().get("refA"));
+    }
+
+    @Test
+    public void testIssue704() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/sample/swagger.json");
+        Assert.assertNotNull(swagger);
+
+        assertNotNull(swagger.getPaths().get("/api/Address").getGet());
+        assertTrue(swagger.getDefinitions().size() == 1);
+        assertNotNull(swagger.getDefinitions().get("AddressEx"));
+    }
+
+    @Test
+    public void testIssue697() throws Exception {
+        String yaml = "{\n" +
+                "    \"swagger\": \"2.0\",\n" +
+                "    \"info\": {\n" +
+                "        \"version\": \"1.0\",\n" +
+                "        \"title\": \"x-example\"\n" +
+                "    },\n" +
+                "    \"host\": \"httpbin.org\",\n" +
+                "    \"basePath\": \"/anything\",\n" +
+                "    \"schemes\": [\n" +
+                "        \"http\"\n" +
+                "    ],\n" +
+                "    \"paths\": {\n" +
+                "        \"/{foo}\": {\n" +
+                "            \"get\": {\n" +
+                "                \"responses\": {\n" +
+                "                    \"200\": {\n" +
+                "                        \"description\": \"OK\"\n" +
+                "                    }\n" +
+                "                },\n" +
+                "                \"deprecated\": false\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+
+        SwaggerParser parser = new SwaggerParser();
+
+        Swagger swagger = parser.parse(yaml);
+        assertFalse(swagger.getPaths().get("/{foo}").getGet().isDeprecated());
+
+    }
+
+    @Test
+    public void testNPEIssue684() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/issue-684.json");
+        Assert.assertNotNull(swagger);
+        assertTrue(swagger.getParameters().get("ParamDef3") instanceof RefParameter);
+    }
+
+    @Test
+    public void testRefPaths() throws Exception {
+        String yaml = "swagger: '2.0'\n" +
+                "info:\n" +
+                "  version: 0.0.0\n" +
+                "  title: Path item $ref test\n" +
+                "paths:\n" +
+                "  /foo:\n" +
+                "    get:\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "  /foo2:\n" +
+                "    $ref: '#/paths/~1foo'";
+
+        SwaggerParser parser = new SwaggerParser();
+
+        Swagger swagger = parser.parse(yaml);
+
+        assertEquals(swagger.getPaths().get("foo"),swagger.getPaths().get("foo2"));
+        
+
+    }
+    @Test
+    public void testModelParameters() throws Exception {
+        String yaml = "swagger: '2.0'\n" +
+                "info:\n" +
+                "  version: \"0.0.0\"\n" +
+                "  title: test\n" +
+                "paths:\n" +
+                "  /foo:\n" +
+                "    get:\n" +
+                "      parameters:\n" +
+                "      - name: amount\n" +
+                "        in: body\n" +
+                "        schema:\n" +
+                "          type: integer\n" +
+                "          format: int64\n" +
+                "          description: amount of money\n" +
+                "          default: 1000\n" +
+                "          maximum: 100000\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: ok";
+
+        SwaggerParser parser = new SwaggerParser();
+
+        Swagger swagger = parser.parse(yaml);
+
+    }
+
+    @Test
+    public void testParseSharedPathParameters() throws Exception {
+        String yaml =
+                "swagger: '2.0'\n" +
+                        "info:\n" +
+                        "  version: \"0.0.0\"\n" +
+                        "  title: test\n" +
+                        "paths:\n" +
+                        "  /persons/{id}:\n" +
+                        "    parameters:\n" +
+                        "      - in: path\n" +
+                        "        name: id\n" +
+                        "        type: string\n" +
+                        "        required: true\n" +
+                        "        description: \"no\"\n" +
+                        "    get:\n" +
+                        "      parameters:\n" +
+                        "        - name: id\n" +
+                        "          in: path\n" +
+                        "          required: true\n" +
+                        "          type: string\n" +
+                        "          description: \"yes\"\n" +
+                        "        - name: name\n" +
+                        "          in: query\n" +
+                        "          type: string\n" +
+                        "      responses:\n" +
+                        "        200:\n" +
+                        "          description: ok\n";
+
+        SwaggerParser parser = new SwaggerParser();
+
+        Swagger swagger = parser.parse(yaml);
+        List<Parameter> parameters = swagger.getPath("/persons/{id}").getGet().getParameters();
+        assertTrue(parameters.size() == 2);
+        Parameter id = parameters.get(0);
+        assertEquals(id.getDescription(), "yes");
+    }
+
+    @Test
+    public void testParseRefPathParameters() throws Exception {
+        String yaml =
+                "swagger: '2.0'\n" +
+                        "info:\n" +
+                        "  title: test\n" +
+                        "  version: '0.0.0'\n" +
+                        "parameters:\n" +
+                        "  report-id:\n" +
+                        "    name: id\n" +
+                        "    in: path\n" +
+                        "    type: string\n" +
+                        "    required: true\n" +
+                        "paths:\n" +
+                        "  /reports/{id}:\n" +
+                        "    parameters:\n" +
+                        "        - $ref: '#/parameters/report-id'\n" +
+                        "    put:\n" +
+                        "      parameters:\n" +
+                        "        - name: id\n" +
+                        "          in: body\n" +
+                        "          required: true\n" +
+                        "          schema:\n" +
+                        "            $ref: '#/definitions/report'\n" +
+                        "      responses:\n" +
+                        "        200:\n" +
+                        "          description: ok\n" +
+                        "definitions:\n" +
+                        "  report:\n" +
+                        "    type: object\n" +
+                        "    properties:\n" +
+                        "      id:\n" +
+                        "        type: string\n" +
+                        "      name:\n" +
+                        "        type: string\n" +
+                        "    required:\n" +
+                        "    - id\n" +
+                        "    - name\n";
+        SwaggerParser parser = new SwaggerParser();
+        Swagger swagger = parser.parse(yaml);
+    }
+
+    @Test
+    public void testUniqueParameters() throws Exception {
+        String yaml =
+                "swagger: '2.0'\n" +
+                        "info:\n" +
+                        "  title: test\n" +
+                        "  version: '0.0.0'\n" +
+                        "parameters:\n" +
+                        "  foo-id:\n" +
+                        "    name: id\n" +
+                        "    in: path\n" +
+                        "    type: string\n" +
+                        "    required: true\n" +
+                        "paths:\n" +
+                        "  /foos/{id}:\n" +
+                        "    parameters:\n" +
+                        "        - $ref: '#/parameters/foo-id'\n" +
+                        "    get:\n" +
+                        "      responses:\n" +
+                        "        200:\n" +
+                        "          schema:\n" +
+                        "            $ref: '#/definitions/foo'\n" +
+                        "    put:\n" +
+                        "      parameters:\n" +
+                        "        - name: foo\n" +
+                        "          in: body\n" +
+                        "          required: true\n" +
+                        "          schema:\n" +
+                        "            $ref: '#/definitions/foo'\n" +
+                        "      responses:\n" +
+                        "        200:\n" +
+                        "          schema:\n" +
+                        "            $ref: '#/definitions/foo'\n" +
+                        "definitions:\n" +
+                        "  foo:\n" +
+                        "    type: object\n" +
+                        "    properties:\n" +
+                        "      id:\n" +
+                        "        type: string\n" +
+                        "    required:\n" +
+                        "      - id\n";
+        SwaggerParser parser = new SwaggerParser();
+        Swagger swagger = parser.parse(yaml);
+        List<Parameter> parameters = swagger.getPath("/foos/{id}").getPut().getParameters();
+        assertTrue(parameters.size() == 2);
+    }
+
+    @Test
+    public void testLoadRelativeFileTree_Json() throws Exception {
+        final Swagger swagger = doRelativeFileTest("src/test/resources/relative-file-references/json/parent.json");
+        //Json.mapper().writerWithDefaultPrettyPrinter().writeValue(new File("resolved.json"), swagger);
+    }
+
+
+
+    @Test
+    public void testPetstore() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        SwaggerDeserializationResult result = parser.readWithInfo("src/test/resources/petstore.json", null, true);
+
+        assertNotNull(result);
+        assertTrue(result.getMessages().isEmpty());
+
+        Swagger swagger = result.getSwagger();
+        Map<String, Model> definitions = swagger.getDefinitions();
+        Set<String> expectedDefinitions = new HashSet<String>();
+        expectedDefinitions.add("User");
+        expectedDefinitions.add("Category");
+        expectedDefinitions.add("Pet");
+        expectedDefinitions.add("Tag");
+        expectedDefinitions.add("Order");
+        expectedDefinitions.add("PetArray");
+        assertEquals(definitions.keySet(), expectedDefinitions);
+
+        Model petModel = definitions.get("Pet");
+        Set<String> expectedPetProps = new HashSet<String>();
+        expectedPetProps.add("id");
+        expectedPetProps.add("category");
+        expectedPetProps.add("name");
+        expectedPetProps.add("photoUrls");
+        expectedPetProps.add("tags");
+        expectedPetProps.add("status");
+        assertEquals(petModel.getProperties().keySet(), expectedPetProps);
+
+        ArrayModel petArrayModel = (ArrayModel) definitions.get("PetArray");
+        assertEquals(petArrayModel.getType(), "array");
+        RefProperty refProp = (RefProperty) petArrayModel.getItems();
+        assertEquals(refProp.get$ref(), "#/definitions/Pet");
+        assertNull(petArrayModel.getProperties());
+    }
+
+    @Test
+    public void testFileReferenceWithVendorExt() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/file-reference-with-vendor-ext/b.yaml");
+        Map<String, Model> definitions = swagger.getDefinitions();
+        assertTrue(definitions.get("z").getVendorExtensions().get("x-foo") instanceof Map);
+        assertEquals(((Map) definitions.get("z").getVendorExtensions().get("x-foo")).get("bar"), "baz");
+        assertTrue(definitions.get("x").getVendorExtensions().get("x-foo") instanceof Map);
+        assertEquals(((Map) definitions.get("x").getVendorExtensions().get("x-foo")).get("bar"), "baz");
+    }
+
+    @Test
+    public void testTroublesomeFile() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/troublesome.yaml");
+    }
+
+    @Test
+    public void testLoadRelativeFileTree_Yaml() throws Exception {
+        JsonToYamlFileDuplicator.duplicateFilesInYamlFormat("src/test/resources/relative-file-references/json",
+                "src/test/resources/relative-file-references/yaml");
+        final Swagger swagger = doRelativeFileTest("src/test/resources/relative-file-references/yaml/parent.yaml");
+        assertNotNull(Yaml.mapper().writeValueAsString(swagger));
+        assertTrue(swagger.getParameters().get("param2") instanceof HeaderParameter);
+    }
+
+    @Test
+    public void testLoadnestedExternalResponseReferencesFile_Yaml() throws Exception {
+        final Swagger swagger = doRelativeResponseFileTest("src/test/resources/nested-external-response-references/swagger-root.yaml");
+        assertNotNull(Yaml.mapper().writeValueAsString(swagger));
+    }
+    
+    @Test
+    public void testLoadRecursiveExternalDef() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/file-reference-to-recursive-defs/b.yaml");
+
+        Map<String, Model> definitions = swagger.getDefinitions();
+        assertEquals(((RefProperty) ((ArrayProperty) definitions.get("v").getProperties().get("children")).getItems()).get$ref(), "#/definitions/v");
+        assertTrue(definitions.containsKey("y"));
+        assertEquals(((RefProperty) ((ArrayProperty) definitions.get("x").getProperties().get("children")).getItems()).get$ref(), "#/definitions/y");
+    }
+
+    @Test
+    public void testLoadNestedItemsReferences() {
+        SwaggerParser parser = new SwaggerParser();
+        SwaggerDeserializationResult result = parser.readWithInfo("src/test/resources/nested-items-references/b.yaml", null, true);
+        Swagger swagger = result.getSwagger();
+        Map<String, Model> definitions = swagger.getDefinitions();
+        assertTrue(definitions.containsKey("z"));
+        assertTrue(definitions.containsKey("w"));
+    }
+
+    @Test
+    public void testIssue75() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/issue99.json");
+
+        BodyParameter param = (BodyParameter) swagger.getPaths().get("/albums").getPost().getParameters().get(0);
+        Model model = param.getSchema();
+
+        assertNotNull(model);
+        assertTrue(model instanceof ArrayModel);
+
+        ArrayModel am = (ArrayModel) model;
+        assertTrue(am.getItems() instanceof ByteArrayProperty);
+        assertEquals(am.getItems().getFormat(), "byte");
+    }
+
+    @Test(enabled = false, description = "see https://github.com/swagger-api/swagger-parser/issues/337")
+    public void testIssue62() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/fixtures/v2.0/json/resources/resourceWithLinkedDefinitions.json");
+
+        assertNotNull(swagger.getPaths().get("/pets/{petId}").getGet());
+    }
+
+    @Test
+    public void testIssue146() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/issue_146.yaml");
+        assertNotNull(swagger);
+        QueryParameter p = ((QueryParameter) swagger.getPaths().get("/checker").getGet().getParameters().get(0));
+        StringProperty pp = (StringProperty) p.getItems();
+        assertTrue("registration".equalsIgnoreCase(pp.getEnum().get(0)));
+    }
+
+    @Test(description = "Test (path & form) parameter's required attribute")
+    public void testParameterRequired() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/petstore.json");
+        final List<Parameter> operationParams = swagger.getPath("/pet/{petId}").getPost().getParameters();
+
+        final PathParameter pathParameter = (PathParameter) operationParams.get(0);
+        Assert.assertTrue(pathParameter.getRequired());
+
+        final FormParameter formParameter = (FormParameter) operationParams.get(1);
+        Assert.assertFalse(formParameter.getRequired());
+    }
+
+    @Test(description = "Test consumes and produces in top level and operation level")
+    public void testConsumesAndProduces() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/consumes_and_produces");
+        Assert.assertNotNull(swagger);
+
+        // test consumes and produces at spec level
+        Assert.assertEquals(swagger.getConsumes(), Arrays.asList("application/json"));
+        Assert.assertEquals(swagger.getProduces(), Arrays.asList("application/xml"));
+
+        // test consumes and produces at operation level
+        Assert.assertEquals(swagger.getPath("/pets").getPost().getConsumes(), Arrays.asList("image/jpeg"));
+        Assert.assertEquals(swagger.getPath("/pets").getPost().getProduces(), Arrays.asList("image/png"));
+
+        // test empty consumes and produces at operation level
+        Assert.assertEquals(swagger.getPath("/pets").getGet().getConsumes(), Collections.<String>emptyList());
+        Assert.assertEquals(swagger.getPath("/pets").getGet().getProduces(), Collections.<String>emptyList());
+
+        // test consumes and produces not defined at operation level
+        Assert.assertNull(swagger.getPath("/pets").getPatch().getConsumes());
+        Assert.assertNull(swagger.getPath("/pets").getPatch().getProduces());
+
+    }
+
+    @Test
+    public void testIssue108() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/issue_108.json");
+
+        assertNotNull(swagger);
+    }
+
+    @Test
+    public void testIssue() {
+        String yaml =
+                "swagger: '2.0'\n" +
+                        "info:\n" +
+                        "  description: 'No description provided.'\n" +
+                        "  version: '2.0'\n" +
+                        "  title: 'My web service'\n" +
+                        "  x-endpoint-name: 'default'\n" +
+                        "paths:\n" +
+                        "  x-nothing: 'sorry not supported'\n" +
+                        "  /foo:\n" +
+                        "    x-something: 'yes, it is supported'\n" +
+                        "    get:\n" +
+                        "      parameters: []\n" +
+                        "      responses:\n" +
+                        "        200:\n" +
+                        "          description: 'Swagger API document for this service'\n" +
+                        "x-some-vendor:\n" +
+                        "  sometesting: 'bye!'";
+        SwaggerParser parser = new SwaggerParser();
+        SwaggerDeserializationResult result = parser.readWithInfo(yaml);
+
+        Swagger swagger = result.getSwagger();
+
+        assertEquals(((Map) swagger.getVendorExtensions().get("x-some-vendor")).get("sometesting"), "bye!");
+        assertEquals(swagger.getPath("/foo").getVendorExtensions().get("x-something"), "yes, it is supported");
+        assertTrue(result.getMessages().size() == 1);
+        assertEquals(result.getMessages().get(0), "attribute paths.x-nothing is unsupported");
+    }
+
+    @Test
+    public void testIssue292WithNoCollectionFormat() {
+        String yaml =
+                "swagger: '2.0'\n" +
+                        "info:\n" +
+                        "  version: '0.0.0'\n" +
+                        "  title: nada\n" +
+                        "paths:\n" +
+                        "  /persons:\n" +
+                        "    get:\n" +
+                        "      parameters:\n" +
+                        "      - name: testParam\n" +
+                        "        in: query\n" +
+                        "        type: array\n" +
+                        "        items:\n" +
+                        "          type: string\n" +
+                        "      responses:\n" +
+                        "        200:\n" +
+                        "          description: Successful response";
+        SwaggerParser parser = new SwaggerParser();
+        SwaggerDeserializationResult result = parser.readWithInfo(yaml);
+
+        Swagger swagger = result.getSwagger();
+
+        Parameter param = swagger.getPaths().get("/persons").getGet().getParameters().get(0);
+        QueryParameter qp = (QueryParameter) param;
+        assertNull(qp.getCollectionFormat());
+    }
+
+    @Test
+    public void testIssue292WithCSVCollectionFormat() {
+        String yaml =
+                "swagger: '2.0'\n" +
+                        "info:\n" +
+                        "  version: '0.0.0'\n" +
+                        "  title: nada\n" +
+                        "paths:\n" +
+                        "  /persons:\n" +
+                        "    get:\n" +
+                        "      parameters:\n" +
+                        "      - name: testParam\n" +
+                        "        in: query\n" +
+                        "        type: array\n" +
+                        "        items:\n" +
+                        "          type: string\n" +
+                        "        collectionFormat: csv\n" +
+                        "      responses:\n" +
+                        "        200:\n" +
+                        "          description: Successful response";
+        SwaggerParser parser = new SwaggerParser();
+        SwaggerDeserializationResult result = parser.readWithInfo(yaml);
+
+        Swagger swagger = result.getSwagger();
+
+        Parameter param = swagger.getPaths().get("/persons").getGet().getParameters().get(0);
+        QueryParameter qp = (QueryParameter) param;
+        assertEquals(qp.getCollectionFormat(), "csv");
+    }
+    
+    @Test
+    public void testIssue286() {
+        SwaggerParser parser = new SwaggerParser();
+
+        Swagger swagger = parser.read("issue_286.yaml");
+        Property response = swagger.getPath("/").getGet().getResponses().get("200").getSchema();
+        assertTrue(response instanceof RefProperty);
+        assertEquals(((RefProperty) response).getSimpleRef(), "issue_286_PetList");
+        assertNotNull(swagger.getDefinitions().get("issue_286_Allergy"));
+    }
+
+    @Test
+    public void testIssue286WithModel() {
+        SwaggerParser parser = new SwaggerParser();
+
+        Swagger swagger = parser.read("issue_286.yaml");
+        Model response = swagger.getPath("/").getGet().getResponses().get("200").getResponseSchema();
+        assertTrue(response instanceof RefModel);
+        assertEquals( "issue_286_PetList", ((RefModel) response).getSimpleRef());
+        assertNotNull(swagger.getDefinitions().get("issue_286_Allergy"));
+    }
+
+    @Test
+    public void testIssue360() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/issue_360.yaml");
+        assertNotNull(swagger);
+
+        Parameter parameter = swagger.getPath("/pets").getPost().getParameters().get(0);
+        assertNotNull(parameter);
+        assertTrue(parameter instanceof BodyParameter);
+
+        BodyParameter bp = (BodyParameter) parameter;
+
+        assertNotNull(bp.getSchema());
+        Model model = bp.getSchema();
+        assertTrue(model instanceof ModelImpl);
+
+        ModelImpl impl = (ModelImpl) model;
+        assertNotNull(impl.getProperties().get("foo"));
+
+        Map<String, Object> extensions = bp.getVendorExtensions();
+        assertNotNull(extensions);
+
+        assertNotNull(extensions.get("x-examples"));
+        Object o = extensions.get("x-examples");
+        assertTrue(o instanceof Map);
+
+        Map<String, Object> on = (Map<String, Object>) o;
+
+        Object jn = on.get("application/json");
+        assertTrue(jn instanceof Map);
+
+        Map<String, Object> objectNode = (Map<String, Object>) jn;
+        assertEquals(objectNode.get("foo"), "bar");
+
+        Parameter stringBodyParameter = swagger.getPath("/otherPets").getPost().getParameters().get(0);
+
+        assertTrue(stringBodyParameter instanceof BodyParameter);
+        BodyParameter sbp = (BodyParameter) stringBodyParameter;
+        assertTrue(sbp.getRequired());
+        assertEquals(sbp.getName(), "simple");
+
+        Model sbpModel = sbp.getSchema();
+        assertTrue(sbpModel instanceof ModelImpl);
+        ModelImpl sbpModelImpl = (ModelImpl) sbpModel;
+
+        assertEquals(sbpModelImpl.getType(), "string");
+        assertEquals(sbpModelImpl.getFormat(), "uuid");
+
+        Parameter refBodyParameter = swagger.getPath("/evenMorePets").getPost().getParameters().get(0);
+
+        assertTrue(refBodyParameter instanceof BodyParameter);
+        BodyParameter ref = (BodyParameter) refBodyParameter;
+        assertTrue(ref.getRequired());
+        assertEquals(ref.getName(), "simple");
+
+        Model refModel = ref.getSchema();
+        assertTrue(refModel instanceof RefModel);
+        RefModel refModelImpl = (RefModel) refModel;
+
+        assertEquals(refModelImpl.getSimpleRef(), "Pet");
+    }
+
+    private Swagger doRelativeFileTest(String location) {
+        SwaggerParser parser = new SwaggerParser();
+        SwaggerDeserializationResult readResult = parser.readWithInfo(location, null, true);
+        if (readResult.getMessages().size() > 0) {
+            Json.prettyPrint(readResult.getMessages());
+        }
+        final Swagger swagger = readResult.getSwagger();
+
+        final Path path = swagger.getPath("/health");
+        assertEquals(path.getClass(), Path.class); //we successfully converted the RefPath to a Path
+
+        final List<Parameter> parameters = path.getParameters();
+        assertParamDetails(parameters, 0, QueryParameter.class, "param1", "query");
+        assertParamDetails(parameters, 1, HeaderParameter.class, "param2", "header");
+
+        final Operation operation = path.getGet();
+        final List<Parameter> operationParams = operation.getParameters();
+        assertParamDetails(operationParams, 0, PathParameter.class, "param3", "path");
+        assertParamDetails(operationParams, 1, HeaderParameter.class, "param4", "header");
+        assertParamDetails(operationParams, 2, BodyParameter.class, "body", "body");
+        final BodyParameter bodyParameter = (BodyParameter) operationParams.get(2);
+        assertEquals(((RefModel) bodyParameter.getSchema()).get$ref(), "#/definitions/health");
+
+        final Map<String, Response> responsesMap = operation.getResponses();
+
+        assertResponse(swagger, responsesMap, "200", "Health information from the server", "#/definitions/health");
+        assertResponse(swagger, responsesMap, "400", "Your request was not valid", "#/definitions/error");
+        assertResponse(swagger, responsesMap, "500", "An unexpected error occur during processing", "#/definitions/error");
+
+        final Map<String, Model> definitions = swagger.getDefinitions();
+        final ModelImpl refInDefinitions = (ModelImpl) definitions.get("refInDefinitions");
+        assertEquals(refInDefinitions.getDescription(), "The example model");
+        expectedPropertiesInModel(refInDefinitions, "foo", "bar");
+
+        final ArrayModel arrayModel = (ArrayModel) definitions.get("arrayModel");
+        final RefProperty arrayModelItems = (RefProperty) arrayModel.getItems();
+        assertEquals(arrayModelItems.get$ref(), "#/definitions/foo");
+
+        final ModelImpl fooModel = (ModelImpl) definitions.get("foo");
+        assertEquals(fooModel.getDescription(), "Just another model");
+        expectedPropertiesInModel(fooModel, "hello", "world");
+
+        final ComposedModel composedCat = (ComposedModel) definitions.get("composedCat");
+        final ModelImpl child = (ModelImpl) composedCat.getChild();
+        expectedPropertiesInModel(child, "huntingSkill", "prop2", "reflexes", "reflexMap");
+        final ArrayProperty reflexes = (ArrayProperty) child.getProperties().get("reflexes");
+        final RefProperty reflexItems = (RefProperty) reflexes.getItems();
+        assertEquals(reflexItems.get$ref(), "#/definitions/reflex");
+        assertTrue(definitions.containsKey(reflexItems.getSimpleRef()));
+
+        final MapProperty reflexMap = (MapProperty) child.getProperties().get("reflexMap");
+        final RefProperty reflexMapAdditionalProperties = (RefProperty) reflexMap.getAdditionalProperties();
+        assertEquals(reflexMapAdditionalProperties.get$ref(), "#/definitions/reflex");
+
+        assertEquals(composedCat.getInterfaces().size(), 2);
+        assertEquals(composedCat.getInterfaces().get(0).get$ref(), "#/definitions/pet");
+        assertEquals(composedCat.getInterfaces().get(1).get$ref(), "#/definitions/foo_2");
+
+        return swagger;
+    }
+
+    private Swagger doRelativeResponseFileTest(String location) {
+        SwaggerParser parser = new SwaggerParser();
+        SwaggerDeserializationResult readResult = parser.readWithInfo(location, null, true);
+        
+        if (readResult.getMessages().size() > 0) {
+            Json.prettyPrint(readResult.getMessages());
+        }
+        final Swagger swagger = readResult.getSwagger();
+        
+        Json.prettyPrint(swagger);
+        
+        final Path path = swagger.getPath("/users");
+        assertEquals(path.getClass(), Path.class); //we successfully converted the RefPath to a Path
+
+        final Operation operation = path.getGet();
+
+        final Map<String, Response> responsesMap = operation.getResponses();
+
+        assertResponse(swagger, responsesMap, "200", "OK", "#/definitions/User");
+
+        final Map<String, Model> definitions = swagger.getDefinitions();
+        final ModelImpl refInDefinitions = (ModelImpl) definitions.get("UserX");
+        expectedPropertiesInModel(refInDefinitions, "address");
+
+        final ModelImpl refInDefinitionsAddress = (ModelImpl) definitions.get("Address");
+        expectedPropertiesInModel(refInDefinitionsAddress, "postal", "country");
+
+        final ModelImpl refInDefinitionsCountry = (ModelImpl) definitions.get("Country");
+        expectedPropertiesInModel(refInDefinitionsCountry, "name");
+
+        final ModelImpl refInDefinitionsAddress_2 = (ModelImpl) definitions.get("Address_2");
+        expectedPropertiesInModel(refInDefinitionsAddress_2, "postal", "country");
+
+        final ModelImpl refInDefinitionsCountry_2 = (ModelImpl) definitions.get("Country_2");
+        expectedPropertiesInModel(refInDefinitionsCountry_2, "name");        
+        
+        return swagger;
+    }
+    
+    
+    private void expectedPropertiesInModel(ModelImpl model, String... expectedProperties) {
+        assertEquals(model.getProperties().size(), expectedProperties.length);
+        for (String expectedProperty : expectedProperties) {
+            assertTrue(model.getProperties().containsKey(expectedProperty));
+        }
+    }
+
+    private void assertResponse(Swagger swagger, Map<String, Response> responsesMap, String responseCode,
+                                String expectedDescription, String expectedSchemaRef) {
+        final Response response = responsesMap.get(responseCode);
+        final RefProperty schema = (RefProperty) response.getSchema();
+        assertEquals(response.getDescription(), expectedDescription);
+        assertEquals(schema.getClass(), RefProperty.class);
+        assertEquals(schema.get$ref(), expectedSchemaRef);
+        assertTrue(swagger.getDefinitions().containsKey(schema.getSimpleRef()));
+    }
+
+    private void assertParamDetails(List<Parameter> parameters, int index, Class<?> expectedType,
+                                    String expectedName, String expectedIn) {
+        final Parameter param1 = parameters.get(index);
+        assertEquals(param1.getClass(), expectedType);
+        assertEquals(param1.getName(), expectedName);
+        assertEquals(param1.getIn(), expectedIn);
+    }
+
+    @Test
+    public void testNestedReferences() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/relative-file-references/json/parent.json");
+        assertTrue(swagger.getDefinitions().containsKey("externalArray"));
+        assertTrue(swagger.getDefinitions().containsKey("referencedByLocalArray"));
+        assertTrue(swagger.getDefinitions().containsKey("externalObject"));
+        assertTrue(swagger.getDefinitions().containsKey("referencedByLocalElement"));
+        assertTrue(swagger.getDefinitions().containsKey("referencedBy"));
+        assertEquals(((RefProperty)swagger.getDefinitions().get("externalObject").getProperties().get("hello1")).get$ref(),
+                "#/definitions/referencedByLocalElement"); //issue #434
+    }
+
+    @Test
+    public void testCodegenPetstore() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/petstore-codegen.yaml");
+        ModelImpl enumModel = (ModelImpl) swagger.getDefinitions().get("Enum_Test");
+        assertNotNull(enumModel);
+        Property enumProperty = enumModel.getProperties().get("enum_integer");
+        assertNotNull(enumProperty);
+
+        assertTrue(enumProperty instanceof IntegerProperty);
+        IntegerProperty enumIntegerProperty = (IntegerProperty) enumProperty;
+        List<Integer> integers = enumIntegerProperty.getEnum();
+        assertEquals(integers.get(0), new Integer(1));
+        assertEquals(integers.get(1), new Integer(-1));
+
+        Operation getOrderOperation = swagger.getPath("/store/order/{orderId}").getGet();
+        assertNotNull(getOrderOperation);
+        Parameter orderId = getOrderOperation.getParameters().get(0);
+        assertTrue(orderId instanceof PathParameter);
+        PathParameter orderIdPathParam = (PathParameter) orderId;
+        assertNotNull(orderIdPathParam.getMinimum());
+
+        BigDecimal minimum = orderIdPathParam.getMinimum();
+        assertEquals(minimum.toString(), "1");
+
+        FormParameter formParam = (FormParameter) swagger.getPath("/fake").getPost().getParameters().get(3);
+
+        assertEquals(formParam.getMinimum().toString(), "32.1");
+    }
+
+    @Test
+    public void testIssue339() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/issue-339.json");
+
+        Parameter param = swagger.getPath("/store/order/{orderId}").getGet().getParameters().get(0);
+        assertTrue(param instanceof PathParameter);
+        PathParameter pp = (PathParameter) param;
+
+        assertTrue(pp.getMinimum().toString().equals("1"));
+        assertTrue(pp.getMaximum().toString().equals("5"));
+    }
+
+    @Test
+    public void testCodegenIssue4555() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        String yaml = "swagger: '2.0'\n" +
+                "\n" +
+                "info:\n" +
+                "  title: test\n" +
+                "  version: \"0.0.1\"\n" +
+                "\n" +
+                "schemes:\n" +
+                "  - http\n" +
+                "produces:\n" +
+                "  - application/json\n" +
+                "\n" +
+                "paths:\n" +
+                "  /contents/{id}:\n" +
+                "    parameters:\n" +
+                "      - name: id\n" +
+                "        in: path\n" +
+                "        description: test\n" +
+                "        required: true\n" +
+                "        type: integer\n" +
+                "\n" +
+                "    get:\n" +
+                "      description: test\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            $ref: '#/definitions/Content'\n" +
+                "\n" +
+                "definitions:\n" +
+                "  Content:\n" +
+                "    type: object\n" +
+                "    title: \t\ttest";
+        final SwaggerDeserializationResult result = parser.readWithInfo(yaml);
+
+        // can't parse with tabs!
+        assertNull(result.getSwagger());
+    }
+
+    @Test
+    public void testConverterIssue17() throws Exception {
+        String yaml =
+                "swagger: '2.0'\n" +
+                        "info:\n" +
+                        "  version: '0.0.0'\n" +
+                        "  title: nada\n" +
+                        "paths:\n" +
+                        "  /persons:\n" +
+                        "    get:\n" +
+                        "      parameters:\n" +
+                        "      - name: testParam\n" +
+                        "        in: query\n" +
+                        "        type: array\n" +
+                        "        items:\n" +
+                        "          type: string\n" +
+                        "        collectionFormat: csv\n" +
+                        "      responses:\n" +
+                        "        200:\n" +
+                        "          description: Successful response\n"+
+                        "          schema:\n" +
+                        "            $ref: '#/definitions/Content'\n" +
+                        "definitions:\n" +
+                                "  Content:\n" +
+                                "    type: object";
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml, Boolean.FALSE);
+
+        assertNotNull(result.getSwagger());
+        assertEquals(((RefProperty) result.getSwagger().getPaths().
+                get("/persons").getGet().getResponses().get("200")
+                .getSchema()).get$ref(), "#/definitions/Content");
+    }
+
+    @Test
+    public void testIssue393() {
+        SwaggerParser parser = new SwaggerParser();
+
+        String yaml =
+                "swagger: '2.0'\n" +
+                        "info:\n" +
+                        "  title: x\n" +
+                        "  version: 1.0.0\n" +
+                        "paths:\n" +
+                        "  /test:\n" +
+                        "    get:\n" +
+                        "      parameters: []\n" +
+                        "      responses:\n" +
+                        "        '400':\n" +
+                        "          description: |\n" +
+                        "            The account could not be created because a credential didn't meet the complexity requirements.\n" +
+                        "          x-error-refs:\n" +
+                        "            - '$ref': '#/x-error-defs/credentialTooShort'\n" +
+                        "            - '$ref': '#/x-error-defs/credentialTooLong'\n" +
+                        "x-error-defs:\n" +
+                        "  credentialTooShort:\n" +
+                        "    errorID: credentialTooShort";
+        final SwaggerDeserializationResult result = parser.readWithInfo(yaml);
+
+        assertNotNull(result.getSwagger());
+        Swagger swagger = result.getSwagger();
+
+        assertNotNull(swagger.getVendorExtensions().get("x-error-defs"));
+    }
+
+    @Test
+    public void testBadFormat() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/bad_format.yaml");
+
+        Path path = swagger.getPath("/pets");
+
+        Parameter parameter = path.getGet().getParameters().get(0);
+        assertNotNull(parameter);
+        assertTrue(parameter instanceof QueryParameter);
+        QueryParameter queryParameter = (QueryParameter) parameter;
+        assertEquals(queryParameter.getName(), "query-param-int32");
+        assertNotNull(queryParameter.getEnum());
+        assertEquals(queryParameter.getEnum().size(), 3);
+        List<Object> enumValues = queryParameter.getEnumValue();
+        assertEquals(enumValues.get(0), 1);
+        assertEquals(enumValues.get(1), 2);
+        assertEquals(enumValues.get(2), 7);
+
+        parameter = path.getGet().getParameters().get(1);
+        assertNotNull(parameter);
+        assertTrue(parameter instanceof QueryParameter);
+        queryParameter = (QueryParameter) parameter;
+        assertEquals(queryParameter.getName(), "query-param-invalid-format");
+        assertNotNull(queryParameter.getEnum());
+        assertEquals(queryParameter.getEnum().size(), 3);
+        enumValues = queryParameter.getEnumValue();
+        assertEquals(enumValues.get(0), 1);
+        assertEquals(enumValues.get(1), 2);
+        assertEquals(enumValues.get(2), 7);
+
+        parameter = path.getGet().getParameters().get(2);
+        assertNotNull(parameter);
+        assertTrue(parameter instanceof QueryParameter);
+        queryParameter = (QueryParameter) parameter;
+        assertEquals(queryParameter.getName(), "query-param-collection-format-and-uniqueItems");
+        assertEquals(queryParameter.getCollectionFormat(), "multi");
+        assertEquals(queryParameter.isUniqueItems(), true);
+    }
+    @Test
+    public void testNumberAttributes() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        Swagger swagger = parser.read(TestUtils.getResourceAbsolutePath("/number_attributes.yaml"));
+
+        ModelImpl numberType = (ModelImpl)swagger.getDefinitions().get("NumberType");
+        assertNotNull(numberType);
+        assertNotNull(numberType.getEnum());
+        assertEquals(numberType.getEnum().size(), 2);
+        List<String> numberTypeEnumValues = numberType.getEnum();
+        assertEquals(numberTypeEnumValues.get(0), "1.0");
+        assertEquals(numberTypeEnumValues.get(1), "2.0");
+        assertEquals(numberType.getDefaultValue(), new BigDecimal("1.0"));
+        assertEquals(numberType.getMinimum(), new BigDecimal("1.0"));
+        assertEquals(numberType.getMaximum(), new BigDecimal("2.0"));
+
+        ModelImpl numberDoubleType = (ModelImpl)swagger.getDefinitions().get("NumberDoubleType");
+        assertNotNull(numberDoubleType);
+        assertNotNull(numberDoubleType.getEnum());
+        assertEquals(numberDoubleType.getEnum().size(), 2);
+        List<String> numberDoubleTypeEnumValues = numberDoubleType.getEnum();
+        assertEquals(numberDoubleTypeEnumValues.get(0), "1.0");
+        assertEquals(numberDoubleTypeEnumValues.get(1), "2.0");
+        assertEquals(numberDoubleType.getDefaultValue(), new BigDecimal("1.0"));
+        assertEquals(numberDoubleType.getMinimum(), new BigDecimal("1.0"));
+        assertEquals(numberDoubleType.getMaximum(), new BigDecimal("2.0"));
+
+        ModelImpl integerType = (ModelImpl)swagger.getDefinitions().get("IntegerType");
+        assertNotNull(integerType);
+        assertNotNull(integerType.getEnum());
+        assertEquals(integerType.getEnum().size(), 2);
+        List<String> integerTypeEnumValues = integerType.getEnum();
+        assertEquals(integerTypeEnumValues.get(0), "1");
+        assertEquals(integerTypeEnumValues.get(1), "2");
+        assertEquals(integerType.getDefaultValue(), new Integer("1"));
+        assertEquals(integerType.getMinimum(), new BigDecimal("1"));
+        assertEquals(integerType.getMaximum(), new BigDecimal("2"));
+
+        ModelImpl integerInt32Type = (ModelImpl)swagger.getDefinitions().get("IntegerInt32Type");
+        assertNotNull(integerInt32Type);
+        assertNotNull(integerInt32Type.getEnum());
+        assertEquals(integerInt32Type.getEnum().size(), 2);
+        List<String> integerInt32TypeEnumValues = integerInt32Type.getEnum();
+        assertEquals(integerInt32TypeEnumValues.get(0), "1");
+        assertEquals(integerInt32TypeEnumValues.get(1), "2");
+        assertEquals(integerInt32Type.getDefaultValue(), new Integer("1"));
+        assertEquals(integerInt32Type.getMinimum(), new BigDecimal("1"));
+        assertEquals(integerInt32Type.getMaximum(), new BigDecimal("2"));
+
+
+    }
+
+    @Test
+    public void testDefinitionExample() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read(TestUtils.getResourceAbsolutePath("/definition_example.yaml"));
+
+        ModelImpl model;
+        ArrayModel arrayModel;
+
+        model = (ModelImpl)swagger.getDefinitions().get("NumberType");
+        assertEquals((Double)model.getExample(), 2.0d, 0d);
+
+        model = (ModelImpl)swagger.getDefinitions().get("IntegerType");
+        assertEquals((int)model.getExample(), 2);
+
+        model = (ModelImpl)swagger.getDefinitions().get("StringType");
+        assertEquals((String)model.getExample(), "2");
+
+        model = (ModelImpl)swagger.getDefinitions().get("ObjectType");
+        assertTrue(model.getExample() instanceof Map);
+        Map objectExample = (Map) model.getExample();
+        assertEquals((String)objectExample.get("propertyA"), "valueA");
+        assertEquals((Integer)objectExample.get("propertyB"), new Integer(123));
+
+        arrayModel = (ArrayModel)swagger.getDefinitions().get("ArrayType");
+        assertTrue(arrayModel.getExample() instanceof List);
+        List<Map> arrayExample = (List<Map>) arrayModel.getExample();
+        assertEquals((String)arrayExample.get(0).get("propertyA"), "valueA1");
+        assertEquals((Integer)arrayExample.get(0).get("propertyB"), new Integer(123));
+        assertEquals((String)arrayExample.get(1).get("propertyA"), "valueA2");
+        assertEquals((Integer)arrayExample.get(1).get("propertyB"), new Integer(456));
+
+        model = (ModelImpl)swagger.getDefinitions().get("NumberTypeStringExample");
+        assertEquals((String)model.getExample(), "2.0");
+
+        model = (ModelImpl)swagger.getDefinitions().get("IntegerTypeStringExample");
+        assertEquals((String)model.getExample(), "2");
+
+        model = (ModelImpl)swagger.getDefinitions().get("StringTypeStringExample");
+        assertEquals((String)model.getExample(), "2");
+
+        model = (ModelImpl)swagger.getDefinitions().get("ObjectTypeStringExample");
+        assertEquals((String)model.getExample(), "{\"propertyA\": \"valueA\", \"propertyB\": 123}");
+
+        arrayModel = (ArrayModel) swagger.getDefinitions().get("ArrayTypeStringExample");
+        assertEquals((String)arrayModel.getExample(), "[{\"propertyA\": \"valueA1\", \"propertyB\": 123}, {\"propertyA\": \"valueA2\", \"propertyB\": 456}]");
+    }
 
 	@Test
 	public void testExternalParameters() {
@@ -1349,4 +1259,338 @@ public class SwaggerParserTest {
 			Assert.fail(message);
 		}
 	}
+
+    @Test
+    public void testIssue357() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/issue_357.yaml");
+        assertNotNull(swagger);
+        List<Parameter> getParams = swagger.getPath("/testApi").getGet().getParameters();
+        assertEquals(2, getParams.size());
+        for (Parameter param : getParams) {
+            SerializableParameter sp = (SerializableParameter) param;
+            switch (param.getName()) {
+                case "pathParam1":
+                    assertEquals(sp.getType(), "integer");
+                    break;
+                case "pathParam2":
+                    assertEquals(sp.getType(), "string");
+                    break;
+                default:
+                    fail("Unexpected parameter named " + sp.getName());
+                    break;
+            }
+        }
+    }
+
+    @Test
+    public void testIssue358() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/issue_358.yaml");
+        assertNotNull(swagger);
+        List<Parameter> parms = swagger.getPath("/testApi").getGet().getParameters();
+        assertEquals(1, parms.size());
+        assertEquals("pathParam", parms.get(0).getName());
+        assertEquals("string", ((SerializableParameter) parms.get(0)).getType());
+    }
+
+    @Test
+    public void testIncompatibleRefs() {
+        String yaml =
+                "swagger: '2.0'\n" +
+                        "paths:\n" +
+                        "  /test:\n" +
+                        "    post:\n" +
+                        "      parameters:\n" +
+                        "        # this is not the correct reference type\n" +
+                        "        - $ref: '#/definitions/Model'\n" +
+                        "        - in: body\n" +
+                        "          name: incorrectType\n" +
+                        "          required: true\n" +
+                        "          schema:\n" +
+                        "            $ref: '#/definitions/Model'\n" +
+                        "      responses:\n" +
+                        "        200:\n" +
+                        "          # this is not the correct reference type\n" +
+                        "          $ref: '#/definitions/Model'\n" +
+                        "        400:\n" +
+                        "          definitions: this is right\n" +
+                        "          schema:\n" +
+                        "            $ref: '#/definitions/Model'\n" +
+                        "definitions:\n" +
+                        "  Model:\n" +
+                        "    type: object";
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
+        assertNotNull(result.getSwagger());
+    }
+
+    @Test
+    public void testIssue243() {
+        String yaml =
+                "swagger: \"2.0\"\n" +
+                        "info:\n" +
+                        "  version: 0.0.0\n" +
+                        "  title: Simple API\n" +
+                        "paths:\n" +
+                        "  /:\n" +
+                        "    get:\n" +
+                        "      responses:\n" +
+                        "        '200':\n" +
+                        "          description: OK\n" +
+                        "          schema:\n" +
+                        "            $ref: \"#/definitions/Simple\"\n" +
+                        "definitions:\n" +
+                        "  Simple:\n" +
+                        "    type: string";
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
+        assertNotNull(result.getSwagger());
+    }
+
+    @Test
+    public void testIssue594() {
+        String yaml =
+                "swagger: '2.0'\n" +
+                        "paths:\n" +
+                        "  /test:\n" +
+                        "    post:\n" +
+                        "      parameters:\n" +
+                        "        - name: body\n" +
+                        "          in: body\n" +
+                        "          description: Hello world\n" +
+                        "          schema:\n" +
+                        "            type: array\n" +
+                        "            minItems: 1\n" +
+                        "            maxItems: 1\n" +
+                        "            items: \n" +
+                        "              $ref: \"#/definitions/Pet\"\n" +
+                        "      responses:\n" +
+                        "        200:\n" +
+                        "          description: 'OK'\n";
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
+        assertNotNull(result.getSwagger());
+        ArrayModel schema = (ArrayModel)((BodyParameter)result.getSwagger().getPaths().get("/test").getPost().getParameters().get(0)).getSchema();
+        assertEquals(((RefProperty)schema.getItems()).get$ref(),"#/definitions/Pet");
+        assertNotNull(schema.getMaxItems());
+        assertNotNull(schema.getMinItems());
+
+    }
+
+    @Test
+    public void testIssue450() {
+        String desc = "An array of Pets";
+        String xTag = "x-my-tag";
+        String xVal = "An extension tag";
+        String yaml =
+                "swagger: \"2.0\"\n" +
+                        "info:\n" +
+                        "  version: 0.0.0\n" +
+                        "  title: Simple API\n" +
+                        "paths:\n" +
+                        "  /:\n" +
+                        "    get:\n" +
+                        "      responses:\n" +
+                        "        '200':\n" +
+                        "          description: OK\n" +
+                        "definitions:\n" +
+                        "  PetArray:\n" +
+                        "    type: array\n" +
+                        "    items:\n" +
+                        "      $ref: \"#/definitions/Pet\"\n" +
+                        "    description: " + desc + "\n" +
+                        "    " + xTag + ": " + xVal + "\n" +
+                        "  Pet:\n" +
+                        "    type: object\n" +
+                        "    properties:\n" +
+                        "      id:\n" +
+                        "        type: string";
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
+        assertNotNull(result.getSwagger());
+        final Swagger swagger = result.getSwagger();
+
+        Model petArray = swagger.getDefinitions().get("PetArray");
+        assertNotNull(petArray);
+        assertTrue(petArray instanceof ArrayModel);
+        assertEquals(petArray.getDescription(), desc);
+        assertNotNull(petArray.getVendorExtensions());
+        assertNotNull(petArray.getVendorExtensions().get(xTag));
+        assertEquals(petArray.getVendorExtensions().get(xTag), xVal);
+    }
+
+    @Test
+    public void testIssue480() {
+        final Swagger swagger = new SwaggerParser().read("src/test/resources/issue-480.yaml");
+
+        for (String key : swagger.getSecurityDefinitions().keySet()) {
+            SecuritySchemeDefinition definition = swagger.getSecurityDefinitions().get(key);
+            if ("petstore_auth".equals(key)) {
+                assertTrue(definition instanceof OAuth2Definition);
+                OAuth2Definition oauth = (OAuth2Definition) definition;
+                assertEquals("This is a description", oauth.getDescription());
+            }
+            if ("api_key".equals(key)) {
+                assertTrue(definition instanceof ApiKeyAuthDefinition);
+                ApiKeyAuthDefinition auth = (ApiKeyAuthDefinition) definition;
+                assertEquals("This is another description", auth.getDescription());
+            }
+        }
+    }
+
+    @Test
+    public void checkAllOfAreTaken() {
+        Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-example/allOf.json");
+        assertEquals(2, swagger.getDefinitions().size());
+
+    }
+
+    @Test(description = "Issue #616 Relative references inside of 'allOf'")
+    public void checkAllOfWithRelativeReferencesAreFound() {
+        Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-relative-file-references/parent.json");
+        assertEquals(4, swagger.getDefinitions().size());
+    }
+
+    @Test(description = "Issue #616 Relative references inside of 'allOf'")
+    public void checkAllOfWithRelativeReferencesIssue604() {
+        Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-relative-file-references/swagger.yaml");
+        assertEquals(2, swagger.getDefinitions().size());
+    }
+
+    @Test(description = "Test that validate resolution of external references in allOf of property")
+    public void checkExtRefResolveInPropertiesWithAllOf() {
+        Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-property-relative-file-references/parent.yaml");
+        assertEquals(2, swagger.getDefinitions().size());
+        assertEquals(1, swagger.getDefinitions().get("test").getProperties().size());
+
+        ComposedProperty property = (ComposedProperty) swagger.getDefinitions().get("test").getProperties().get("property");
+        assertEquals(1, property.getVendorExtensions().size());
+        assertEquals(1, property.getAllOf().size());
+
+        RefProperty refProperty = (RefProperty) property.getAllOf().get(0);
+        assertEquals("#/definitions/def.def", refProperty.get$ref());
+
+    }
+
+    @Test(description = "A string example should not be over quoted when parsing a yaml string")
+    public void readingSpecStringShouldNotOverQuotingStringExample() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/over-quoted-example.yaml", null, false);
+
+        Map<String, Model> definitions = swagger.getDefinitions();
+        assertEquals("NoQuotePlease", definitions.get("CustomerType").getExample());
+    }
+
+    @Test(description = "A string example should not be over quoted when parsing a yaml node")
+    public void readingSpecNodeShouldNotOverQuotingStringExample() throws Exception {
+        String yaml = Files.readFile(new File("src/test/resources/over-quoted-example.yaml"));
+        JsonNode rootNode = Yaml.mapper().readValue(yaml, JsonNode.class);
+        SwaggerParser parser = new SwaggerParser();
+        Swagger swagger = parser.read(rootNode,true);
+
+        Map<String, Model> definitions = swagger.getDefinitions();
+        assertEquals("NoQuotePlease", definitions.get("CustomerType").getExample());
+    }
+
+    @Test
+    public void testRefNameConflicts() throws Exception {
+        Swagger swagger = new SwaggerParser().read("name-conflicts/refs-name-conflict/a.yaml");
+
+        assertTrue(swagger.getDefinitions().size() == 2);
+
+        assertEquals("#/definitions/PersonObj", ((RefProperty) swagger.getPath("/newPerson").getPost().getResponses().get("200").getSchema()).get$ref());
+        assertEquals("#/definitions/PersonObj_2", ((RefProperty) swagger.getPath("/oldPerson").getPost().getResponses().get("200").getSchema()).get$ref());
+        assertEquals("#/definitions/PersonObj_2", ((RefProperty) swagger.getPath("/yetAnotherPerson").getPost().getResponses().get("200").getSchema()).get$ref());
+        assertEquals("local", swagger.getDefinitions().get("PersonObj").getProperties().get("location").getExample());
+        assertEquals("referred", swagger.getDefinitions().get("PersonObj_2").getProperties().get("location").getExample());
+    }
+
+    @Test
+    public void testRefAdditionalProperties() throws Exception {
+        Swagger swagger = new SwaggerParser().read("src/test/resources/additionalProperties.yaml");
+
+        Assert.assertNotNull(swagger);
+
+        Assert.assertTrue(swagger.getDefinitions().size() == 3);
+        
+        Assert.assertNotNull(swagger.getDefinitions().get("link-object"));
+        Assert.assertNotNull(swagger.getDefinitions().get("rel-data"));
+        Assert.assertNotNull(swagger.getDefinitions().get("result"));
+    }
+
+    @Test
+    public void testRefEnum() throws Exception {
+        Swagger swagger = new SwaggerParser().read("src/test/resources/refEnum.yaml");
+
+        Assert.assertNotNull(swagger);
+
+        Assert.assertTrue(swagger.getDefinitions().size() == 5);
+
+        Assert.assertNotNull(swagger.getDefinitions().get("PrintInfo"));
+        Assert.assertNotNull(swagger.getDefinitions().get("SomeEnum"));
+        Assert.assertNotNull(swagger.getDefinitions().get("ShippingInfo"));
+    }
+
+    @Test
+    public void testIssue643() throws Exception {
+        Swagger swagger = new SwaggerParser().read("src/test/resources/issue_643.yaml");
+
+        Assert.assertNotNull(swagger);
+
+        Assert.assertTrue(swagger.getDefinitions().size() == 1);
+
+        Assert.assertNotNull(swagger.getDefinitions().get("XYZResponse"));
+
+    }
+
+    @Test
+    public void testIssueGrace() throws Exception {
+        Swagger swagger = new SwaggerParser().read("src/test/resources/issue_657/issue_657.json");
+
+        Assert.assertNotNull(swagger);
+
+        Assert.assertTrue(swagger.getDefinitions().size() == 2);
+
+        Assert.assertNotNull(swagger.getDefinitions().get("Person"));
+        Assert.assertNotNull(swagger.getDefinitions().get("Persons"));
+
+    }
+
+    @Test
+    public void testLoadExternalNestedDefinitions() throws Exception {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/nested-references/b.yaml");
+
+        Map<String, Model> definitions = swagger.getDefinitions();
+        assertTrue(definitions.containsKey("x"));
+        assertTrue(definitions.containsKey("y"));
+        assertTrue(definitions.containsKey("z"));
+        assertTrue(definitions.containsKey("referencedByLocalElement"));
+        assertEquals("#/definitions/k_2", ((RefModel) definitions.get("i")).get$ref());
+        assertEquals("k-definition", definitions.get("k").getTitle());
+        assertEquals("k-definition", definitions.get("k_2").getTitle());
+        assertEquals(((RefModel) definitions.get("l")).get$ref(), "#/definitions/referencedByLocalElement"); //issue #434
+    }
+
+    @Test(description = "Parser not honoring redirect responses")
+    public void testIssue844() {
+        SwaggerParser parser = new SwaggerParser();
+        final SwaggerDeserializationResult swagger = parser.readWithInfo("src/test/resources/reusableParametersWithExternalRef.json", null, true);
+        assertNotNull(swagger.getSwagger());
+        assertEquals(swagger.getSwagger().getPath("/pets/{id}").getGet().getParameters().get(0).getIn(), "header");
+    }
+
+    @Test
+    public void testIssue258() {
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("duplicateOperationId.json", null, true);
+        assertNotNull(result);
+        assertNotNull(result.getSwagger());
+        assertEquals(result.getMessages().get(0), "attribute paths.'/pets/{id}'(post).operationId is repeated");
+    }
+
+    @Test
+    public void testIssue913() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/issue-913/BS/ApiSpecification.yaml");
+        Assert.assertNotNull(swagger);
+        Assert.assertNotNull(swagger.getDefinitions().get("indicatorType"));
+        Assert.assertEquals(swagger.getDefinitions().get("indicatorType").getProperties().size(),1);
+    }
 }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -57,1511 +57,1296 @@ import static org.testng.Assert.fail;
 public class SwaggerParserTest {
 
     @Test
-    public void testIssue1143(){
-        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue1143.json", null, true);
-        assertNotNull(result.getSwagger().getDefinitions().get("RedisResource"));
-        assertNotNull(result.getSwagger().getDefinitions().get("identificacion_usuario_aplicacion"));
-    }
-
-    @Test
-    public void testIssue1204() {
-        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue1204.yaml", null, true);
-        System.out.println(result.getMessages());
-        assertTrue(result.getMessages().size() == 0);
-        assertNotNull(result.getSwagger());
-
-    }
-
-    @Test
-    public void testIssue1169() {
-        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue1169.yaml", null, true);
-        assertTrue(result.getMessages().size() == 0);
-        assertNotNull(result.getSwagger());
-    }
-
-
-    @Test
-    public void testIssueRelativeRefs2(){
-        String location = "exampleSpecs/specs/my-domain/test-api/v1/test-api-swagger_v1.json";
-        Swagger swagger = new SwaggerParser().read(location, null, true);
-        assertNotNull(swagger);
-        Map<String, Model> definitions = swagger.getDefinitions();
-        Assert.assertTrue(definitions.get("confirmMessageType_v01").getProperties().get("resources") instanceof ArrayProperty);
-        ArrayProperty arraySchema = (ArrayProperty) definitions.get("confirmMessageType_v01").getProperties().get("resources");
-        ObjectProperty prop = (ObjectProperty) arraySchema.getItems();
-        RefProperty refProperty = (RefProperty) prop.getProperties().get("resourceID");
-        assertEquals(refProperty.get$ref(),"#/definitions/simpleIDType_v01");
-    }
-
-    @Test
-    public void testIssue111() {
-        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue-111.yaml", null, true);
-        assertTrue(result.getMessages().get(0).equals("attribute definitions.Filter.items is missing"));
-        assertNotNull(result.getSwagger());
-    }
-
-    @Test
-    public void testIssue1146() {
-        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue-1146.yaml", null, true);
-        assertEquals(0, result.getMessages().size());
-    }
-
-    @Test
-    public void testIssueDefinitionWithDots_2() {
-        Swagger swagger = new SwaggerParser().read("SimpleAPI.yaml");
-        assertNotNull(swagger);
-    }
-
-    @Test
-    public void testIssueDefinitionWithDots() {
-        Swagger swagger = new SwaggerParser().read("API-Service-2.0.0-swagger.yaml");
-        assertNotNull(swagger);
-    }
-
-    @Test
-    public void testIssue995() {
-        Swagger swagger = new SwaggerParser().read("issue-995/digitalExp-Product-Unresolved.yaml");
-        assertNotNull(swagger);
-        assertTrue(swagger.getDefinitions().size() == 6);
-        assertNotNull(swagger.getDefinitions().get("MobileProduct"));
-        assertNotNull(swagger.getDefinitions().get("FixedVoiceProduct"));
-        assertNotNull(swagger.getDefinitions().get("InternetProduct"));
-    }
-
-    @Test
-    public void testIssue927() {
-        Swagger swagger = new SwaggerParser().read("issue-927/issue-927.yaml");
-        assertNotNull(swagger);
-        assertTrue(swagger.getDefinitions().size() == 3);
-        assertNotNull(swagger.getDefinitions().get("Pet"));
-        assertNotNull(swagger.getDefinitions().get("Cat"));
-        assertNotNull(swagger.getDefinitions().get("Dog"));
-    }
-
-    @Test
-    public void testIssue901_2() {
-        Swagger swagger = new SwaggerParser().read("issue-901/spec2.yaml");
-        assertNotNull(swagger);
-        assertNotNull(swagger.getDefinitions());
-        ArrayProperty arraySchema = (ArrayProperty) swagger.getDefinitions().get("Test.Definition").getProperties().get("stuff");
-        String internalRef = ((RefProperty) arraySchema.getItems()).get$ref();
-        assertEquals(internalRef,"#/definitions/TEST.THING.OUT.Stuff");
-    }
-
-    @Test
-    public void testIssue901() {
-        Swagger swagger = new SwaggerParser().read("issue-901/spec.yaml");
-        assertNotNull(swagger);
-        String internalRef = ((RefModel)swagger.getPaths().get("/test").getPut().getResponses().get("200").getResponseSchema()).get$ref();
-        assertEquals(internalRef,"#/definitions/Test.Definition");
-        assertNotNull(swagger.getDefinitions());
-
-    }
-
-    @Test
-    public void testIssue435() {
-        Swagger swagger = new SwaggerParser().read("issue-435/main.yaml");
-        assertNotNull(swagger.getDefinitions().get("sub"));
-        assertNotNull(swagger.getDefinitions().get("subsub"));
-    }
-
-
-    @Test
-    public void testIssue845() {
-        SwaggerDeserializationResult swaggerDeserializationResult = new SwaggerParser().readWithInfo("");
-        assertEquals(swaggerDeserializationResult.getMessages().get(0), "empty or null swagger supplied");
-    }
-  
-    @Test
-    public void testIssue834() {
-        Swagger swagger = new SwaggerParser().read("issue-834/index.yaml", null, true);
-        assertNotNull(swagger);
-
-        Response foo200 =swagger.getPaths().get("/foo").getGet().getResponses().get("200");
-        assertNotNull(foo200);
-        RefModel model200 = (RefModel) foo200.getResponseSchema();
-        String foo200SchemaRef = model200.get$ref();
-        assertEquals(foo200SchemaRef, "#/definitions/schema");
-
-        Response foo300 = swagger.getPaths().get("/foo").getGet().getResponses().get("300");
-        assertNotNull(foo300);
-        RefModel model300 = (RefModel) foo300.getResponseSchema();
-        String foo300SchemaRef = model300.get$ref();
-        assertEquals(foo300SchemaRef, "#/definitions/schema");
-
-        Response bar200 = swagger.getPaths().get("/bar").getGet().getResponses().get("200");
-        assertNotNull(bar200);
-        RefModel modelBar200 = (RefModel) bar200.getResponseSchema();
-        String bar200SchemaRef = modelBar200.get$ref();
-        assertEquals(bar200SchemaRef, "#/definitions/schema");
-    }
-
-    @Test
-    public void testIssue811_RefSchema_ToRefSchema() {
-        final Swagger swagger = new SwaggerParser().read("oapi-reference-test2/index.yaml", null, true);
-        Assert.assertNotNull(swagger);
-        RefModel model = (RefModel) swagger.getPaths().get("/").getGet().getResponses().get("200").getResponseSchema();
-        Assert.assertEquals(model.get$ref() ,"#/definitions/schema-with-reference");
-    }
-
-    @Test
-    public void testIssue811() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/oapi-reference-test/index.yaml");
-        Assert.assertNotNull(swagger);
-        assertTrue(swagger.getPaths().get("/").getGet().getResponses().get("200").getResponseSchema() instanceof RefModel);
-        RefModel model = (RefModel) swagger.getPaths().get("/").getGet().getResponses().get("200").getResponseSchema();
-        Assert.assertEquals(model.get$ref(),"#/definitions/schema-with-reference");
-
-    }
-
-    @Test
-    public void testIssue727() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/issue-714/serviceA.yaml");
-        Assert.assertNotNull(swagger);
-        assertNotNull(swagger.getPaths().get("/test").getGet().getParameters().get(0));
-        assertTrue(swagger.getDefinitions().size() == 1);
-        assertNotNull(swagger.getDefinitions().get("refA"));
-    }
-
-    @Test
-    public void testIssue704() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/sample/swagger.json");
-        Assert.assertNotNull(swagger);
-
-        assertNotNull(swagger.getPaths().get("/api/Address").getGet());
-        assertTrue(swagger.getDefinitions().size() == 1);
-        assertNotNull(swagger.getDefinitions().get("AddressEx"));
-    }
-
-    @Test
-    public void testIssue697() throws Exception {
-        String yaml = "{\n" +
-                "    \"swagger\": \"2.0\",\n" +
-                "    \"info\": {\n" +
-                "        \"version\": \"1.0\",\n" +
-                "        \"title\": \"x-example\"\n" +
-                "    },\n" +
-                "    \"host\": \"httpbin.org\",\n" +
-                "    \"basePath\": \"/anything\",\n" +
-                "    \"schemes\": [\n" +
-                "        \"http\"\n" +
-                "    ],\n" +
-                "    \"paths\": {\n" +
-                "        \"/{foo}\": {\n" +
-                "            \"get\": {\n" +
-                "                \"responses\": {\n" +
-                "                    \"200\": {\n" +
-                "                        \"description\": \"OK\"\n" +
-                "                    }\n" +
-                "                },\n" +
-                "                \"deprecated\": false\n" +
-                "            }\n" +
-                "        }\n" +
-                "    }\n" +
-                "}";
-
-        SwaggerParser parser = new SwaggerParser();
-
-        Swagger swagger = parser.parse(yaml);
-        assertFalse(swagger.getPaths().get("/{foo}").getGet().isDeprecated());
-
-    }
-
-    @Test
-    public void testNPEIssue684() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/issue-684.json");
-        Assert.assertNotNull(swagger);
-        assertTrue(swagger.getParameters().get("ParamDef3") instanceof RefParameter);
-    }
-
-    @Test
-    public void testRefPaths() throws Exception {
-        String yaml = "swagger: '2.0'\n" +
-                "info:\n" +
-                "  version: 0.0.0\n" +
-                "  title: Path item $ref test\n" +
-                "paths:\n" +
-                "  /foo:\n" +
-                "    get:\n" +
-                "      responses:\n" +
-                "        200:\n" +
-                "          description: OK\n" +
-                "  /foo2:\n" +
-                "    $ref: '#/paths/~1foo'";
-
-        SwaggerParser parser = new SwaggerParser();
-
-        Swagger swagger = parser.parse(yaml);
-
-        assertEquals(swagger.getPaths().get("foo"),swagger.getPaths().get("foo2"));
-        
-
-    }
-    @Test
-    public void testModelParameters() throws Exception {
-        String yaml = "swagger: '2.0'\n" +
-                "info:\n" +
-                "  version: \"0.0.0\"\n" +
-                "  title: test\n" +
-                "paths:\n" +
-                "  /foo:\n" +
-                "    get:\n" +
-                "      parameters:\n" +
-                "      - name: amount\n" +
-                "        in: body\n" +
-                "        schema:\n" +
-                "          type: integer\n" +
-                "          format: int64\n" +
-                "          description: amount of money\n" +
-                "          default: 1000\n" +
-                "          maximum: 100000\n" +
-                "      responses:\n" +
-                "        200:\n" +
-                "          description: ok";
-
-        SwaggerParser parser = new SwaggerParser();
-
-        Swagger swagger = parser.parse(yaml);
-
-    }
-
-    @Test
-    public void testParseSharedPathParameters() throws Exception {
-        String yaml =
-                "swagger: '2.0'\n" +
-                        "info:\n" +
-                        "  version: \"0.0.0\"\n" +
-                        "  title: test\n" +
-                        "paths:\n" +
-                        "  /persons/{id}:\n" +
-                        "    parameters:\n" +
-                        "      - in: path\n" +
-                        "        name: id\n" +
-                        "        type: string\n" +
-                        "        required: true\n" +
-                        "        description: \"no\"\n" +
-                        "    get:\n" +
-                        "      parameters:\n" +
-                        "        - name: id\n" +
-                        "          in: path\n" +
-                        "          required: true\n" +
-                        "          type: string\n" +
-                        "          description: \"yes\"\n" +
-                        "        - name: name\n" +
-                        "          in: query\n" +
-                        "          type: string\n" +
-                        "      responses:\n" +
-                        "        200:\n" +
-                        "          description: ok\n";
-
-        SwaggerParser parser = new SwaggerParser();
-
-        Swagger swagger = parser.parse(yaml);
-        List<Parameter> parameters = swagger.getPath("/persons/{id}").getGet().getParameters();
-        assertTrue(parameters.size() == 2);
-        Parameter id = parameters.get(0);
-        assertEquals(id.getDescription(), "yes");
-    }
-
-    @Test
-    public void testParseRefPathParameters() throws Exception {
-        String yaml =
-                "swagger: '2.0'\n" +
-                        "info:\n" +
-                        "  title: test\n" +
-                        "  version: '0.0.0'\n" +
-                        "parameters:\n" +
-                        "  report-id:\n" +
-                        "    name: id\n" +
-                        "    in: path\n" +
-                        "    type: string\n" +
-                        "    required: true\n" +
-                        "paths:\n" +
-                        "  /reports/{id}:\n" +
-                        "    parameters:\n" +
-                        "        - $ref: '#/parameters/report-id'\n" +
-                        "    put:\n" +
-                        "      parameters:\n" +
-                        "        - name: id\n" +
-                        "          in: body\n" +
-                        "          required: true\n" +
-                        "          schema:\n" +
-                        "            $ref: '#/definitions/report'\n" +
-                        "      responses:\n" +
-                        "        200:\n" +
-                        "          description: ok\n" +
-                        "definitions:\n" +
-                        "  report:\n" +
-                        "    type: object\n" +
-                        "    properties:\n" +
-                        "      id:\n" +
-                        "        type: string\n" +
-                        "      name:\n" +
-                        "        type: string\n" +
-                        "    required:\n" +
-                        "    - id\n" +
-                        "    - name\n";
-        SwaggerParser parser = new SwaggerParser();
-        Swagger swagger = parser.parse(yaml);
-    }
-
-    @Test
-    public void testUniqueParameters() throws Exception {
-        String yaml =
-                "swagger: '2.0'\n" +
-                        "info:\n" +
-                        "  title: test\n" +
-                        "  version: '0.0.0'\n" +
-                        "parameters:\n" +
-                        "  foo-id:\n" +
-                        "    name: id\n" +
-                        "    in: path\n" +
-                        "    type: string\n" +
-                        "    required: true\n" +
-                        "paths:\n" +
-                        "  /foos/{id}:\n" +
-                        "    parameters:\n" +
-                        "        - $ref: '#/parameters/foo-id'\n" +
-                        "    get:\n" +
-                        "      responses:\n" +
-                        "        200:\n" +
-                        "          schema:\n" +
-                        "            $ref: '#/definitions/foo'\n" +
-                        "    put:\n" +
-                        "      parameters:\n" +
-                        "        - name: foo\n" +
-                        "          in: body\n" +
-                        "          required: true\n" +
-                        "          schema:\n" +
-                        "            $ref: '#/definitions/foo'\n" +
-                        "      responses:\n" +
-                        "        200:\n" +
-                        "          schema:\n" +
-                        "            $ref: '#/definitions/foo'\n" +
-                        "definitions:\n" +
-                        "  foo:\n" +
-                        "    type: object\n" +
-                        "    properties:\n" +
-                        "      id:\n" +
-                        "        type: string\n" +
-                        "    required:\n" +
-                        "      - id\n";
-        SwaggerParser parser = new SwaggerParser();
-        Swagger swagger = parser.parse(yaml);
-        List<Parameter> parameters = swagger.getPath("/foos/{id}").getPut().getParameters();
-        assertTrue(parameters.size() == 2);
-    }
-
-    @Test
-    public void testLoadRelativeFileTree_Json() throws Exception {
-        final Swagger swagger = doRelativeFileTest("src/test/resources/relative-file-references/json/parent.json");
-        //Json.mapper().writerWithDefaultPrettyPrinter().writeValue(new File("resolved.json"), swagger);
-    }
-
-
-
-    @Test
-    public void testPetstore() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        SwaggerDeserializationResult result = parser.readWithInfo("src/test/resources/petstore.json", null, true);
-
-        assertNotNull(result);
-        assertTrue(result.getMessages().isEmpty());
-
-        Swagger swagger = result.getSwagger();
-        Map<String, Model> definitions = swagger.getDefinitions();
-        Set<String> expectedDefinitions = new HashSet<String>();
-        expectedDefinitions.add("User");
-        expectedDefinitions.add("Category");
-        expectedDefinitions.add("Pet");
-        expectedDefinitions.add("Tag");
-        expectedDefinitions.add("Order");
-        expectedDefinitions.add("PetArray");
-        assertEquals(definitions.keySet(), expectedDefinitions);
-
-        Model petModel = definitions.get("Pet");
-        Set<String> expectedPetProps = new HashSet<String>();
-        expectedPetProps.add("id");
-        expectedPetProps.add("category");
-        expectedPetProps.add("name");
-        expectedPetProps.add("photoUrls");
-        expectedPetProps.add("tags");
-        expectedPetProps.add("status");
-        assertEquals(petModel.getProperties().keySet(), expectedPetProps);
-
-        ArrayModel petArrayModel = (ArrayModel) definitions.get("PetArray");
-        assertEquals(petArrayModel.getType(), "array");
-        RefProperty refProp = (RefProperty) petArrayModel.getItems();
-        assertEquals(refProp.get$ref(), "#/definitions/Pet");
-        assertNull(petArrayModel.getProperties());
-    }
-
-    @Test
-    public void testFileReferenceWithVendorExt() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/file-reference-with-vendor-ext/b.yaml");
-        Map<String, Model> definitions = swagger.getDefinitions();
-        assertTrue(definitions.get("z").getVendorExtensions().get("x-foo") instanceof Map);
-        assertEquals(((Map) definitions.get("z").getVendorExtensions().get("x-foo")).get("bar"), "baz");
-        assertTrue(definitions.get("x").getVendorExtensions().get("x-foo") instanceof Map);
-        assertEquals(((Map) definitions.get("x").getVendorExtensions().get("x-foo")).get("bar"), "baz");
-    }
-
-    @Test
-    public void testTroublesomeFile() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/troublesome.yaml");
-    }
-
-    @Test
-    public void testLoadRelativeFileTree_Yaml() throws Exception {
-        JsonToYamlFileDuplicator.duplicateFilesInYamlFormat("src/test/resources/relative-file-references/json",
-                "src/test/resources/relative-file-references/yaml");
-        final Swagger swagger = doRelativeFileTest("src/test/resources/relative-file-references/yaml/parent.yaml");
-        assertNotNull(Yaml.mapper().writeValueAsString(swagger));
-        assertTrue(swagger.getParameters().get("param2") instanceof HeaderParameter);
-    }
-
-    @Test
-    public void testLoadnestedExternalResponseReferencesFile_Yaml() throws Exception {
-        final Swagger swagger = doRelativeResponseFileTest("src/test/resources/nested-external-response-references/swagger-root.yaml");
-        assertNotNull(Yaml.mapper().writeValueAsString(swagger));
-    }
-    
-    @Test
-    public void testLoadRecursiveExternalDef() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/file-reference-to-recursive-defs/b.yaml");
-
-        Map<String, Model> definitions = swagger.getDefinitions();
-        assertEquals(((RefProperty) ((ArrayProperty) definitions.get("v").getProperties().get("children")).getItems()).get$ref(), "#/definitions/v");
-        assertTrue(definitions.containsKey("y"));
-        assertEquals(((RefProperty) ((ArrayProperty) definitions.get("x").getProperties().get("children")).getItems()).get$ref(), "#/definitions/y");
-    }
-
-    @Test
-    public void testLoadNestedItemsReferences() {
-        SwaggerParser parser = new SwaggerParser();
-        SwaggerDeserializationResult result = parser.readWithInfo("src/test/resources/nested-items-references/b.yaml", null, true);
-        Swagger swagger = result.getSwagger();
-        Map<String, Model> definitions = swagger.getDefinitions();
-        assertTrue(definitions.containsKey("z"));
-        assertTrue(definitions.containsKey("w"));
-    }
-
-    @Test
-    public void testIssue75() {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/issue99.json");
-
-        BodyParameter param = (BodyParameter) swagger.getPaths().get("/albums").getPost().getParameters().get(0);
-        Model model = param.getSchema();
-
-        assertNotNull(model);
-        assertTrue(model instanceof ArrayModel);
-
-        ArrayModel am = (ArrayModel) model;
-        assertTrue(am.getItems() instanceof ByteArrayProperty);
-        assertEquals(am.getItems().getFormat(), "byte");
-    }
-
-    @Test(enabled = false, description = "see https://github.com/swagger-api/swagger-parser/issues/337")
-    public void testIssue62() {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/fixtures/v2.0/json/resources/resourceWithLinkedDefinitions.json");
-
-        assertNotNull(swagger.getPaths().get("/pets/{petId}").getGet());
-    }
-
-    @Test
-    public void testIssue146() {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/issue_146.yaml");
-        assertNotNull(swagger);
-        QueryParameter p = ((QueryParameter) swagger.getPaths().get("/checker").getGet().getParameters().get(0));
-        StringProperty pp = (StringProperty) p.getItems();
-        assertTrue("registration".equalsIgnoreCase(pp.getEnum().get(0)));
-    }
-
-    @Test(description = "Test (path & form) parameter's required attribute")
-    public void testParameterRequired() {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/petstore.json");
-        final List<Parameter> operationParams = swagger.getPath("/pet/{petId}").getPost().getParameters();
-
-        final PathParameter pathParameter = (PathParameter) operationParams.get(0);
-        Assert.assertTrue(pathParameter.getRequired());
-
-        final FormParameter formParameter = (FormParameter) operationParams.get(1);
-        Assert.assertFalse(formParameter.getRequired());
-    }
-
-    @Test(description = "Test consumes and produces in top level and operation level")
-    public void testConsumesAndProduces() {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/consumes_and_produces");
-        Assert.assertNotNull(swagger);
-
-        // test consumes and produces at spec level
-        Assert.assertEquals(swagger.getConsumes(), Arrays.asList("application/json"));
-        Assert.assertEquals(swagger.getProduces(), Arrays.asList("application/xml"));
-
-        // test consumes and produces at operation level
-        Assert.assertEquals(swagger.getPath("/pets").getPost().getConsumes(), Arrays.asList("image/jpeg"));
-        Assert.assertEquals(swagger.getPath("/pets").getPost().getProduces(), Arrays.asList("image/png"));
-
-        // test empty consumes and produces at operation level
-        Assert.assertEquals(swagger.getPath("/pets").getGet().getConsumes(), Collections.<String>emptyList());
-        Assert.assertEquals(swagger.getPath("/pets").getGet().getProduces(), Collections.<String>emptyList());
-
-        // test consumes and produces not defined at operation level
-        Assert.assertNull(swagger.getPath("/pets").getPatch().getConsumes());
-        Assert.assertNull(swagger.getPath("/pets").getPatch().getProduces());
-
-    }
-
-    @Test
-    public void testIssue108() {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/issue_108.json");
-
-        assertNotNull(swagger);
-    }
-
-    @Test
-    public void testIssue() {
-        String yaml =
-                "swagger: '2.0'\n" +
-                        "info:\n" +
-                        "  description: 'No description provided.'\n" +
-                        "  version: '2.0'\n" +
-                        "  title: 'My web service'\n" +
-                        "  x-endpoint-name: 'default'\n" +
-                        "paths:\n" +
-                        "  x-nothing: 'sorry not supported'\n" +
-                        "  /foo:\n" +
-                        "    x-something: 'yes, it is supported'\n" +
-                        "    get:\n" +
-                        "      parameters: []\n" +
-                        "      responses:\n" +
-                        "        200:\n" +
-                        "          description: 'Swagger API document for this service'\n" +
-                        "x-some-vendor:\n" +
-                        "  sometesting: 'bye!'";
-        SwaggerParser parser = new SwaggerParser();
-        SwaggerDeserializationResult result = parser.readWithInfo(yaml);
-
-        Swagger swagger = result.getSwagger();
-
-        assertEquals(((Map) swagger.getVendorExtensions().get("x-some-vendor")).get("sometesting"), "bye!");
-        assertEquals(swagger.getPath("/foo").getVendorExtensions().get("x-something"), "yes, it is supported");
-        assertTrue(result.getMessages().size() == 1);
-        assertEquals(result.getMessages().get(0), "attribute paths.x-nothing is unsupported");
-    }
-
-    @Test
-    public void testIssue292WithNoCollectionFormat() {
-        String yaml =
-                "swagger: '2.0'\n" +
-                        "info:\n" +
-                        "  version: '0.0.0'\n" +
-                        "  title: nada\n" +
-                        "paths:\n" +
-                        "  /persons:\n" +
-                        "    get:\n" +
-                        "      parameters:\n" +
-                        "      - name: testParam\n" +
-                        "        in: query\n" +
-                        "        type: array\n" +
-                        "        items:\n" +
-                        "          type: string\n" +
-                        "      responses:\n" +
-                        "        200:\n" +
-                        "          description: Successful response";
-        SwaggerParser parser = new SwaggerParser();
-        SwaggerDeserializationResult result = parser.readWithInfo(yaml);
-
-        Swagger swagger = result.getSwagger();
-
-        Parameter param = swagger.getPaths().get("/persons").getGet().getParameters().get(0);
-        QueryParameter qp = (QueryParameter) param;
-        assertNull(qp.getCollectionFormat());
-    }
-
-    @Test
-    public void testIssue292WithCSVCollectionFormat() {
-        String yaml =
-                "swagger: '2.0'\n" +
-                        "info:\n" +
-                        "  version: '0.0.0'\n" +
-                        "  title: nada\n" +
-                        "paths:\n" +
-                        "  /persons:\n" +
-                        "    get:\n" +
-                        "      parameters:\n" +
-                        "      - name: testParam\n" +
-                        "        in: query\n" +
-                        "        type: array\n" +
-                        "        items:\n" +
-                        "          type: string\n" +
-                        "        collectionFormat: csv\n" +
-                        "      responses:\n" +
-                        "        200:\n" +
-                        "          description: Successful response";
-        SwaggerParser parser = new SwaggerParser();
-        SwaggerDeserializationResult result = parser.readWithInfo(yaml);
-
-        Swagger swagger = result.getSwagger();
-
-        Parameter param = swagger.getPaths().get("/persons").getGet().getParameters().get(0);
-        QueryParameter qp = (QueryParameter) param;
-        assertEquals(qp.getCollectionFormat(), "csv");
-    }
-    
-    @Test
-    public void testIssue286() {
-        SwaggerParser parser = new SwaggerParser();
-
-        Swagger swagger = parser.read("issue_286.yaml");
-        Property response = swagger.getPath("/").getGet().getResponses().get("200").getSchema();
-        assertTrue(response instanceof RefProperty);
-        assertEquals(((RefProperty) response).getSimpleRef(), "issue_286_PetList");
-        assertNotNull(swagger.getDefinitions().get("issue_286_Allergy"));
-    }
-
-    @Test
-    public void testIssue286WithModel() {
-        SwaggerParser parser = new SwaggerParser();
-
-        Swagger swagger = parser.read("issue_286.yaml");
-        Model response = swagger.getPath("/").getGet().getResponses().get("200").getResponseSchema();
-        assertTrue(response instanceof RefModel);
-        assertEquals( "issue_286_PetList", ((RefModel) response).getSimpleRef());
-        assertNotNull(swagger.getDefinitions().get("issue_286_Allergy"));
-    }
-
-    @Test
-    public void testIssue360() {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/issue_360.yaml");
-        assertNotNull(swagger);
-
-        Parameter parameter = swagger.getPath("/pets").getPost().getParameters().get(0);
-        assertNotNull(parameter);
-        assertTrue(parameter instanceof BodyParameter);
-
-        BodyParameter bp = (BodyParameter) parameter;
-
-        assertNotNull(bp.getSchema());
-        Model model = bp.getSchema();
-        assertTrue(model instanceof ModelImpl);
-
-        ModelImpl impl = (ModelImpl) model;
-        assertNotNull(impl.getProperties().get("foo"));
-
-        Map<String, Object> extensions = bp.getVendorExtensions();
-        assertNotNull(extensions);
-
-        assertNotNull(extensions.get("x-examples"));
-        Object o = extensions.get("x-examples");
-        assertTrue(o instanceof Map);
-
-        Map<String, Object> on = (Map<String, Object>) o;
-
-        Object jn = on.get("application/json");
-        assertTrue(jn instanceof Map);
-
-        Map<String, Object> objectNode = (Map<String, Object>) jn;
-        assertEquals(objectNode.get("foo"), "bar");
-
-        Parameter stringBodyParameter = swagger.getPath("/otherPets").getPost().getParameters().get(0);
-
-        assertTrue(stringBodyParameter instanceof BodyParameter);
-        BodyParameter sbp = (BodyParameter) stringBodyParameter;
-        assertTrue(sbp.getRequired());
-        assertEquals(sbp.getName(), "simple");
-
-        Model sbpModel = sbp.getSchema();
-        assertTrue(sbpModel instanceof ModelImpl);
-        ModelImpl sbpModelImpl = (ModelImpl) sbpModel;
-
-        assertEquals(sbpModelImpl.getType(), "string");
-        assertEquals(sbpModelImpl.getFormat(), "uuid");
-
-        Parameter refBodyParameter = swagger.getPath("/evenMorePets").getPost().getParameters().get(0);
-
-        assertTrue(refBodyParameter instanceof BodyParameter);
-        BodyParameter ref = (BodyParameter) refBodyParameter;
-        assertTrue(ref.getRequired());
-        assertEquals(ref.getName(), "simple");
-
-        Model refModel = ref.getSchema();
-        assertTrue(refModel instanceof RefModel);
-        RefModel refModelImpl = (RefModel) refModel;
-
-        assertEquals(refModelImpl.getSimpleRef(), "Pet");
-    }
-
-    private Swagger doRelativeFileTest(String location) {
-        SwaggerParser parser = new SwaggerParser();
-        SwaggerDeserializationResult readResult = parser.readWithInfo(location, null, true);
-        if (readResult.getMessages().size() > 0) {
-            Json.prettyPrint(readResult.getMessages());
-        }
-        final Swagger swagger = readResult.getSwagger();
-
-        final Path path = swagger.getPath("/health");
-        assertEquals(path.getClass(), Path.class); //we successfully converted the RefPath to a Path
-
-        final List<Parameter> parameters = path.getParameters();
-        assertParamDetails(parameters, 0, QueryParameter.class, "param1", "query");
-        assertParamDetails(parameters, 1, HeaderParameter.class, "param2", "header");
-
-        final Operation operation = path.getGet();
-        final List<Parameter> operationParams = operation.getParameters();
-        assertParamDetails(operationParams, 0, PathParameter.class, "param3", "path");
-        assertParamDetails(operationParams, 1, HeaderParameter.class, "param4", "header");
-        assertParamDetails(operationParams, 2, BodyParameter.class, "body", "body");
-        final BodyParameter bodyParameter = (BodyParameter) operationParams.get(2);
-        assertEquals(((RefModel) bodyParameter.getSchema()).get$ref(), "#/definitions/health");
-
-        final Map<String, Response> responsesMap = operation.getResponses();
-
-        assertResponse(swagger, responsesMap, "200", "Health information from the server", "#/definitions/health");
-        assertResponse(swagger, responsesMap, "400", "Your request was not valid", "#/definitions/error");
-        assertResponse(swagger, responsesMap, "500", "An unexpected error occur during processing", "#/definitions/error");
-
-        final Map<String, Model> definitions = swagger.getDefinitions();
-        final ModelImpl refInDefinitions = (ModelImpl) definitions.get("refInDefinitions");
-        assertEquals(refInDefinitions.getDescription(), "The example model");
-        expectedPropertiesInModel(refInDefinitions, "foo", "bar");
-
-        final ArrayModel arrayModel = (ArrayModel) definitions.get("arrayModel");
-        final RefProperty arrayModelItems = (RefProperty) arrayModel.getItems();
-        assertEquals(arrayModelItems.get$ref(), "#/definitions/foo");
-
-        final ModelImpl fooModel = (ModelImpl) definitions.get("foo");
-        assertEquals(fooModel.getDescription(), "Just another model");
-        expectedPropertiesInModel(fooModel, "hello", "world");
-
-        final ComposedModel composedCat = (ComposedModel) definitions.get("composedCat");
-        final ModelImpl child = (ModelImpl) composedCat.getChild();
-        expectedPropertiesInModel(child, "huntingSkill", "prop2", "reflexes", "reflexMap");
-        final ArrayProperty reflexes = (ArrayProperty) child.getProperties().get("reflexes");
-        final RefProperty reflexItems = (RefProperty) reflexes.getItems();
-        assertEquals(reflexItems.get$ref(), "#/definitions/reflex");
-        assertTrue(definitions.containsKey(reflexItems.getSimpleRef()));
-
-        final MapProperty reflexMap = (MapProperty) child.getProperties().get("reflexMap");
-        final RefProperty reflexMapAdditionalProperties = (RefProperty) reflexMap.getAdditionalProperties();
-        assertEquals(reflexMapAdditionalProperties.get$ref(), "#/definitions/reflex");
-
-        assertEquals(composedCat.getInterfaces().size(), 2);
-        assertEquals(composedCat.getInterfaces().get(0).get$ref(), "#/definitions/pet");
-        assertEquals(composedCat.getInterfaces().get(1).get$ref(), "#/definitions/foo_2");
-
-        return swagger;
-    }
-
-    private Swagger doRelativeResponseFileTest(String location) {
-        SwaggerParser parser = new SwaggerParser();
-        SwaggerDeserializationResult readResult = parser.readWithInfo(location, null, true);
-        
-        if (readResult.getMessages().size() > 0) {
-            Json.prettyPrint(readResult.getMessages());
-        }
-        final Swagger swagger = readResult.getSwagger();
-        
-        Json.prettyPrint(swagger);
-        
-        final Path path = swagger.getPath("/users");
-        assertEquals(path.getClass(), Path.class); //we successfully converted the RefPath to a Path
-
-        final Operation operation = path.getGet();
-
-        final Map<String, Response> responsesMap = operation.getResponses();
-
-        assertResponse(swagger, responsesMap, "200", "OK", "#/definitions/User");
-
-        final Map<String, Model> definitions = swagger.getDefinitions();
-        final ModelImpl refInDefinitions = (ModelImpl) definitions.get("UserX");
-        expectedPropertiesInModel(refInDefinitions, "address");
-
-        final ModelImpl refInDefinitionsAddress = (ModelImpl) definitions.get("Address");
-        expectedPropertiesInModel(refInDefinitionsAddress, "postal", "country");
-
-        final ModelImpl refInDefinitionsCountry = (ModelImpl) definitions.get("Country");
-        expectedPropertiesInModel(refInDefinitionsCountry, "name");
-
-        final ModelImpl refInDefinitionsAddress_2 = (ModelImpl) definitions.get("Address_2");
-        expectedPropertiesInModel(refInDefinitionsAddress_2, "postal", "country");
-
-        final ModelImpl refInDefinitionsCountry_2 = (ModelImpl) definitions.get("Country_2");
-        expectedPropertiesInModel(refInDefinitionsCountry_2, "name");        
-        
-        return swagger;
-    }
-    
-    
-    private void expectedPropertiesInModel(ModelImpl model, String... expectedProperties) {
-        assertEquals(model.getProperties().size(), expectedProperties.length);
-        for (String expectedProperty : expectedProperties) {
-            assertTrue(model.getProperties().containsKey(expectedProperty));
-        }
-    }
-
-    private void assertResponse(Swagger swagger, Map<String, Response> responsesMap, String responseCode,
-                                String expectedDescription, String expectedSchemaRef) {
-        final Response response = responsesMap.get(responseCode);
-        final RefProperty schema = (RefProperty) response.getSchema();
-        assertEquals(response.getDescription(), expectedDescription);
-        assertEquals(schema.getClass(), RefProperty.class);
-        assertEquals(schema.get$ref(), expectedSchemaRef);
-        assertTrue(swagger.getDefinitions().containsKey(schema.getSimpleRef()));
-    }
-
-    private void assertParamDetails(List<Parameter> parameters, int index, Class<?> expectedType,
-                                    String expectedName, String expectedIn) {
-        final Parameter param1 = parameters.get(index);
-        assertEquals(param1.getClass(), expectedType);
-        assertEquals(param1.getName(), expectedName);
-        assertEquals(param1.getIn(), expectedIn);
-    }
-
-    @Test
-    public void testNestedReferences() {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/relative-file-references/json/parent.json");
-        assertTrue(swagger.getDefinitions().containsKey("externalArray"));
-        assertTrue(swagger.getDefinitions().containsKey("referencedByLocalArray"));
-        assertTrue(swagger.getDefinitions().containsKey("externalObject"));
-        assertTrue(swagger.getDefinitions().containsKey("referencedByLocalElement"));
-        assertTrue(swagger.getDefinitions().containsKey("referencedBy"));
-        assertEquals(((RefProperty)swagger.getDefinitions().get("externalObject").getProperties().get("hello1")).get$ref(),
-                "#/definitions/referencedByLocalElement"); //issue #434
-    }
-
-    @Test
-    public void testCodegenPetstore() {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/petstore-codegen.yaml");
-        ModelImpl enumModel = (ModelImpl) swagger.getDefinitions().get("Enum_Test");
-        assertNotNull(enumModel);
-        Property enumProperty = enumModel.getProperties().get("enum_integer");
-        assertNotNull(enumProperty);
-
-        assertTrue(enumProperty instanceof IntegerProperty);
-        IntegerProperty enumIntegerProperty = (IntegerProperty) enumProperty;
-        List<Integer> integers = enumIntegerProperty.getEnum();
-        assertEquals(integers.get(0), new Integer(1));
-        assertEquals(integers.get(1), new Integer(-1));
-
-        Operation getOrderOperation = swagger.getPath("/store/order/{orderId}").getGet();
-        assertNotNull(getOrderOperation);
-        Parameter orderId = getOrderOperation.getParameters().get(0);
-        assertTrue(orderId instanceof PathParameter);
-        PathParameter orderIdPathParam = (PathParameter) orderId;
-        assertNotNull(orderIdPathParam.getMinimum());
-
-        BigDecimal minimum = orderIdPathParam.getMinimum();
-        assertEquals(minimum.toString(), "1");
-
-        FormParameter formParam = (FormParameter) swagger.getPath("/fake").getPost().getParameters().get(3);
-
-        assertEquals(formParam.getMinimum().toString(), "32.1");
-    }
-
-    @Test
-    public void testIssue339() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/issue-339.json");
-
-        Parameter param = swagger.getPath("/store/order/{orderId}").getGet().getParameters().get(0);
-        assertTrue(param instanceof PathParameter);
-        PathParameter pp = (PathParameter) param;
-
-        assertTrue(pp.getMinimum().toString().equals("1"));
-        assertTrue(pp.getMaximum().toString().equals("5"));
-    }
-
-    @Test
-    public void testCodegenIssue4555() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        String yaml = "swagger: '2.0'\n" +
-                "\n" +
-                "info:\n" +
-                "  title: test\n" +
-                "  version: \"0.0.1\"\n" +
-                "\n" +
-                "schemes:\n" +
-                "  - http\n" +
-                "produces:\n" +
-                "  - application/json\n" +
-                "\n" +
-                "paths:\n" +
-                "  /contents/{id}:\n" +
-                "    parameters:\n" +
-                "      - name: id\n" +
-                "        in: path\n" +
-                "        description: test\n" +
-                "        required: true\n" +
-                "        type: integer\n" +
-                "\n" +
-                "    get:\n" +
-                "      description: test\n" +
-                "      responses:\n" +
-                "        200:\n" +
-                "          description: OK\n" +
-                "          schema:\n" +
-                "            $ref: '#/definitions/Content'\n" +
-                "\n" +
-                "definitions:\n" +
-                "  Content:\n" +
-                "    type: object\n" +
-                "    title: \t\ttest";
-        final SwaggerDeserializationResult result = parser.readWithInfo(yaml);
-
-        // can't parse with tabs!
-        assertNull(result.getSwagger());
-    }
-
-    @Test
-    public void testConverterIssue17() throws Exception {
-        String yaml =
-                "swagger: '2.0'\n" +
-                        "info:\n" +
-                        "  version: '0.0.0'\n" +
-                        "  title: nada\n" +
-                        "paths:\n" +
-                        "  /persons:\n" +
-                        "    get:\n" +
-                        "      parameters:\n" +
-                        "      - name: testParam\n" +
-                        "        in: query\n" +
-                        "        type: array\n" +
-                        "        items:\n" +
-                        "          type: string\n" +
-                        "        collectionFormat: csv\n" +
-                        "      responses:\n" +
-                        "        200:\n" +
-                        "          description: Successful response\n"+
-                        "          schema:\n" +
-                        "            $ref: '#/definitions/Content'\n" +
-                        "definitions:\n" +
-                                "  Content:\n" +
-                                "    type: object";
-        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml, Boolean.FALSE);
-
-        assertNotNull(result.getSwagger());
-        assertEquals(((RefProperty) result.getSwagger().getPaths().
-                get("/persons").getGet().getResponses().get("200")
-                .getSchema()).get$ref(), "#/definitions/Content");
-    }
-
-    @Test
-    public void testIssue393() {
-        SwaggerParser parser = new SwaggerParser();
-
-        String yaml =
-                "swagger: '2.0'\n" +
-                        "info:\n" +
-                        "  title: x\n" +
-                        "  version: 1.0.0\n" +
-                        "paths:\n" +
-                        "  /test:\n" +
-                        "    get:\n" +
-                        "      parameters: []\n" +
-                        "      responses:\n" +
-                        "        '400':\n" +
-                        "          description: |\n" +
-                        "            The account could not be created because a credential didn't meet the complexity requirements.\n" +
-                        "          x-error-refs:\n" +
-                        "            - '$ref': '#/x-error-defs/credentialTooShort'\n" +
-                        "            - '$ref': '#/x-error-defs/credentialTooLong'\n" +
-                        "x-error-defs:\n" +
-                        "  credentialTooShort:\n" +
-                        "    errorID: credentialTooShort";
-        final SwaggerDeserializationResult result = parser.readWithInfo(yaml);
-
-        assertNotNull(result.getSwagger());
-        Swagger swagger = result.getSwagger();
-
-        assertNotNull(swagger.getVendorExtensions().get("x-error-defs"));
-    }
-
-    @Test
-    public void testBadFormat() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/bad_format.yaml");
-
-        Path path = swagger.getPath("/pets");
-
-        Parameter parameter = path.getGet().getParameters().get(0);
-        assertNotNull(parameter);
-        assertTrue(parameter instanceof QueryParameter);
-        QueryParameter queryParameter = (QueryParameter) parameter;
-        assertEquals(queryParameter.getName(), "query-param-int32");
-        assertNotNull(queryParameter.getEnum());
-        assertEquals(queryParameter.getEnum().size(), 3);
-        List<Object> enumValues = queryParameter.getEnumValue();
-        assertEquals(enumValues.get(0), 1);
-        assertEquals(enumValues.get(1), 2);
-        assertEquals(enumValues.get(2), 7);
-
-        parameter = path.getGet().getParameters().get(1);
-        assertNotNull(parameter);
-        assertTrue(parameter instanceof QueryParameter);
-        queryParameter = (QueryParameter) parameter;
-        assertEquals(queryParameter.getName(), "query-param-invalid-format");
-        assertNotNull(queryParameter.getEnum());
-        assertEquals(queryParameter.getEnum().size(), 3);
-        enumValues = queryParameter.getEnumValue();
-        assertEquals(enumValues.get(0), 1);
-        assertEquals(enumValues.get(1), 2);
-        assertEquals(enumValues.get(2), 7);
-
-        parameter = path.getGet().getParameters().get(2);
-        assertNotNull(parameter);
-        assertTrue(parameter instanceof QueryParameter);
-        queryParameter = (QueryParameter) parameter;
-        assertEquals(queryParameter.getName(), "query-param-collection-format-and-uniqueItems");
-        assertEquals(queryParameter.getCollectionFormat(), "multi");
-        assertEquals(queryParameter.isUniqueItems(), true);
-    }
-    @Test
-    public void testNumberAttributes() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        Swagger swagger = parser.read(TestUtils.getResourceAbsolutePath("/number_attributes.yaml"));
-
-        ModelImpl numberType = (ModelImpl)swagger.getDefinitions().get("NumberType");
-        assertNotNull(numberType);
-        assertNotNull(numberType.getEnum());
-        assertEquals(numberType.getEnum().size(), 2);
-        List<String> numberTypeEnumValues = numberType.getEnum();
-        assertEquals(numberTypeEnumValues.get(0), "1.0");
-        assertEquals(numberTypeEnumValues.get(1), "2.0");
-        assertEquals(numberType.getDefaultValue(), new BigDecimal("1.0"));
-        assertEquals(numberType.getMinimum(), new BigDecimal("1.0"));
-        assertEquals(numberType.getMaximum(), new BigDecimal("2.0"));
-
-        ModelImpl numberDoubleType = (ModelImpl)swagger.getDefinitions().get("NumberDoubleType");
-        assertNotNull(numberDoubleType);
-        assertNotNull(numberDoubleType.getEnum());
-        assertEquals(numberDoubleType.getEnum().size(), 2);
-        List<String> numberDoubleTypeEnumValues = numberDoubleType.getEnum();
-        assertEquals(numberDoubleTypeEnumValues.get(0), "1.0");
-        assertEquals(numberDoubleTypeEnumValues.get(1), "2.0");
-        assertEquals(numberDoubleType.getDefaultValue(), new BigDecimal("1.0"));
-        assertEquals(numberDoubleType.getMinimum(), new BigDecimal("1.0"));
-        assertEquals(numberDoubleType.getMaximum(), new BigDecimal("2.0"));
-
-        ModelImpl integerType = (ModelImpl)swagger.getDefinitions().get("IntegerType");
-        assertNotNull(integerType);
-        assertNotNull(integerType.getEnum());
-        assertEquals(integerType.getEnum().size(), 2);
-        List<String> integerTypeEnumValues = integerType.getEnum();
-        assertEquals(integerTypeEnumValues.get(0), "1");
-        assertEquals(integerTypeEnumValues.get(1), "2");
-        assertEquals(integerType.getDefaultValue(), new Integer("1"));
-        assertEquals(integerType.getMinimum(), new BigDecimal("1"));
-        assertEquals(integerType.getMaximum(), new BigDecimal("2"));
-
-        ModelImpl integerInt32Type = (ModelImpl)swagger.getDefinitions().get("IntegerInt32Type");
-        assertNotNull(integerInt32Type);
-        assertNotNull(integerInt32Type.getEnum());
-        assertEquals(integerInt32Type.getEnum().size(), 2);
-        List<String> integerInt32TypeEnumValues = integerInt32Type.getEnum();
-        assertEquals(integerInt32TypeEnumValues.get(0), "1");
-        assertEquals(integerInt32TypeEnumValues.get(1), "2");
-        assertEquals(integerInt32Type.getDefaultValue(), new Integer("1"));
-        assertEquals(integerInt32Type.getMinimum(), new BigDecimal("1"));
-        assertEquals(integerInt32Type.getMaximum(), new BigDecimal("2"));
-
-
-    }
-
-    @Test
-    public void testDefinitionExample() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read(TestUtils.getResourceAbsolutePath("/definition_example.yaml"));
-
-        ModelImpl model;
-        ArrayModel arrayModel;
-
-        model = (ModelImpl)swagger.getDefinitions().get("NumberType");
-        assertEquals((Double)model.getExample(), 2.0d, 0d);
-
-        model = (ModelImpl)swagger.getDefinitions().get("IntegerType");
-        assertEquals((int)model.getExample(), 2);
-
-        model = (ModelImpl)swagger.getDefinitions().get("StringType");
-        assertEquals((String)model.getExample(), "2");
-
-        model = (ModelImpl)swagger.getDefinitions().get("ObjectType");
-        assertTrue(model.getExample() instanceof Map);
-        Map objectExample = (Map) model.getExample();
-        assertEquals((String)objectExample.get("propertyA"), "valueA");
-        assertEquals((Integer)objectExample.get("propertyB"), new Integer(123));
-
-        arrayModel = (ArrayModel)swagger.getDefinitions().get("ArrayType");
-        assertTrue(arrayModel.getExample() instanceof List);
-        List<Map> arrayExample = (List<Map>) arrayModel.getExample();
-        assertEquals((String)arrayExample.get(0).get("propertyA"), "valueA1");
-        assertEquals((Integer)arrayExample.get(0).get("propertyB"), new Integer(123));
-        assertEquals((String)arrayExample.get(1).get("propertyA"), "valueA2");
-        assertEquals((Integer)arrayExample.get(1).get("propertyB"), new Integer(456));
-
-        model = (ModelImpl)swagger.getDefinitions().get("NumberTypeStringExample");
-        assertEquals((String)model.getExample(), "2.0");
-
-        model = (ModelImpl)swagger.getDefinitions().get("IntegerTypeStringExample");
-        assertEquals((String)model.getExample(), "2");
-
-        model = (ModelImpl)swagger.getDefinitions().get("StringTypeStringExample");
-        assertEquals((String)model.getExample(), "2");
-
-        model = (ModelImpl)swagger.getDefinitions().get("ObjectTypeStringExample");
-        assertEquals((String)model.getExample(), "{\"propertyA\": \"valueA\", \"propertyB\": 123}");
-
-        arrayModel = (ArrayModel) swagger.getDefinitions().get("ArrayTypeStringExample");
-        assertEquals((String)arrayModel.getExample(), "[{\"propertyA\": \"valueA1\", \"propertyB\": 123}, {\"propertyA\": \"valueA2\", \"propertyB\": 456}]");
-    }
-
-    @Test
-    public void testIssue357() {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/issue_357.yaml");
-        assertNotNull(swagger);
-        List<Parameter> getParams = swagger.getPath("/testApi").getGet().getParameters();
-        assertEquals(2, getParams.size());
-        for (Parameter param : getParams) {
-            SerializableParameter sp = (SerializableParameter) param;
-            switch (param.getName()) {
-                case "pathParam1":
-                    assertEquals(sp.getType(), "integer");
-                    break;
-                case "pathParam2":
-                    assertEquals(sp.getType(), "string");
-                    break;
-                default:
-                    fail("Unexpected parameter named " + sp.getName());
-                    break;
-            }
-        }
-    }
-
-    @Test
-    public void testIssue358() {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/issue_358.yaml");
-        assertNotNull(swagger);
-        List<Parameter> parms = swagger.getPath("/testApi").getGet().getParameters();
-        assertEquals(1, parms.size());
-        assertEquals("pathParam", parms.get(0).getName());
-        assertEquals("string", ((SerializableParameter) parms.get(0)).getType());
-    }
-
-    @Test
-    public void testIncompatibleRefs() {
-        String yaml =
-                "swagger: '2.0'\n" +
-                        "paths:\n" +
-                        "  /test:\n" +
-                        "    post:\n" +
-                        "      parameters:\n" +
-                        "        # this is not the correct reference type\n" +
-                        "        - $ref: '#/definitions/Model'\n" +
-                        "        - in: body\n" +
-                        "          name: incorrectType\n" +
-                        "          required: true\n" +
-                        "          schema:\n" +
-                        "            $ref: '#/definitions/Model'\n" +
-                        "      responses:\n" +
-                        "        200:\n" +
-                        "          # this is not the correct reference type\n" +
-                        "          $ref: '#/definitions/Model'\n" +
-                        "        400:\n" +
-                        "          definitions: this is right\n" +
-                        "          schema:\n" +
-                        "            $ref: '#/definitions/Model'\n" +
-                        "definitions:\n" +
-                        "  Model:\n" +
-                        "    type: object";
-        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
-        assertNotNull(result.getSwagger());
-    }
-
-    @Test
-    public void testIssue243() {
-        String yaml =
-                "swagger: \"2.0\"\n" +
-                        "info:\n" +
-                        "  version: 0.0.0\n" +
-                        "  title: Simple API\n" +
-                        "paths:\n" +
-                        "  /:\n" +
-                        "    get:\n" +
-                        "      responses:\n" +
-                        "        '200':\n" +
-                        "          description: OK\n" +
-                        "          schema:\n" +
-                        "            $ref: \"#/definitions/Simple\"\n" +
-                        "definitions:\n" +
-                        "  Simple:\n" +
-                        "    type: string";
-        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
-        assertNotNull(result.getSwagger());
-    }
-
-    @Test
-    public void testIssue594() {
-        String yaml =
-                "swagger: '2.0'\n" +
-                        "paths:\n" +
-                        "  /test:\n" +
-                        "    post:\n" +
-                        "      parameters:\n" +
-                        "        - name: body\n" +
-                        "          in: body\n" +
-                        "          description: Hello world\n" +
-                        "          schema:\n" +
-                        "            type: array\n" +
-                        "            minItems: 1\n" +
-                        "            maxItems: 1\n" +
-                        "            items: \n" +
-                        "              $ref: \"#/definitions/Pet\"\n" +
-                        "      responses:\n" +
-                        "        200:\n" +
-                        "          description: 'OK'\n";
-        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
-        assertNotNull(result.getSwagger());
-        ArrayModel schema = (ArrayModel)((BodyParameter)result.getSwagger().getPaths().get("/test").getPost().getParameters().get(0)).getSchema();
-        assertEquals(((RefProperty)schema.getItems()).get$ref(),"#/definitions/Pet");
-        assertNotNull(schema.getMaxItems());
-        assertNotNull(schema.getMinItems());
-
-    }
-
-    @Test
-    public void testIssue450() {
-        String desc = "An array of Pets";
-        String xTag = "x-my-tag";
-        String xVal = "An extension tag";
-        String yaml =
-                "swagger: \"2.0\"\n" +
-                        "info:\n" +
-                        "  version: 0.0.0\n" +
-                        "  title: Simple API\n" +
-                        "paths:\n" +
-                        "  /:\n" +
-                        "    get:\n" +
-                        "      responses:\n" +
-                        "        '200':\n" +
-                        "          description: OK\n" +
-                        "definitions:\n" +
-                        "  PetArray:\n" +
-                        "    type: array\n" +
-                        "    items:\n" +
-                        "      $ref: \"#/definitions/Pet\"\n" +
-                        "    description: " + desc + "\n" +
-                        "    " + xTag + ": " + xVal + "\n" +
-                        "  Pet:\n" +
-                        "    type: object\n" +
-                        "    properties:\n" +
-                        "      id:\n" +
-                        "        type: string";
-        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
-        assertNotNull(result.getSwagger());
-        final Swagger swagger = result.getSwagger();
-
-        Model petArray = swagger.getDefinitions().get("PetArray");
-        assertNotNull(petArray);
-        assertTrue(petArray instanceof ArrayModel);
-        assertEquals(petArray.getDescription(), desc);
-        assertNotNull(petArray.getVendorExtensions());
-        assertNotNull(petArray.getVendorExtensions().get(xTag));
-        assertEquals(petArray.getVendorExtensions().get(xTag), xVal);
-    }
-
-    @Test
-    public void testIssue480() {
-        final Swagger swagger = new SwaggerParser().read("src/test/resources/issue-480.yaml");
-
-        for (String key : swagger.getSecurityDefinitions().keySet()) {
-            SecuritySchemeDefinition definition = swagger.getSecurityDefinitions().get(key);
-            if ("petstore_auth".equals(key)) {
-                assertTrue(definition instanceof OAuth2Definition);
-                OAuth2Definition oauth = (OAuth2Definition) definition;
-                assertEquals("This is a description", oauth.getDescription());
-            }
-            if ("api_key".equals(key)) {
-                assertTrue(definition instanceof ApiKeyAuthDefinition);
-                ApiKeyAuthDefinition auth = (ApiKeyAuthDefinition) definition;
-                assertEquals("This is another description", auth.getDescription());
-            }
-        }
-    }
-
-    @Test
-    public void checkAllOfAreTaken() {
-        Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-example/allOf.json");
-        assertEquals(2, swagger.getDefinitions().size());
-
-    }
-
-    @Test(description = "Issue #616 Relative references inside of 'allOf'")
-    public void checkAllOfWithRelativeReferencesAreFound() {
-        Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-relative-file-references/parent.json");
-        assertEquals(4, swagger.getDefinitions().size());
-    }
-
-    @Test(description = "Issue #616 Relative references inside of 'allOf'")
-    public void checkAllOfWithRelativeReferencesIssue604() {
-        Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-relative-file-references/swagger.yaml");
-        assertEquals(2, swagger.getDefinitions().size());
-    }
-
-    @Test(description = "Test that validate resolution of external references in allOf of property")
-    public void checkExtRefResolveInPropertiesWithAllOf() {
-        Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-property-relative-file-references/parent.yaml");
-        assertEquals(2, swagger.getDefinitions().size());
-        assertEquals(1, swagger.getDefinitions().get("test").getProperties().size());
-
-        ComposedProperty property = (ComposedProperty) swagger.getDefinitions().get("test").getProperties().get("property");
-        assertEquals(1, property.getVendorExtensions().size());
-        assertEquals(1, property.getAllOf().size());
-
-        RefProperty refProperty = (RefProperty) property.getAllOf().get(0);
-        assertEquals("#/definitions/def.def", refProperty.get$ref());
-
-    }
-
-    @Test(description = "A string example should not be over quoted when parsing a yaml string")
-    public void readingSpecStringShouldNotOverQuotingStringExample() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/over-quoted-example.yaml", null, false);
-
-        Map<String, Model> definitions = swagger.getDefinitions();
-        assertEquals("NoQuotePlease", definitions.get("CustomerType").getExample());
-    }
-
-    @Test(description = "A string example should not be over quoted when parsing a yaml node")
-    public void readingSpecNodeShouldNotOverQuotingStringExample() throws Exception {
-        String yaml = Files.readFile(new File("src/test/resources/over-quoted-example.yaml"));
-        JsonNode rootNode = Yaml.mapper().readValue(yaml, JsonNode.class);
-        SwaggerParser parser = new SwaggerParser();
-        Swagger swagger = parser.read(rootNode,true);
-
-        Map<String, Model> definitions = swagger.getDefinitions();
-        assertEquals("NoQuotePlease", definitions.get("CustomerType").getExample());
-    }
-
-    @Test
-    public void testRefNameConflicts() throws Exception {
-        Swagger swagger = new SwaggerParser().read("name-conflicts/refs-name-conflict/a.yaml");
-
-        assertTrue(swagger.getDefinitions().size() == 2);
-
-        assertEquals("#/definitions/PersonObj", ((RefProperty) swagger.getPath("/newPerson").getPost().getResponses().get("200").getSchema()).get$ref());
-        assertEquals("#/definitions/PersonObj_2", ((RefProperty) swagger.getPath("/oldPerson").getPost().getResponses().get("200").getSchema()).get$ref());
-        assertEquals("#/definitions/PersonObj_2", ((RefProperty) swagger.getPath("/yetAnotherPerson").getPost().getResponses().get("200").getSchema()).get$ref());
-        assertEquals("local", swagger.getDefinitions().get("PersonObj").getProperties().get("location").getExample());
-        assertEquals("referred", swagger.getDefinitions().get("PersonObj_2").getProperties().get("location").getExample());
-    }
-
-    @Test
-    public void testRefAdditionalProperties() throws Exception {
-        Swagger swagger = new SwaggerParser().read("src/test/resources/additionalProperties.yaml");
-
-        Assert.assertNotNull(swagger);
-
-        Assert.assertTrue(swagger.getDefinitions().size() == 3);
-        
-        Assert.assertNotNull(swagger.getDefinitions().get("link-object"));
-        Assert.assertNotNull(swagger.getDefinitions().get("rel-data"));
-        Assert.assertNotNull(swagger.getDefinitions().get("result"));
-    }
-
-    @Test
-    public void testRefEnum() throws Exception {
-        Swagger swagger = new SwaggerParser().read("src/test/resources/refEnum.yaml");
-
-        Assert.assertNotNull(swagger);
-
-        Assert.assertTrue(swagger.getDefinitions().size() == 5);
-
-        Assert.assertNotNull(swagger.getDefinitions().get("PrintInfo"));
-        Assert.assertNotNull(swagger.getDefinitions().get("SomeEnum"));
-        Assert.assertNotNull(swagger.getDefinitions().get("ShippingInfo"));
-    }
-
-    @Test
-    public void testIssue643() throws Exception {
-        Swagger swagger = new SwaggerParser().read("src/test/resources/issue_643.yaml");
-
-        Assert.assertNotNull(swagger);
-
-        Assert.assertTrue(swagger.getDefinitions().size() == 1);
-
-        Assert.assertNotNull(swagger.getDefinitions().get("XYZResponse"));
-
-    }
-
-    @Test
-    public void testIssueGrace() throws Exception {
-        Swagger swagger = new SwaggerParser().read("src/test/resources/issue_657/issue_657.json");
-
-        Assert.assertNotNull(swagger);
-
-        Assert.assertTrue(swagger.getDefinitions().size() == 2);
-
-        Assert.assertNotNull(swagger.getDefinitions().get("Person"));
-        Assert.assertNotNull(swagger.getDefinitions().get("Persons"));
-
-    }
-
-    @Test
-    public void testLoadExternalNestedDefinitions() throws Exception {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/nested-references/b.yaml");
-
-        Map<String, Model> definitions = swagger.getDefinitions();
-        assertTrue(definitions.containsKey("x"));
-        assertTrue(definitions.containsKey("y"));
-        assertTrue(definitions.containsKey("z"));
-        assertTrue(definitions.containsKey("referencedByLocalElement"));
-        assertEquals("#/definitions/k_2", ((RefModel) definitions.get("i")).get$ref());
-        assertEquals("k-definition", definitions.get("k").getTitle());
-        assertEquals("k-definition", definitions.get("k_2").getTitle());
-        assertEquals(((RefModel) definitions.get("l")).get$ref(), "#/definitions/referencedByLocalElement"); //issue #434
-    }
-
-    @Test(description = "Parser not honoring redirect responses")
-    public void testIssue844() {
-        SwaggerParser parser = new SwaggerParser();
-        final SwaggerDeserializationResult swagger = parser.readWithInfo("src/test/resources/reusableParametersWithExternalRef.json", null, true);
-        assertNotNull(swagger.getSwagger());
-        assertEquals(swagger.getSwagger().getPath("/pets/{id}").getGet().getParameters().get(0).getIn(), "header");
-    }
-
-    @Test
-    public void testIssue258() {
-        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("duplicateOperationId.json", null, true);
-        assertNotNull(result);
-        assertNotNull(result.getSwagger());
-        assertEquals(result.getMessages().get(0), "attribute paths.'/pets/{id}'(post).operationId is repeated");
-    }
-
-    @Test
-    public void testIssue913() {
-        SwaggerParser parser = new SwaggerParser();
-        final Swagger swagger = parser.read("src/test/resources/issue-913/BS/ApiSpecification.yaml");
-        Assert.assertNotNull(swagger);
-        Assert.assertNotNull(swagger.getDefinitions().get("indicatorType"));
-        Assert.assertEquals(swagger.getDefinitions().get("indicatorType").getProperties().size(),1);
-    }
+	public void testIssue1143() {
+		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue1143.json", null, true);
+		assertNotNull(result.getSwagger().getDefinitions().get("RedisResource"));
+		assertNotNull(result.getSwagger().getDefinitions().get("identificacion_usuario_aplicacion"));
+	}
+
+	@Test
+	public void testIssue1204() {
+		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue1204.yaml", null, true);
+		System.out.println(result.getMessages());
+		assertTrue(result.getMessages().size() == 0);
+		assertNotNull(result.getSwagger());
+
+	}
+
+	@Test
+	public void testIssue1169() {
+		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue1169.yaml", null, true);
+		assertTrue(result.getMessages().size() == 0);
+		assertNotNull(result.getSwagger());
+	}
+
+	@Test
+	public void testIssueRelativeRefs2() {
+		String location = "exampleSpecs/specs/my-domain/test-api/v1/test-api-swagger_v1.json";
+		Swagger swagger = new SwaggerParser().read(location, null, true);
+		assertNotNull(swagger);
+		Map<String, Model> definitions = swagger.getDefinitions();
+		Assert.assertTrue(
+				definitions.get("confirmMessageType_v01").getProperties().get("resources") instanceof ArrayProperty);
+		ArrayProperty arraySchema = (ArrayProperty) definitions.get("confirmMessageType_v01").getProperties()
+				.get("resources");
+		ObjectProperty prop = (ObjectProperty) arraySchema.getItems();
+		RefProperty refProperty = (RefProperty) prop.getProperties().get("resourceID");
+		assertEquals(refProperty.get$ref(), "#/definitions/simpleIDType_v01");
+	}
+
+	@Test
+	public void testIssue111() {
+		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue-111.yaml", null, true);
+		assertTrue(result.getMessages().get(0).equals("attribute definitions.Filter.items is missing"));
+		assertNotNull(result.getSwagger());
+	}
+
+	@Test
+	public void testIssue1146() {
+		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("issue-1146.yaml", null, true);
+		assertEquals(0, result.getMessages().size());
+	}
+
+	@Test
+	public void testIssueDefinitionWithDots_2() {
+		Swagger swagger = new SwaggerParser().read("SimpleAPI.yaml");
+		assertNotNull(swagger);
+	}
+
+	@Test
+	public void testIssueDefinitionWithDots() {
+		Swagger swagger = new SwaggerParser().read("API-Service-2.0.0-swagger.yaml");
+		assertNotNull(swagger);
+	}
+
+	@Test
+	public void testIssue995() {
+		Swagger swagger = new SwaggerParser().read("issue-995/digitalExp-Product-Unresolved.yaml");
+		assertNotNull(swagger);
+		assertTrue(swagger.getDefinitions().size() == 6);
+		assertNotNull(swagger.getDefinitions().get("MobileProduct"));
+		assertNotNull(swagger.getDefinitions().get("FixedVoiceProduct"));
+		assertNotNull(swagger.getDefinitions().get("InternetProduct"));
+	}
+
+	@Test
+	public void testIssue927() {
+		Swagger swagger = new SwaggerParser().read("issue-927/issue-927.yaml");
+		assertNotNull(swagger);
+		assertTrue(swagger.getDefinitions().size() == 3);
+		assertNotNull(swagger.getDefinitions().get("Pet"));
+		assertNotNull(swagger.getDefinitions().get("Cat"));
+		assertNotNull(swagger.getDefinitions().get("Dog"));
+	}
+
+	@Test
+	public void testIssue901_2() {
+		Swagger swagger = new SwaggerParser().read("issue-901/spec2.yaml");
+		assertNotNull(swagger);
+		assertNotNull(swagger.getDefinitions());
+		ArrayProperty arraySchema = (ArrayProperty) swagger.getDefinitions().get("Test.Definition").getProperties()
+				.get("stuff");
+		String internalRef = ((RefProperty) arraySchema.getItems()).get$ref();
+		assertEquals(internalRef, "#/definitions/TEST.THING.OUT.Stuff");
+	}
+
+	@Test
+	public void testIssue901() {
+		Swagger swagger = new SwaggerParser().read("issue-901/spec.yaml");
+		assertNotNull(swagger);
+		String internalRef = ((RefModel) swagger.getPaths().get("/test").getPut().getResponses().get("200")
+				.getResponseSchema()).get$ref();
+		assertEquals(internalRef, "#/definitions/Test.Definition");
+		assertNotNull(swagger.getDefinitions());
+
+	}
+
+	@Test
+	public void testIssue435() {
+		Swagger swagger = new SwaggerParser().read("issue-435/main.yaml");
+		assertNotNull(swagger.getDefinitions().get("sub"));
+		assertNotNull(swagger.getDefinitions().get("subsub"));
+	}
+
+	@Test
+	public void testIssue845() {
+		SwaggerDeserializationResult swaggerDeserializationResult = new SwaggerParser().readWithInfo("");
+		assertEquals(swaggerDeserializationResult.getMessages().get(0), "empty or null swagger supplied");
+	}
+
+	@Test
+	public void testIssue834() {
+		Swagger swagger = new SwaggerParser().read("issue-834/index.yaml", null, true);
+		assertNotNull(swagger);
+
+		Response foo200 = swagger.getPaths().get("/foo").getGet().getResponses().get("200");
+		assertNotNull(foo200);
+		RefModel model200 = (RefModel) foo200.getResponseSchema();
+		String foo200SchemaRef = model200.get$ref();
+		assertEquals(foo200SchemaRef, "#/definitions/schema");
+
+		Response foo300 = swagger.getPaths().get("/foo").getGet().getResponses().get("300");
+		assertNotNull(foo300);
+		RefModel model300 = (RefModel) foo300.getResponseSchema();
+		String foo300SchemaRef = model300.get$ref();
+		assertEquals(foo300SchemaRef, "#/definitions/schema");
+
+		Response bar200 = swagger.getPaths().get("/bar").getGet().getResponses().get("200");
+		assertNotNull(bar200);
+		RefModel modelBar200 = (RefModel) bar200.getResponseSchema();
+		String bar200SchemaRef = modelBar200.get$ref();
+		assertEquals(bar200SchemaRef, "#/definitions/schema");
+	}
+
+	@Test
+	public void testIssue811_RefSchema_ToRefSchema() {
+		final Swagger swagger = new SwaggerParser().read("oapi-reference-test2/index.yaml", null, true);
+		Assert.assertNotNull(swagger);
+		RefModel model = (RefModel) swagger.getPaths().get("/").getGet().getResponses().get("200").getResponseSchema();
+		Assert.assertEquals(model.get$ref(), "#/definitions/schema-with-reference");
+	}
+
+	@Test
+	public void testIssue811() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/oapi-reference-test/index.yaml");
+		Assert.assertNotNull(swagger);
+		assertTrue(
+				swagger.getPaths().get("/").getGet().getResponses().get("200").getResponseSchema() instanceof RefModel);
+		RefModel model = (RefModel) swagger.getPaths().get("/").getGet().getResponses().get("200").getResponseSchema();
+		Assert.assertEquals(model.get$ref(), "#/definitions/schema-with-reference");
+
+	}
+
+	@Test
+	public void testIssue727() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/issue-714/serviceA.yaml");
+		Assert.assertNotNull(swagger);
+		assertNotNull(swagger.getPaths().get("/test").getGet().getParameters().get(0));
+		assertTrue(swagger.getDefinitions().size() == 1);
+		assertNotNull(swagger.getDefinitions().get("refA"));
+	}
+
+	@Test
+	public void testIssue704() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/sample/swagger.json");
+		Assert.assertNotNull(swagger);
+
+		assertNotNull(swagger.getPaths().get("/api/Address").getGet());
+		assertTrue(swagger.getDefinitions().size() == 1);
+		assertNotNull(swagger.getDefinitions().get("AddressEx"));
+	}
+
+	@Test
+	public void testIssue697() throws Exception {
+		String yaml = "{\n" + "    \"swagger\": \"2.0\",\n" + "    \"info\": {\n" + "        \"version\": \"1.0\",\n"
+				+ "        \"title\": \"x-example\"\n" + "    },\n" + "    \"host\": \"httpbin.org\",\n"
+				+ "    \"basePath\": \"/anything\",\n" + "    \"schemes\": [\n" + "        \"http\"\n" + "    ],\n"
+				+ "    \"paths\": {\n" + "        \"/{foo}\": {\n" + "            \"get\": {\n"
+				+ "                \"responses\": {\n" + "                    \"200\": {\n"
+				+ "                        \"description\": \"OK\"\n" + "                    }\n"
+				+ "                },\n" + "                \"deprecated\": false\n" + "            }\n" + "        }\n"
+				+ "    }\n" + "}";
+
+		SwaggerParser parser = new SwaggerParser();
+
+		Swagger swagger = parser.parse(yaml);
+		assertFalse(swagger.getPaths().get("/{foo}").getGet().isDeprecated());
+
+	}
+
+	@Test
+	public void testNPEIssue684() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/issue-684.json");
+		Assert.assertNotNull(swagger);
+		assertTrue(swagger.getParameters().get("ParamDef3") instanceof RefParameter);
+	}
+
+	@Test
+	public void testRefPaths() throws Exception {
+		String yaml = "swagger: '2.0'\n" + "info:\n" + "  version: 0.0.0\n" + "  title: Path item $ref test\n"
+				+ "paths:\n" + "  /foo:\n" + "    get:\n" + "      responses:\n" + "        200:\n"
+				+ "          description: OK\n" + "  /foo2:\n" + "    $ref: '#/paths/~1foo'";
+
+		SwaggerParser parser = new SwaggerParser();
+
+		Swagger swagger = parser.parse(yaml);
+
+		assertEquals(swagger.getPaths().get("foo"), swagger.getPaths().get("foo2"));
+
+	}
+
+	@Test
+	public void testModelParameters() throws Exception {
+		String yaml = "swagger: '2.0'\n" + "info:\n" + "  version: \"0.0.0\"\n" + "  title: test\n" + "paths:\n"
+				+ "  /foo:\n" + "    get:\n" + "      parameters:\n" + "      - name: amount\n" + "        in: body\n"
+				+ "        schema:\n" + "          type: integer\n" + "          format: int64\n"
+				+ "          description: amount of money\n" + "          default: 1000\n"
+				+ "          maximum: 100000\n" + "      responses:\n" + "        200:\n" + "          description: ok";
+
+		SwaggerParser parser = new SwaggerParser();
+
+		Swagger swagger = parser.parse(yaml);
+
+	}
+
+	@Test
+	public void testParseSharedPathParameters() throws Exception {
+		String yaml = "swagger: '2.0'\n" + "info:\n" + "  version: \"0.0.0\"\n" + "  title: test\n" + "paths:\n"
+				+ "  /persons/{id}:\n" + "    parameters:\n" + "      - in: path\n" + "        name: id\n"
+				+ "        type: string\n" + "        required: true\n" + "        description: \"no\"\n" + "    get:\n"
+				+ "      parameters:\n" + "        - name: id\n" + "          in: path\n" + "          required: true\n"
+				+ "          type: string\n" + "          description: \"yes\"\n" + "        - name: name\n"
+				+ "          in: query\n" + "          type: string\n" + "      responses:\n" + "        200:\n"
+				+ "          description: ok\n";
+
+		SwaggerParser parser = new SwaggerParser();
+
+		Swagger swagger = parser.parse(yaml);
+		List<Parameter> parameters = swagger.getPath("/persons/{id}").getGet().getParameters();
+		assertTrue(parameters.size() == 2);
+		Parameter id = parameters.get(0);
+		assertEquals(id.getDescription(), "yes");
+	}
+
+	@Test
+	public void testParseRefPathParameters() throws Exception {
+		String yaml = "swagger: '2.0'\n" + "info:\n" + "  title: test\n" + "  version: '0.0.0'\n" + "parameters:\n"
+				+ "  report-id:\n" + "    name: id\n" + "    in: path\n" + "    type: string\n" + "    required: true\n"
+				+ "paths:\n" + "  /reports/{id}:\n" + "    parameters:\n" + "        - $ref: '#/parameters/report-id'\n"
+				+ "    put:\n" + "      parameters:\n" + "        - name: id\n" + "          in: body\n"
+				+ "          required: true\n" + "          schema:\n" + "            $ref: '#/definitions/report'\n"
+				+ "      responses:\n" + "        200:\n" + "          description: ok\n" + "definitions:\n"
+				+ "  report:\n" + "    type: object\n" + "    properties:\n" + "      id:\n" + "        type: string\n"
+				+ "      name:\n" + "        type: string\n" + "    required:\n" + "    - id\n" + "    - name\n";
+		SwaggerParser parser = new SwaggerParser();
+		Swagger swagger = parser.parse(yaml);
+	}
+
+	@Test
+	public void testUniqueParameters() throws Exception {
+		String yaml = "swagger: '2.0'\n" + "info:\n" + "  title: test\n" + "  version: '0.0.0'\n" + "parameters:\n"
+				+ "  foo-id:\n" + "    name: id\n" + "    in: path\n" + "    type: string\n" + "    required: true\n"
+				+ "paths:\n" + "  /foos/{id}:\n" + "    parameters:\n" + "        - $ref: '#/parameters/foo-id'\n"
+				+ "    get:\n" + "      responses:\n" + "        200:\n" + "          schema:\n"
+				+ "            $ref: '#/definitions/foo'\n" + "    put:\n" + "      parameters:\n"
+				+ "        - name: foo\n" + "          in: body\n" + "          required: true\n"
+				+ "          schema:\n" + "            $ref: '#/definitions/foo'\n" + "      responses:\n"
+				+ "        200:\n" + "          schema:\n" + "            $ref: '#/definitions/foo'\n"
+				+ "definitions:\n" + "  foo:\n" + "    type: object\n" + "    properties:\n" + "      id:\n"
+				+ "        type: string\n" + "    required:\n" + "      - id\n";
+		SwaggerParser parser = new SwaggerParser();
+		Swagger swagger = parser.parse(yaml);
+		List<Parameter> parameters = swagger.getPath("/foos/{id}").getPut().getParameters();
+		assertTrue(parameters.size() == 2);
+	}
+
+	@Test
+	public void testLoadRelativeFileTree_Json() throws Exception {
+		final Swagger swagger = doRelativeFileTest("src/test/resources/relative-file-references/json/parent.json");
+		// Json.mapper().writerWithDefaultPrettyPrinter().writeValue(new
+		// File("resolved.json"), swagger);
+	}
+
+	@Test
+	public void testPetstore() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		SwaggerDeserializationResult result = parser.readWithInfo("src/test/resources/petstore.json", null, true);
+
+		assertNotNull(result);
+		assertTrue(result.getMessages().isEmpty());
+
+		Swagger swagger = result.getSwagger();
+		Map<String, Model> definitions = swagger.getDefinitions();
+		Set<String> expectedDefinitions = new HashSet<String>();
+		expectedDefinitions.add("User");
+		expectedDefinitions.add("Category");
+		expectedDefinitions.add("Pet");
+		expectedDefinitions.add("Tag");
+		expectedDefinitions.add("Order");
+		expectedDefinitions.add("PetArray");
+		assertEquals(definitions.keySet(), expectedDefinitions);
+
+		Model petModel = definitions.get("Pet");
+		Set<String> expectedPetProps = new HashSet<String>();
+		expectedPetProps.add("id");
+		expectedPetProps.add("category");
+		expectedPetProps.add("name");
+		expectedPetProps.add("photoUrls");
+		expectedPetProps.add("tags");
+		expectedPetProps.add("status");
+		assertEquals(petModel.getProperties().keySet(), expectedPetProps);
+
+		ArrayModel petArrayModel = (ArrayModel) definitions.get("PetArray");
+		assertEquals(petArrayModel.getType(), "array");
+		RefProperty refProp = (RefProperty) petArrayModel.getItems();
+		assertEquals(refProp.get$ref(), "#/definitions/Pet");
+		assertNull(petArrayModel.getProperties());
+	}
+
+	@Test
+	public void testFileReferenceWithVendorExt() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/file-reference-with-vendor-ext/b.yaml");
+		Map<String, Model> definitions = swagger.getDefinitions();
+		assertTrue(definitions.get("z").getVendorExtensions().get("x-foo") instanceof Map);
+		assertEquals(((Map) definitions.get("z").getVendorExtensions().get("x-foo")).get("bar"), "baz");
+		assertTrue(definitions.get("x").getVendorExtensions().get("x-foo") instanceof Map);
+		assertEquals(((Map) definitions.get("x").getVendorExtensions().get("x-foo")).get("bar"), "baz");
+	}
+
+	@Test
+	public void testTroublesomeFile() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/troublesome.yaml");
+	}
+
+	@Test
+	public void testLoadRelativeFileTree_Yaml() throws Exception {
+		JsonToYamlFileDuplicator.duplicateFilesInYamlFormat("src/test/resources/relative-file-references/json",
+				"src/test/resources/relative-file-references/yaml");
+		final Swagger swagger = doRelativeFileTest("src/test/resources/relative-file-references/yaml/parent.yaml");
+		assertNotNull(Yaml.mapper().writeValueAsString(swagger));
+		assertTrue(swagger.getParameters().get("param2") instanceof HeaderParameter);
+	}
+
+	@Test
+	public void testLoadnestedExternalResponseReferencesFile_Yaml() throws Exception {
+		final Swagger swagger = doRelativeResponseFileTest(
+				"src/test/resources/nested-external-response-references/swagger-root.yaml");
+		assertNotNull(Yaml.mapper().writeValueAsString(swagger));
+	}
+
+	@Test
+	public void testLoadRecursiveExternalDef() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/file-reference-to-recursive-defs/b.yaml");
+
+		Map<String, Model> definitions = swagger.getDefinitions();
+		assertEquals(((RefProperty) ((ArrayProperty) definitions.get("v").getProperties().get("children")).getItems())
+				.get$ref(), "#/definitions/v");
+		assertTrue(definitions.containsKey("y"));
+		assertEquals(((RefProperty) ((ArrayProperty) definitions.get("x").getProperties().get("children")).getItems())
+				.get$ref(), "#/definitions/y");
+	}
+
+	@Test
+	public void testLoadNestedItemsReferences() {
+		SwaggerParser parser = new SwaggerParser();
+		SwaggerDeserializationResult result = parser.readWithInfo("src/test/resources/nested-items-references/b.yaml",
+				null, true);
+		Swagger swagger = result.getSwagger();
+		Map<String, Model> definitions = swagger.getDefinitions();
+		assertTrue(definitions.containsKey("z"));
+		assertTrue(definitions.containsKey("w"));
+	}
+
+	@Test
+	public void testIssue75() {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/issue99.json");
+
+		BodyParameter param = (BodyParameter) swagger.getPaths().get("/albums").getPost().getParameters().get(0);
+		Model model = param.getSchema();
+
+		assertNotNull(model);
+		assertTrue(model instanceof ArrayModel);
+
+		ArrayModel am = (ArrayModel) model;
+		assertTrue(am.getItems() instanceof ByteArrayProperty);
+		assertEquals(am.getItems().getFormat(), "byte");
+	}
+
+	@Test(enabled = false, description = "see https://github.com/swagger-api/swagger-parser/issues/337")
+	public void testIssue62() {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read(
+				"https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/fixtures/v2.0/json/resources/resourceWithLinkedDefinitions.json");
+
+		assertNotNull(swagger.getPaths().get("/pets/{petId}").getGet());
+	}
+
+	@Test
+	public void testIssue146() {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/issue_146.yaml");
+		assertNotNull(swagger);
+		QueryParameter p = ((QueryParameter) swagger.getPaths().get("/checker").getGet().getParameters().get(0));
+		StringProperty pp = (StringProperty) p.getItems();
+		assertTrue("registration".equalsIgnoreCase(pp.getEnum().get(0)));
+	}
+
+	@Test(description = "Test (path & form) parameter's required attribute")
+	public void testParameterRequired() {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/petstore.json");
+		final List<Parameter> operationParams = swagger.getPath("/pet/{petId}").getPost().getParameters();
+
+		final PathParameter pathParameter = (PathParameter) operationParams.get(0);
+		Assert.assertTrue(pathParameter.getRequired());
+
+		final FormParameter formParameter = (FormParameter) operationParams.get(1);
+		Assert.assertFalse(formParameter.getRequired());
+	}
+
+	@Test(description = "Test consumes and produces in top level and operation level")
+	public void testConsumesAndProduces() {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/consumes_and_produces");
+		Assert.assertNotNull(swagger);
+
+		// test consumes and produces at spec level
+		Assert.assertEquals(swagger.getConsumes(), Arrays.asList("application/json"));
+		Assert.assertEquals(swagger.getProduces(), Arrays.asList("application/xml"));
+
+		// test consumes and produces at operation level
+		Assert.assertEquals(swagger.getPath("/pets").getPost().getConsumes(), Arrays.asList("image/jpeg"));
+		Assert.assertEquals(swagger.getPath("/pets").getPost().getProduces(), Arrays.asList("image/png"));
+
+		// test empty consumes and produces at operation level
+		Assert.assertEquals(swagger.getPath("/pets").getGet().getConsumes(), Collections.<String>emptyList());
+		Assert.assertEquals(swagger.getPath("/pets").getGet().getProduces(), Collections.<String>emptyList());
+
+		// test consumes and produces not defined at operation level
+		Assert.assertNull(swagger.getPath("/pets").getPatch().getConsumes());
+		Assert.assertNull(swagger.getPath("/pets").getPatch().getProduces());
+
+	}
+
+	@Test
+	public void testIssue108() {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/issue_108.json");
+
+		assertNotNull(swagger);
+	}
+
+	@Test
+	public void testIssue() {
+		String yaml = "swagger: '2.0'\n" + "info:\n" + "  description: 'No description provided.'\n"
+				+ "  version: '2.0'\n" + "  title: 'My web service'\n" + "  x-endpoint-name: 'default'\n" + "paths:\n"
+				+ "  x-nothing: 'sorry not supported'\n" + "  /foo:\n" + "    x-something: 'yes, it is supported'\n"
+				+ "    get:\n" + "      parameters: []\n" + "      responses:\n" + "        200:\n"
+				+ "          description: 'Swagger API document for this service'\n" + "x-some-vendor:\n"
+				+ "  sometesting: 'bye!'";
+		SwaggerParser parser = new SwaggerParser();
+		SwaggerDeserializationResult result = parser.readWithInfo(yaml);
+
+		Swagger swagger = result.getSwagger();
+
+		assertEquals(((Map) swagger.getVendorExtensions().get("x-some-vendor")).get("sometesting"), "bye!");
+		assertEquals(swagger.getPath("/foo").getVendorExtensions().get("x-something"), "yes, it is supported");
+		assertTrue(result.getMessages().size() == 1);
+		assertEquals(result.getMessages().get(0), "attribute paths.x-nothing is unsupported");
+	}
+
+	@Test
+	public void testIssue292WithNoCollectionFormat() {
+		String yaml = "swagger: '2.0'\n" + "info:\n" + "  version: '0.0.0'\n" + "  title: nada\n" + "paths:\n"
+				+ "  /persons:\n" + "    get:\n" + "      parameters:\n" + "      - name: testParam\n"
+				+ "        in: query\n" + "        type: array\n" + "        items:\n" + "          type: string\n"
+				+ "      responses:\n" + "        200:\n" + "          description: Successful response";
+		SwaggerParser parser = new SwaggerParser();
+		SwaggerDeserializationResult result = parser.readWithInfo(yaml);
+
+		Swagger swagger = result.getSwagger();
+
+		Parameter param = swagger.getPaths().get("/persons").getGet().getParameters().get(0);
+		QueryParameter qp = (QueryParameter) param;
+		assertNull(qp.getCollectionFormat());
+	}
+
+	@Test
+	public void testIssue292WithCSVCollectionFormat() {
+		String yaml = "swagger: '2.0'\n" + "info:\n" + "  version: '0.0.0'\n" + "  title: nada\n" + "paths:\n"
+				+ "  /persons:\n" + "    get:\n" + "      parameters:\n" + "      - name: testParam\n"
+				+ "        in: query\n" + "        type: array\n" + "        items:\n" + "          type: string\n"
+				+ "        collectionFormat: csv\n" + "      responses:\n" + "        200:\n"
+				+ "          description: Successful response";
+		SwaggerParser parser = new SwaggerParser();
+		SwaggerDeserializationResult result = parser.readWithInfo(yaml);
+
+		Swagger swagger = result.getSwagger();
+
+		Parameter param = swagger.getPaths().get("/persons").getGet().getParameters().get(0);
+		QueryParameter qp = (QueryParameter) param;
+		assertEquals(qp.getCollectionFormat(), "csv");
+	}
+
+	@Test
+	public void testIssue286() {
+		SwaggerParser parser = new SwaggerParser();
+
+		Swagger swagger = parser.read("issue_286.yaml");
+		Property response = swagger.getPath("/").getGet().getResponses().get("200").getSchema();
+		assertTrue(response instanceof RefProperty);
+		assertEquals(((RefProperty) response).getSimpleRef(), "issue_286_PetList");
+		assertNotNull(swagger.getDefinitions().get("issue_286_Allergy"));
+	}
+
+	@Test
+	public void testIssue286WithModel() {
+		SwaggerParser parser = new SwaggerParser();
+
+		Swagger swagger = parser.read("issue_286.yaml");
+		Model response = swagger.getPath("/").getGet().getResponses().get("200").getResponseSchema();
+		assertTrue(response instanceof RefModel);
+		assertEquals("issue_286_PetList", ((RefModel) response).getSimpleRef());
+		assertNotNull(swagger.getDefinitions().get("issue_286_Allergy"));
+	}
+
+	@Test
+	public void testIssue360() {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/issue_360.yaml");
+		assertNotNull(swagger);
+
+		Parameter parameter = swagger.getPath("/pets").getPost().getParameters().get(0);
+		assertNotNull(parameter);
+		assertTrue(parameter instanceof BodyParameter);
+
+		BodyParameter bp = (BodyParameter) parameter;
+
+		assertNotNull(bp.getSchema());
+		Model model = bp.getSchema();
+		assertTrue(model instanceof ModelImpl);
+
+		ModelImpl impl = (ModelImpl) model;
+		assertNotNull(impl.getProperties().get("foo"));
+
+		Map<String, Object> extensions = bp.getVendorExtensions();
+		assertNotNull(extensions);
+
+		assertNotNull(extensions.get("x-examples"));
+		Object o = extensions.get("x-examples");
+		assertTrue(o instanceof Map);
+
+		Map<String, Object> on = (Map<String, Object>) o;
+
+		Object jn = on.get("application/json");
+		assertTrue(jn instanceof Map);
+
+		Map<String, Object> objectNode = (Map<String, Object>) jn;
+		assertEquals(objectNode.get("foo"), "bar");
+
+		Parameter stringBodyParameter = swagger.getPath("/otherPets").getPost().getParameters().get(0);
+
+		assertTrue(stringBodyParameter instanceof BodyParameter);
+		BodyParameter sbp = (BodyParameter) stringBodyParameter;
+		assertTrue(sbp.getRequired());
+		assertEquals(sbp.getName(), "simple");
+
+		Model sbpModel = sbp.getSchema();
+		assertTrue(sbpModel instanceof ModelImpl);
+		ModelImpl sbpModelImpl = (ModelImpl) sbpModel;
+
+		assertEquals(sbpModelImpl.getType(), "string");
+		assertEquals(sbpModelImpl.getFormat(), "uuid");
+
+		Parameter refBodyParameter = swagger.getPath("/evenMorePets").getPost().getParameters().get(0);
+
+		assertTrue(refBodyParameter instanceof BodyParameter);
+		BodyParameter ref = (BodyParameter) refBodyParameter;
+		assertTrue(ref.getRequired());
+		assertEquals(ref.getName(), "simple");
+
+		Model refModel = ref.getSchema();
+		assertTrue(refModel instanceof RefModel);
+		RefModel refModelImpl = (RefModel) refModel;
+
+		assertEquals(refModelImpl.getSimpleRef(), "Pet");
+	}
+
+	private Swagger doRelativeFileTest(String location) {
+		SwaggerParser parser = new SwaggerParser();
+		SwaggerDeserializationResult readResult = parser.readWithInfo(location, null, true);
+		if (readResult.getMessages().size() > 0) {
+			Json.prettyPrint(readResult.getMessages());
+		}
+		final Swagger swagger = readResult.getSwagger();
+
+		final Path path = swagger.getPath("/health");
+		assertEquals(path.getClass(), Path.class); // we successfully converted the RefPath to a Path
+
+		final List<Parameter> parameters = path.getParameters();
+		assertParamDetails(parameters, 0, QueryParameter.class, "param1", "query");
+		assertParamDetails(parameters, 1, HeaderParameter.class, "param2", "header");
+
+		final Operation operation = path.getGet();
+		final List<Parameter> operationParams = operation.getParameters();
+		assertParamDetails(operationParams, 0, PathParameter.class, "param3", "path");
+		assertParamDetails(operationParams, 1, HeaderParameter.class, "param4", "header");
+		assertParamDetails(operationParams, 2, BodyParameter.class, "body", "body");
+		final BodyParameter bodyParameter = (BodyParameter) operationParams.get(2);
+		assertEquals(((RefModel) bodyParameter.getSchema()).get$ref(), "#/definitions/health");
+
+		final Map<String, Response> responsesMap = operation.getResponses();
+
+		assertResponse(swagger, responsesMap, "200", "Health information from the server", "#/definitions/health");
+		assertResponse(swagger, responsesMap, "400", "Your request was not valid", "#/definitions/error");
+		assertResponse(swagger, responsesMap, "500", "An unexpected error occur during processing",
+				"#/definitions/error");
+
+		final Map<String, Model> definitions = swagger.getDefinitions();
+		final ModelImpl refInDefinitions = (ModelImpl) definitions.get("refInDefinitions");
+		assertEquals(refInDefinitions.getDescription(), "The example model");
+		expectedPropertiesInModel(refInDefinitions, "foo", "bar");
+
+		final ArrayModel arrayModel = (ArrayModel) definitions.get("arrayModel");
+		final RefProperty arrayModelItems = (RefProperty) arrayModel.getItems();
+		assertEquals(arrayModelItems.get$ref(), "#/definitions/foo");
+
+		final ModelImpl fooModel = (ModelImpl) definitions.get("foo");
+		assertEquals(fooModel.getDescription(), "Just another model");
+		expectedPropertiesInModel(fooModel, "hello", "world");
+
+		final ComposedModel composedCat = (ComposedModel) definitions.get("composedCat");
+		final ModelImpl child = (ModelImpl) composedCat.getChild();
+		expectedPropertiesInModel(child, "huntingSkill", "prop2", "reflexes", "reflexMap");
+		final ArrayProperty reflexes = (ArrayProperty) child.getProperties().get("reflexes");
+		final RefProperty reflexItems = (RefProperty) reflexes.getItems();
+		assertEquals(reflexItems.get$ref(), "#/definitions/reflex");
+		assertTrue(definitions.containsKey(reflexItems.getSimpleRef()));
+
+		final MapProperty reflexMap = (MapProperty) child.getProperties().get("reflexMap");
+		final RefProperty reflexMapAdditionalProperties = (RefProperty) reflexMap.getAdditionalProperties();
+		assertEquals(reflexMapAdditionalProperties.get$ref(), "#/definitions/reflex");
+
+		assertEquals(composedCat.getInterfaces().size(), 2);
+		assertEquals(composedCat.getInterfaces().get(0).get$ref(), "#/definitions/pet");
+		assertEquals(composedCat.getInterfaces().get(1).get$ref(), "#/definitions/foo_2");
+
+		return swagger;
+	}
+
+	private Swagger doRelativeResponseFileTest(String location) {
+		SwaggerParser parser = new SwaggerParser();
+		SwaggerDeserializationResult readResult = parser.readWithInfo(location, null, true);
+
+		if (readResult.getMessages().size() > 0) {
+			Json.prettyPrint(readResult.getMessages());
+		}
+		final Swagger swagger = readResult.getSwagger();
+
+		Json.prettyPrint(swagger);
+
+		final Path path = swagger.getPath("/users");
+		assertEquals(path.getClass(), Path.class); // we successfully converted the RefPath to a Path
+
+		final Operation operation = path.getGet();
+
+		final Map<String, Response> responsesMap = operation.getResponses();
+
+		assertResponse(swagger, responsesMap, "200", "OK", "#/definitions/User");
+
+		final Map<String, Model> definitions = swagger.getDefinitions();
+		final ModelImpl refInDefinitions = (ModelImpl) definitions.get("UserX");
+		expectedPropertiesInModel(refInDefinitions, "address");
+
+		final ModelImpl refInDefinitionsAddress = (ModelImpl) definitions.get("Address");
+		expectedPropertiesInModel(refInDefinitionsAddress, "postal", "country");
+
+		final ModelImpl refInDefinitionsCountry = (ModelImpl) definitions.get("Country");
+		expectedPropertiesInModel(refInDefinitionsCountry, "name");
+
+		final ModelImpl refInDefinitionsAddress_2 = (ModelImpl) definitions.get("Address_2");
+		expectedPropertiesInModel(refInDefinitionsAddress_2, "postal", "country");
+
+		final ModelImpl refInDefinitionsCountry_2 = (ModelImpl) definitions.get("Country_2");
+		expectedPropertiesInModel(refInDefinitionsCountry_2, "name");
+
+		return swagger;
+	}
+
+	private void expectedPropertiesInModel(ModelImpl model, String... expectedProperties) {
+		assertEquals(model.getProperties().size(), expectedProperties.length);
+		for (String expectedProperty : expectedProperties) {
+			assertTrue(model.getProperties().containsKey(expectedProperty));
+		}
+	}
+
+	private void assertResponse(Swagger swagger, Map<String, Response> responsesMap, String responseCode,
+			String expectedDescription, String expectedSchemaRef) {
+		final Response response = responsesMap.get(responseCode);
+		final RefProperty schema = (RefProperty) response.getSchema();
+		assertEquals(response.getDescription(), expectedDescription);
+		assertEquals(schema.getClass(), RefProperty.class);
+		assertEquals(schema.get$ref(), expectedSchemaRef);
+		assertTrue(swagger.getDefinitions().containsKey(schema.getSimpleRef()));
+	}
+
+	private void assertParamDetails(List<Parameter> parameters, int index, Class<?> expectedType, String expectedName,
+			String expectedIn) {
+		final Parameter param1 = parameters.get(index);
+		assertEquals(param1.getClass(), expectedType);
+		assertEquals(param1.getName(), expectedName);
+		assertEquals(param1.getIn(), expectedIn);
+	}
+
+	@Test
+	public void testNestedReferences() {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/relative-file-references/json/parent.json");
+		assertTrue(swagger.getDefinitions().containsKey("externalArray"));
+		assertTrue(swagger.getDefinitions().containsKey("referencedByLocalArray"));
+		assertTrue(swagger.getDefinitions().containsKey("externalObject"));
+		assertTrue(swagger.getDefinitions().containsKey("referencedByLocalElement"));
+		assertTrue(swagger.getDefinitions().containsKey("referencedBy"));
+		assertEquals(
+				((RefProperty) swagger.getDefinitions().get("externalObject").getProperties().get("hello1")).get$ref(),
+				"#/definitions/referencedByLocalElement"); // issue #434
+	}
+
+	@Test
+	public void testCodegenPetstore() {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/petstore-codegen.yaml");
+		ModelImpl enumModel = (ModelImpl) swagger.getDefinitions().get("Enum_Test");
+		assertNotNull(enumModel);
+		Property enumProperty = enumModel.getProperties().get("enum_integer");
+		assertNotNull(enumProperty);
+
+		assertTrue(enumProperty instanceof IntegerProperty);
+		IntegerProperty enumIntegerProperty = (IntegerProperty) enumProperty;
+		List<Integer> integers = enumIntegerProperty.getEnum();
+		assertEquals(integers.get(0), new Integer(1));
+		assertEquals(integers.get(1), new Integer(-1));
+
+		Operation getOrderOperation = swagger.getPath("/store/order/{orderId}").getGet();
+		assertNotNull(getOrderOperation);
+		Parameter orderId = getOrderOperation.getParameters().get(0);
+		assertTrue(orderId instanceof PathParameter);
+		PathParameter orderIdPathParam = (PathParameter) orderId;
+		assertNotNull(orderIdPathParam.getMinimum());
+
+		BigDecimal minimum = orderIdPathParam.getMinimum();
+		assertEquals(minimum.toString(), "1");
+
+		FormParameter formParam = (FormParameter) swagger.getPath("/fake").getPost().getParameters().get(3);
+
+		assertEquals(formParam.getMinimum().toString(), "32.1");
+	}
+
+	@Test
+	public void testIssue339() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/issue-339.json");
+
+		Parameter param = swagger.getPath("/store/order/{orderId}").getGet().getParameters().get(0);
+		assertTrue(param instanceof PathParameter);
+		PathParameter pp = (PathParameter) param;
+
+		assertTrue(pp.getMinimum().toString().equals("1"));
+		assertTrue(pp.getMaximum().toString().equals("5"));
+	}
+
+	@Test
+	public void testCodegenIssue4555() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		String yaml = "swagger: '2.0'\n" + "\n" + "info:\n" + "  title: test\n" + "  version: \"0.0.1\"\n" + "\n"
+				+ "schemes:\n" + "  - http\n" + "produces:\n" + "  - application/json\n" + "\n" + "paths:\n"
+				+ "  /contents/{id}:\n" + "    parameters:\n" + "      - name: id\n" + "        in: path\n"
+				+ "        description: test\n" + "        required: true\n" + "        type: integer\n" + "\n"
+				+ "    get:\n" + "      description: test\n" + "      responses:\n" + "        200:\n"
+				+ "          description: OK\n" + "          schema:\n" + "            $ref: '#/definitions/Content'\n"
+				+ "\n" + "definitions:\n" + "  Content:\n" + "    type: object\n" + "    title: \t\ttest";
+		final SwaggerDeserializationResult result = parser.readWithInfo(yaml);
+
+		// can't parse with tabs!
+		assertNull(result.getSwagger());
+	}
+
+	@Test
+	public void testConverterIssue17() throws Exception {
+		String yaml = "swagger: '2.0'\n" + "info:\n" + "  version: '0.0.0'\n" + "  title: nada\n" + "paths:\n"
+				+ "  /persons:\n" + "    get:\n" + "      parameters:\n" + "      - name: testParam\n"
+				+ "        in: query\n" + "        type: array\n" + "        items:\n" + "          type: string\n"
+				+ "        collectionFormat: csv\n" + "      responses:\n" + "        200:\n"
+				+ "          description: Successful response\n" + "          schema:\n"
+				+ "            $ref: '#/definitions/Content'\n" + "definitions:\n" + "  Content:\n"
+				+ "    type: object";
+		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml, Boolean.FALSE);
+
+		assertNotNull(result.getSwagger());
+		assertEquals(((RefProperty) result.getSwagger().getPaths().get("/persons").getGet().getResponses().get("200")
+				.getSchema()).get$ref(), "#/definitions/Content");
+	}
+
+	@Test
+	public void testIssue393() {
+		SwaggerParser parser = new SwaggerParser();
+
+		String yaml = "swagger: '2.0'\n" + "info:\n" + "  title: x\n" + "  version: 1.0.0\n" + "paths:\n" + "  /test:\n"
+				+ "    get:\n" + "      parameters: []\n" + "      responses:\n" + "        '400':\n"
+				+ "          description: |\n"
+				+ "            The account could not be created because a credential didn't meet the complexity requirements.\n"
+				+ "          x-error-refs:\n" + "            - '$ref': '#/x-error-defs/credentialTooShort'\n"
+				+ "            - '$ref': '#/x-error-defs/credentialTooLong'\n" + "x-error-defs:\n"
+				+ "  credentialTooShort:\n" + "    errorID: credentialTooShort";
+		final SwaggerDeserializationResult result = parser.readWithInfo(yaml);
+
+		assertNotNull(result.getSwagger());
+		Swagger swagger = result.getSwagger();
+
+		assertNotNull(swagger.getVendorExtensions().get("x-error-defs"));
+	}
+
+	@Test
+	public void testBadFormat() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/bad_format.yaml");
+
+		Path path = swagger.getPath("/pets");
+
+		Parameter parameter = path.getGet().getParameters().get(0);
+		assertNotNull(parameter);
+		assertTrue(parameter instanceof QueryParameter);
+		QueryParameter queryParameter = (QueryParameter) parameter;
+		assertEquals(queryParameter.getName(), "query-param-int32");
+		assertNotNull(queryParameter.getEnum());
+		assertEquals(queryParameter.getEnum().size(), 3);
+		List<Object> enumValues = queryParameter.getEnumValue();
+		assertEquals(enumValues.get(0), 1);
+		assertEquals(enumValues.get(1), 2);
+		assertEquals(enumValues.get(2), 7);
+
+		parameter = path.getGet().getParameters().get(1);
+		assertNotNull(parameter);
+		assertTrue(parameter instanceof QueryParameter);
+		queryParameter = (QueryParameter) parameter;
+		assertEquals(queryParameter.getName(), "query-param-invalid-format");
+		assertNotNull(queryParameter.getEnum());
+		assertEquals(queryParameter.getEnum().size(), 3);
+		enumValues = queryParameter.getEnumValue();
+		assertEquals(enumValues.get(0), 1);
+		assertEquals(enumValues.get(1), 2);
+		assertEquals(enumValues.get(2), 7);
+
+		parameter = path.getGet().getParameters().get(2);
+		assertNotNull(parameter);
+		assertTrue(parameter instanceof QueryParameter);
+		queryParameter = (QueryParameter) parameter;
+		assertEquals(queryParameter.getName(), "query-param-collection-format-and-uniqueItems");
+		assertEquals(queryParameter.getCollectionFormat(), "multi");
+		assertEquals(queryParameter.isUniqueItems(), true);
+	}
+
+	@Test
+	public void testNumberAttributes() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		Swagger swagger = parser.read(TestUtils.getResourceAbsolutePath("/number_attributes.yaml"));
+
+		ModelImpl numberType = (ModelImpl) swagger.getDefinitions().get("NumberType");
+		assertNotNull(numberType);
+		assertNotNull(numberType.getEnum());
+		assertEquals(numberType.getEnum().size(), 2);
+		List<String> numberTypeEnumValues = numberType.getEnum();
+		assertEquals(numberTypeEnumValues.get(0), "1.0");
+		assertEquals(numberTypeEnumValues.get(1), "2.0");
+		assertEquals(numberType.getDefaultValue(), new BigDecimal("1.0"));
+		assertEquals(numberType.getMinimum(), new BigDecimal("1.0"));
+		assertEquals(numberType.getMaximum(), new BigDecimal("2.0"));
+
+		ModelImpl numberDoubleType = (ModelImpl) swagger.getDefinitions().get("NumberDoubleType");
+		assertNotNull(numberDoubleType);
+		assertNotNull(numberDoubleType.getEnum());
+		assertEquals(numberDoubleType.getEnum().size(), 2);
+		List<String> numberDoubleTypeEnumValues = numberDoubleType.getEnum();
+		assertEquals(numberDoubleTypeEnumValues.get(0), "1.0");
+		assertEquals(numberDoubleTypeEnumValues.get(1), "2.0");
+		assertEquals(numberDoubleType.getDefaultValue(), new BigDecimal("1.0"));
+		assertEquals(numberDoubleType.getMinimum(), new BigDecimal("1.0"));
+		assertEquals(numberDoubleType.getMaximum(), new BigDecimal("2.0"));
+
+		ModelImpl integerType = (ModelImpl) swagger.getDefinitions().get("IntegerType");
+		assertNotNull(integerType);
+		assertNotNull(integerType.getEnum());
+		assertEquals(integerType.getEnum().size(), 2);
+		List<String> integerTypeEnumValues = integerType.getEnum();
+		assertEquals(integerTypeEnumValues.get(0), "1");
+		assertEquals(integerTypeEnumValues.get(1), "2");
+		assertEquals(integerType.getDefaultValue(), new Integer("1"));
+		assertEquals(integerType.getMinimum(), new BigDecimal("1"));
+		assertEquals(integerType.getMaximum(), new BigDecimal("2"));
+
+		ModelImpl integerInt32Type = (ModelImpl) swagger.getDefinitions().get("IntegerInt32Type");
+		assertNotNull(integerInt32Type);
+		assertNotNull(integerInt32Type.getEnum());
+		assertEquals(integerInt32Type.getEnum().size(), 2);
+		List<String> integerInt32TypeEnumValues = integerInt32Type.getEnum();
+		assertEquals(integerInt32TypeEnumValues.get(0), "1");
+		assertEquals(integerInt32TypeEnumValues.get(1), "2");
+		assertEquals(integerInt32Type.getDefaultValue(), new Integer("1"));
+		assertEquals(integerInt32Type.getMinimum(), new BigDecimal("1"));
+		assertEquals(integerInt32Type.getMaximum(), new BigDecimal("2"));
+
+	}
+
+	@Test
+	public void testDefinitionExample() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read(TestUtils.getResourceAbsolutePath("/definition_example.yaml"));
+
+		ModelImpl model;
+		ArrayModel arrayModel;
+
+		model = (ModelImpl) swagger.getDefinitions().get("NumberType");
+		assertEquals((Double) model.getExample(), 2.0d, 0d);
+
+		model = (ModelImpl) swagger.getDefinitions().get("IntegerType");
+		assertEquals((int) model.getExample(), 2);
+
+		model = (ModelImpl) swagger.getDefinitions().get("StringType");
+		assertEquals((String) model.getExample(), "2");
+
+		model = (ModelImpl) swagger.getDefinitions().get("ObjectType");
+		assertTrue(model.getExample() instanceof Map);
+		Map objectExample = (Map) model.getExample();
+		assertEquals((String) objectExample.get("propertyA"), "valueA");
+		assertEquals((Integer) objectExample.get("propertyB"), new Integer(123));
+
+		arrayModel = (ArrayModel) swagger.getDefinitions().get("ArrayType");
+		assertTrue(arrayModel.getExample() instanceof List);
+		List<Map> arrayExample = (List<Map>) arrayModel.getExample();
+		assertEquals((String) arrayExample.get(0).get("propertyA"), "valueA1");
+		assertEquals((Integer) arrayExample.get(0).get("propertyB"), new Integer(123));
+		assertEquals((String) arrayExample.get(1).get("propertyA"), "valueA2");
+		assertEquals((Integer) arrayExample.get(1).get("propertyB"), new Integer(456));
+
+		model = (ModelImpl) swagger.getDefinitions().get("NumberTypeStringExample");
+		assertEquals((String) model.getExample(), "2.0");
+
+		model = (ModelImpl) swagger.getDefinitions().get("IntegerTypeStringExample");
+		assertEquals((String) model.getExample(), "2");
+
+		model = (ModelImpl) swagger.getDefinitions().get("StringTypeStringExample");
+		assertEquals((String) model.getExample(), "2");
+
+		model = (ModelImpl) swagger.getDefinitions().get("ObjectTypeStringExample");
+		assertEquals((String) model.getExample(), "{\"propertyA\": \"valueA\", \"propertyB\": 123}");
+
+		arrayModel = (ArrayModel) swagger.getDefinitions().get("ArrayTypeStringExample");
+		assertEquals((String) arrayModel.getExample(),
+				"[{\"propertyA\": \"valueA1\", \"propertyB\": 123}, {\"propertyA\": \"valueA2\", \"propertyB\": 456}]");
+	}
+
+	@Test
+	public void testIssue357() {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/issue_357.yaml");
+		assertNotNull(swagger);
+		List<Parameter> getParams = swagger.getPath("/testApi").getGet().getParameters();
+		assertEquals(2, getParams.size());
+		for (Parameter param : getParams) {
+			SerializableParameter sp = (SerializableParameter) param;
+			switch (param.getName()) {
+			case "pathParam1":
+				assertEquals(sp.getType(), "integer");
+				break;
+			case "pathParam2":
+				assertEquals(sp.getType(), "string");
+				break;
+			default:
+				fail("Unexpected parameter named " + sp.getName());
+				break;
+			}
+		}
+	}
+
+	@Test
+	public void testIssue358() {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/issue_358.yaml");
+		assertNotNull(swagger);
+		List<Parameter> parms = swagger.getPath("/testApi").getGet().getParameters();
+		assertEquals(1, parms.size());
+		assertEquals("pathParam", parms.get(0).getName());
+		assertEquals("string", ((SerializableParameter) parms.get(0)).getType());
+	}
+
+	@Test
+	public void testIncompatibleRefs() {
+		String yaml = "swagger: '2.0'\n" + "paths:\n" + "  /test:\n" + "    post:\n" + "      parameters:\n"
+				+ "        # this is not the correct reference type\n" + "        - $ref: '#/definitions/Model'\n"
+				+ "        - in: body\n" + "          name: incorrectType\n" + "          required: true\n"
+				+ "          schema:\n" + "            $ref: '#/definitions/Model'\n" + "      responses:\n"
+				+ "        200:\n" + "          # this is not the correct reference type\n"
+				+ "          $ref: '#/definitions/Model'\n" + "        400:\n"
+				+ "          definitions: this is right\n" + "          schema:\n"
+				+ "            $ref: '#/definitions/Model'\n" + "definitions:\n" + "  Model:\n" + "    type: object";
+		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
+		assertNotNull(result.getSwagger());
+	}
+
+	@Test
+	public void testIssue243() {
+		String yaml = "swagger: \"2.0\"\n" + "info:\n" + "  version: 0.0.0\n" + "  title: Simple API\n" + "paths:\n"
+				+ "  /:\n" + "    get:\n" + "      responses:\n" + "        '200':\n" + "          description: OK\n"
+				+ "          schema:\n" + "            $ref: \"#/definitions/Simple\"\n" + "definitions:\n"
+				+ "  Simple:\n" + "    type: string";
+		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
+		assertNotNull(result.getSwagger());
+	}
+
+	@Test
+	public void testIssue594() {
+		String yaml = "swagger: '2.0'\n" + "paths:\n" + "  /test:\n" + "    post:\n" + "      parameters:\n"
+				+ "        - name: body\n" + "          in: body\n" + "          description: Hello world\n"
+				+ "          schema:\n" + "            type: array\n" + "            minItems: 1\n"
+				+ "            maxItems: 1\n" + "            items: \n" + "              $ref: \"#/definitions/Pet\"\n"
+				+ "      responses:\n" + "        200:\n" + "          description: 'OK'\n";
+		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
+		assertNotNull(result.getSwagger());
+		ArrayModel schema = (ArrayModel) ((BodyParameter) result.getSwagger().getPaths().get("/test").getPost()
+				.getParameters().get(0)).getSchema();
+		assertEquals(((RefProperty) schema.getItems()).get$ref(), "#/definitions/Pet");
+		assertNotNull(schema.getMaxItems());
+		assertNotNull(schema.getMinItems());
+
+	}
+
+	@Test
+	public void testIssue450() {
+		String desc = "An array of Pets";
+		String xTag = "x-my-tag";
+		String xVal = "An extension tag";
+		String yaml = "swagger: \"2.0\"\n" + "info:\n" + "  version: 0.0.0\n" + "  title: Simple API\n" + "paths:\n"
+				+ "  /:\n" + "    get:\n" + "      responses:\n" + "        '200':\n" + "          description: OK\n"
+				+ "definitions:\n" + "  PetArray:\n" + "    type: array\n" + "    items:\n"
+				+ "      $ref: \"#/definitions/Pet\"\n" + "    description: " + desc + "\n" + "    " + xTag + ": "
+				+ xVal + "\n" + "  Pet:\n" + "    type: object\n" + "    properties:\n" + "      id:\n"
+				+ "        type: string";
+		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo(yaml);
+		assertNotNull(result.getSwagger());
+		final Swagger swagger = result.getSwagger();
+
+		Model petArray = swagger.getDefinitions().get("PetArray");
+		assertNotNull(petArray);
+		assertTrue(petArray instanceof ArrayModel);
+		assertEquals(petArray.getDescription(), desc);
+		assertNotNull(petArray.getVendorExtensions());
+		assertNotNull(petArray.getVendorExtensions().get(xTag));
+		assertEquals(petArray.getVendorExtensions().get(xTag), xVal);
+	}
+
+	@Test
+	public void testIssue480() {
+		final Swagger swagger = new SwaggerParser().read("src/test/resources/issue-480.yaml");
+
+		for (String key : swagger.getSecurityDefinitions().keySet()) {
+			SecuritySchemeDefinition definition = swagger.getSecurityDefinitions().get(key);
+			if ("petstore_auth".equals(key)) {
+				assertTrue(definition instanceof OAuth2Definition);
+				OAuth2Definition oauth = (OAuth2Definition) definition;
+				assertEquals("This is a description", oauth.getDescription());
+			}
+			if ("api_key".equals(key)) {
+				assertTrue(definition instanceof ApiKeyAuthDefinition);
+				ApiKeyAuthDefinition auth = (ApiKeyAuthDefinition) definition;
+				assertEquals("This is another description", auth.getDescription());
+			}
+		}
+	}
+
+	@Test
+	public void checkAllOfAreTaken() {
+		Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-example/allOf.json");
+		assertEquals(2, swagger.getDefinitions().size());
+
+	}
+
+	@Test(description = "Issue #616 Relative references inside of 'allOf'")
+	public void checkAllOfWithRelativeReferencesAreFound() {
+		Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-relative-file-references/parent.json");
+		assertEquals(4, swagger.getDefinitions().size());
+	}
+
+	@Test(description = "Issue #616 Relative references inside of 'allOf'")
+	public void checkAllOfWithRelativeReferencesIssue604() {
+		Swagger swagger = new SwaggerParser().read("src/test/resources/allOf-relative-file-references/swagger.yaml");
+		assertEquals(2, swagger.getDefinitions().size());
+	}
+
+	@Test(description = "Test that validate resolution of external references in allOf of property")
+	public void checkExtRefResolveInPropertiesWithAllOf() {
+		Swagger swagger = new SwaggerParser()
+				.read("src/test/resources/allOf-property-relative-file-references/parent.yaml");
+		assertEquals(2, swagger.getDefinitions().size());
+		assertEquals(1, swagger.getDefinitions().get("test").getProperties().size());
+
+		ComposedProperty property = (ComposedProperty) swagger.getDefinitions().get("test").getProperties()
+				.get("property");
+		assertEquals(1, property.getVendorExtensions().size());
+		assertEquals(1, property.getAllOf().size());
+
+		RefProperty refProperty = (RefProperty) property.getAllOf().get(0);
+		assertEquals("#/definitions/def.def", refProperty.get$ref());
+
+	}
+
+	@Test(description = "A string example should not be over quoted when parsing a yaml string")
+	public void readingSpecStringShouldNotOverQuotingStringExample() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/over-quoted-example.yaml", null, false);
+
+		Map<String, Model> definitions = swagger.getDefinitions();
+		assertEquals("NoQuotePlease", definitions.get("CustomerType").getExample());
+	}
+
+	@Test(description = "A string example should not be over quoted when parsing a yaml node")
+	public void readingSpecNodeShouldNotOverQuotingStringExample() throws Exception {
+		String yaml = Files.readFile(new File("src/test/resources/over-quoted-example.yaml"));
+		JsonNode rootNode = Yaml.mapper().readValue(yaml, JsonNode.class);
+		SwaggerParser parser = new SwaggerParser();
+		Swagger swagger = parser.read(rootNode, true);
+
+		Map<String, Model> definitions = swagger.getDefinitions();
+		assertEquals("NoQuotePlease", definitions.get("CustomerType").getExample());
+	}
+
+	@Test
+	public void testRefNameConflicts() throws Exception {
+		Swagger swagger = new SwaggerParser().read("name-conflicts/refs-name-conflict/a.yaml");
+
+		assertTrue(swagger.getDefinitions().size() == 2);
+
+		assertEquals("#/definitions/PersonObj",
+				((RefProperty) swagger.getPath("/newPerson").getPost().getResponses().get("200").getSchema())
+						.get$ref());
+		assertEquals("#/definitions/PersonObj_2",
+				((RefProperty) swagger.getPath("/oldPerson").getPost().getResponses().get("200").getSchema())
+						.get$ref());
+		assertEquals("#/definitions/PersonObj_2",
+				((RefProperty) swagger.getPath("/yetAnotherPerson").getPost().getResponses().get("200").getSchema())
+						.get$ref());
+		assertEquals("local", swagger.getDefinitions().get("PersonObj").getProperties().get("location").getExample());
+		assertEquals("referred",
+				swagger.getDefinitions().get("PersonObj_2").getProperties().get("location").getExample());
+	}
+
+	@Test
+	public void testRefAdditionalProperties() throws Exception {
+		Swagger swagger = new SwaggerParser().read("src/test/resources/additionalProperties.yaml");
+
+		Assert.assertNotNull(swagger);
+
+		Assert.assertTrue(swagger.getDefinitions().size() == 3);
+
+		Assert.assertNotNull(swagger.getDefinitions().get("link-object"));
+		Assert.assertNotNull(swagger.getDefinitions().get("rel-data"));
+		Assert.assertNotNull(swagger.getDefinitions().get("result"));
+	}
+
+	@Test
+	public void testRefEnum() throws Exception {
+		Swagger swagger = new SwaggerParser().read("src/test/resources/refEnum.yaml");
+
+		Assert.assertNotNull(swagger);
+
+		Assert.assertTrue(swagger.getDefinitions().size() == 5);
+
+		Assert.assertNotNull(swagger.getDefinitions().get("PrintInfo"));
+		Assert.assertNotNull(swagger.getDefinitions().get("SomeEnum"));
+		Assert.assertNotNull(swagger.getDefinitions().get("ShippingInfo"));
+	}
+
+	@Test
+	public void testIssue643() throws Exception {
+		Swagger swagger = new SwaggerParser().read("src/test/resources/issue_643.yaml");
+
+		Assert.assertNotNull(swagger);
+
+		Assert.assertTrue(swagger.getDefinitions().size() == 1);
+
+		Assert.assertNotNull(swagger.getDefinitions().get("XYZResponse"));
+
+	}
+
+	@Test
+	public void testIssueGrace() throws Exception {
+		Swagger swagger = new SwaggerParser().read("src/test/resources/issue_657/issue_657.json");
+
+		Assert.assertNotNull(swagger);
+
+		Assert.assertTrue(swagger.getDefinitions().size() == 2);
+
+		Assert.assertNotNull(swagger.getDefinitions().get("Person"));
+		Assert.assertNotNull(swagger.getDefinitions().get("Persons"));
+
+	}
+
+	@Test
+	public void testLoadExternalNestedDefinitions() throws Exception {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/nested-references/b.yaml");
+
+		Map<String, Model> definitions = swagger.getDefinitions();
+		assertTrue(definitions.containsKey("x"));
+		assertTrue(definitions.containsKey("y"));
+		assertTrue(definitions.containsKey("z"));
+		assertTrue(definitions.containsKey("referencedByLocalElement"));
+		assertEquals("#/definitions/k_2", ((RefModel) definitions.get("i")).get$ref());
+		assertEquals("k-definition", definitions.get("k").getTitle());
+		assertEquals("k-definition", definitions.get("k_2").getTitle());
+		assertEquals(((RefModel) definitions.get("l")).get$ref(), "#/definitions/referencedByLocalElement"); // issue
+																												// #434
+	}
+
+	@Test(description = "Parser not honoring redirect responses")
+	public void testIssue844() {
+		SwaggerParser parser = new SwaggerParser();
+		final SwaggerDeserializationResult swagger = parser
+				.readWithInfo("src/test/resources/reusableParametersWithExternalRef.json", null, true);
+		assertNotNull(swagger.getSwagger());
+		assertEquals(swagger.getSwagger().getPath("/pets/{id}").getGet().getParameters().get(0).getIn(), "header");
+	}
+
+	@Test
+	public void testIssue258() {
+		SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("duplicateOperationId.json", null, true);
+		assertNotNull(result);
+		assertNotNull(result.getSwagger());
+		assertEquals(result.getMessages().get(0), "attribute paths.'/pets/{id}'(post).operationId is repeated");
+	}
+
+	@Test
+	public void testIssue913() {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read("src/test/resources/issue-913/BS/ApiSpecification.yaml");
+		Assert.assertNotNull(swagger);
+		Assert.assertNotNull(swagger.getDefinitions().get("indicatorType"));
+		Assert.assertEquals(swagger.getDefinitions().get("indicatorType").getProperties().size(), 1);
+	}
+
+	@Test
+	public void testExternalParameters() {
+		SwaggerParser parser = new SwaggerParser();
+		final Swagger swagger = parser.read(
+				"src/test/resources/parameters-external/data-plane/ComputerVision/stable/v1.0/ComputerVision.json");
+		Assert.assertNotNull(swagger);
+		final Path path = swagger.getPath("/analyze");
+		Assert.assertNotNull(path);
+		final Operation post = path.getPost();
+		Assert.assertNotNull(post);
+		final List<Parameter> parameters = post.getParameters();
+		Assert.assertNotNull(parameters);
+		final BodyParameter parameter = (BodyParameter) parameters.get(3);
+		Assert.assertNotNull(parameter);
+		Assert.assertEquals(parameter.getName(), "ImageUrl");
+		final RefModel schema = (RefModel) parameter.getSchema();
+		Assert.assertNotNull(schema);
+		final String simpleRef = schema.getSimpleRef();
+		Assert.assertNotNull(simpleRef);
+		final String message = "Where is " + simpleRef + "?";
+		if (schema.getReference().startsWith("#/definitions/")) {
+			Assert.assertNotNull(swagger.getDefinitions().get(simpleRef), message);
+		} else if (schema.getReference().startsWith("#/parameters/")) {
+			Assert.assertNotNull(swagger.getParameters().get(simpleRef), message);
+		} else {
+			Assert.fail(message);
+		}
+	}
 }

--- a/modules/swagger-parser/src/test/resources/parameters-external/data-plane/Common/Parameters.json
+++ b/modules/swagger-parser/src/test/resources/parameters-external/data-plane/Common/Parameters.json
@@ -1,0 +1,57 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2017-08-30",
+    "title": "Common Referenced Parameters File",
+    "description": "File containing commonly referenced parameters."
+  },
+  "paths": {},
+  "parameters": {
+    "GlobalEndpoint": {
+      "name": "Endpoint",
+      "description": "Supported Cognitive Services endpoints (protocol and hostname, for example: \"https://westus.api.cognitive.microsoft.com\", \"https://api.cognitive.microsoft.com\").",
+      "x-ms-parameter-location": "client",
+      "required": true,
+      "type": "string",
+      "in": "path",
+      "x-ms-skip-url-encoding": true,
+      "default": "https://api.cognitive.microsoft.com"
+    },
+    "ImageStream": {
+      "name": "Image",
+      "in": "body",
+      "required": true,
+      "x-ms-parameter-location": "method",
+      "description": "An image stream.",
+      "schema": {
+        "type": "object",
+        "format": "file"
+      }
+    },
+    "ImageUrl": {
+      "name": "ImageUrl",
+      "in": "body",
+      "required": true,
+      "x-ms-parameter-location": "method",
+      "x-ms-client-flatten": true,
+      "description": "A JSON document with a URL pointing to the image that is to be analyzed.",
+      "schema": {
+        "$ref": "#/definitions/ImageUrl"
+      }
+    }
+  },
+  "definitions": {
+    "ImageUrl": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "url": {
+          "description": "Publicly reachable URL of an image",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/parameters-external/data-plane/ComputerVision/stable/v1.0/ComputerVision.json
+++ b/modules/swagger-parser/src/test/resources/parameters-external/data-plane/ComputerVision/stable/v1.0/ComputerVision.json
@@ -1,0 +1,1487 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0",
+    "title": "Computer Vision API",
+    "description": "The Computer Vision API provides state-of-the-art algorithms to process images and return information. For example, it can be used to determine if an image contains mature content, or it can be used to find all the faces in an image.  It also has other features like estimating dominant and accent colors, categorizing the content of images, and describing an image with complete English sentences.  Additionally, it can also intelligently generate images thumbnails for displaying large images effectively."
+  },
+  "securityDefinitions": {
+    "apim_key": {
+      "type": "apiKey",
+      "name": "Ocp-Apim-Subscription-Key",
+      "in": "header"
+    }
+  },
+  "security": [
+    {
+      "apim_key": []
+    }
+  ],
+  "x-ms-parameterized-host": {
+    "hostTemplate": "{AzureRegion}.api.cognitive.microsoft.com",
+    "parameters": [
+      {
+        "$ref": "../../../Common/ExtendedRegions.json#/parameters/AzureRegion"
+      }
+    ]
+  },
+  "basePath": "/vision/v1.0",
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/models": {
+      "get": {
+        "description": "This operation returns the list of domain-specific models that are supported by the Computer Vision API.  Currently, the API only supports one domain-specific model: a celebrity recognizer. A successful response will be returned in JSON.  If the request failed, the response will contain an error code and a message to help understand what went wrong.",
+        "operationId": "ListModels",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "List of available domain models.",
+            "schema": {
+              "$ref": "#/definitions/ListModelsResult"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful List Domains request": {
+            "$ref": "./examples/SuccessfulListDomainModels.json"
+          }
+        }
+      }
+    },
+    "/analyze": {
+      "post": {
+        "description": "This operation extracts a rich set of visual features based on the image content. Two input methods are supported -- (1) Uploading an image or (2) specifying an image URL.  Within your request, there is an optional parameter to allow you to choose which features to return.  By default, image categories are returned in the response.",
+        "operationId": "AnalyzeImage",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/VisualFeatures"
+          },
+          {
+            "name": "details",
+            "in": "query",
+            "description": "A string indicating which domain-specific details to return. Multiple values should be comma-separated. Valid visual feature types include:Celebrities - identifies celebrities if detected in the image.",
+            "type": "array",
+            "required": false,
+            "collectionFormat": "csv",
+            "items": {
+              "type": "string",
+              "x-nullable": false,
+              "x-ms-enum": {
+                "name": "Details",
+                "modelAsString": false
+              },
+              "enum": [
+                "Celebrities",
+                "Landmarks"
+              ]
+            }
+          },
+          {
+            "$ref": "#/parameters/ServiceLanguage"
+          },
+          {
+            "$ref": "../../../Common/Parameters.json#/parameters/ImageUrl"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The response include the extracted features in JSON format.Here is the definitions for enumeration typesClipartTypeNon-clipart = 0,  ambiguous = 1, normal-clipart = 2, good-clipart = 3.LineDrawingTypeNon-LineDrawing = 0,LineDrawing = 1.",
+            "schema": {
+              "$ref": "#/definitions/ImageAnalysis"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Analyze with Url request": {
+            "$ref": "./examples/SuccessfulAnalyzeWithUrl.json"
+          }
+        }
+      }
+    },
+    "/generateThumbnail": {
+      "post": {
+        "description": "This operation generates a thumbnail image with the user-specified width and height. By default, the service analyzes the image, identifies the region of interest (ROI), and generates smart cropping coordinates based on the ROI. Smart cropping helps when you specify an aspect ratio that differs from that of the input image. A successful response contains the thumbnail image binary. If the request failed, the response contains an error code and a message to help determine what went wrong.",
+        "operationId": "GenerateThumbnail",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "name": "width",
+            "type": "integer",
+            "in": "query",
+            "required": true,
+            "minimum": 1,
+            "maximum": 1023,
+            "description": "Width of the thumbnail. It must be between 1 and 1024. Recommended minimum of 50."
+          },
+          {
+            "name": "height",
+            "type": "integer",
+            "in": "query",
+            "required": true,
+            "minimum": 1,
+            "maximum": 1023,
+            "description": "Height of the thumbnail. It must be between 1 and 1024. Recommended minimum of 50."
+          },
+          {
+            "$ref": "../../../Common/Parameters.json#/parameters/ImageUrl"
+          },
+          {
+            "name": "smartCropping",
+            "type": "boolean",
+            "in": "query",
+            "required": false,
+            "default": false,
+            "description": "Boolean flag for enabling smart cropping."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The generated thumbnail in binary format.",
+            "schema": {
+              "type": "file"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Generate Thumbnail request": {
+            "$ref": "./examples/SuccessfulGenerateThumbnailWithUrl.json"
+          }
+        }
+      }
+    },
+    "/ocr": {
+      "post": {
+        "description": "Optical Character Recognition (OCR) detects printed text in an image and extracts the recognized characters into a machine-usable character stream.   Upon success, the OCR results will be returned. Upon failure, the error code together with an error message will be returned. The error code can be one of InvalidImageUrl, InvalidImageFormat, InvalidImageSize, NotSupportedImage,  NotSupportedLanguage, or InternalServerError.",
+        "operationId": "RecognizePrintedText",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/DetectOrientation"
+          },
+          {
+            "$ref": "../../../Common/Parameters.json#/parameters/ImageUrl"
+          },
+          {
+            "$ref": "#/parameters/OcrLanguage"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The OCR results in the hierarchy of region/line/word. The results include text, bounding box for regions, lines and words.textAngleThe angle, in degrees, of the detected text with respect to the closest horizontal or vertical direction. After rotating the input image clockwise by this angle, the recognized text lines become horizontal or vertical. In combination with the orientation property it can be used to overlay recognition results correctly on the original image, by rotating either the original image or recognition results by a suitable angle around the center of the original image. If the angle cannot be confidently detected, this property is not present. If the image contains text at different angles, only part of the text will be recognized correctly.",
+            "schema": {
+              "$ref": "#/definitions/OcrResult"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Ocr request": {
+            "$ref": "./examples/SuccessfulOcrWithUrl.json"
+          }
+        }
+      }
+    },
+    "/describe": {
+      "post": {
+        "description": "This operation generates a description of an image in human readable language with complete sentences.  The description is based on a collection of content tags, which are also returned by the operation. More than one description can be generated for each image.  Descriptions are ordered by their confidence score. All descriptions are in English. Two input methods are supported -- (1) Uploading an image or (2) specifying an image URL.A successful response will be returned in JSON.  If the request failed, the response will contain an error code and a message to help understand what went wrong.",
+        "operationId": "DescribeImage",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "maxCandidates",
+            "in": "query",
+            "description": "Maximum number of candidate descriptions to be returned.  The default is 1.",
+            "type": "string",
+            "required": false,
+            "default": "1"
+          },
+          {
+            "$ref": "#/parameters/ServiceLanguage"
+          },
+          {
+            "$ref": "../../../Common/Parameters.json#/parameters/ImageUrl"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Image description object.",
+            "schema": {
+              "$ref": "#/definitions/ImageDescription"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Describe request": {
+            "$ref": "./examples/SuccessfulDescribeWithUrl.json"
+          }
+        }
+      }
+    },
+    "/tag": {
+      "post": {
+        "description": "This operation generates a list of words, or tags, that are relevant to the content of the supplied image. The Computer Vision API can return tags based on objects, living beings, scenery or actions found in images. Unlike categories, tags are not organized according to a hierarchical classification system, but correspond to image content. Tags may contain hints to avoid ambiguity or provide context, for example the tag 'cello' may be accompanied by the hint 'musical instrument'. All tags are in English.",
+        "operationId": "TagImage",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/ServiceLanguage"
+          },
+          {
+            "$ref": "../../../Common/Parameters.json#/parameters/ImageUrl"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Image tags object.",
+            "schema": {
+              "$ref": "#/definitions/TagResult"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Tag request": {
+            "$ref": "./examples/SuccessfulTagWithUrl.json"
+          }
+        }
+      }
+    },
+    "/models/{model}/analyze": {
+      "post": {
+        "description": "This operation recognizes content within an image by applying a domain-specific model.  The list of domain-specific models that are supported by the Computer Vision API can be retrieved using the /models GET request.  Currently, the API only provides a single domain-specific model: celebrities. Two input methods are supported -- (1) Uploading an image or (2) specifying an image URL. A successful response will be returned in JSON.  If the request failed, the response will contain an error code and a message to help understand what went wrong.",
+        "operationId": "AnalyzeImageByDomain",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "model",
+            "in": "path",
+            "description": "The domain-specific content to recognize.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ServiceLanguage"
+          },
+          {
+            "$ref": "../../../Common/Parameters.json#/parameters/ImageUrl"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Analysis result based on the domain model",
+            "schema": {
+              "$ref": "#/definitions/DomainModelResults"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Domain Model analysis request": {
+            "$ref": "./examples/SuccessfulDomainModelWithUrl.json"
+          }
+        }
+      }
+    },
+    "/recognizeText": {
+      "post": {
+        "description": "Recognize Text operation. When you use the Recognize Text interface, the response contains a field called 'Operation-Location'. The 'Operation-Location' field contains the URL that you must use for your Get Handwritten Text Operation Result operation.",
+        "operationId": "RecognizeText",
+        "parameters": [
+          {
+            "$ref": "../../../Common/Parameters.json#/parameters/ImageUrl"
+          },
+          {
+            "$ref": "#/parameters/HandwritingBoolean"
+          }
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "202": {
+            "description": "The service has accepted the request and will start processing later. It will return Accepted immediately and include an Operation-Location header. Client side should further query the operation status using the URL specified in this header. The operation ID will expire in 48 hours.",
+            "headers": {
+              "Operation-Location": {
+                "description": "URL to query for status of the operation. The operation ID will expire in 48 hours. ",
+                "type": "string"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Domain Model analysis request": {
+            "$ref": "./examples/SuccessfulRecognizeTextWithUrl.json"
+          }
+        }
+      }
+    },
+    "/textOperations/{operationId}": {
+      "get": {
+        "description": "This interface is used for getting text operation result. The URL to this interface should be retrieved from 'Operation-Location' field returned from Recognize Text interface.",
+        "operationId": "GetTextOperationResult",
+        "parameters": [
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "Id of the text operation returned in the response of the 'Recognize Handwritten Text'",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the operation status.",
+            "schema": {
+              "$ref": "#/definitions/TextOperationResult"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Domain Model analysis request": {
+            "$ref": "./examples/SuccessfulGetTextOperationResult.json"
+          }
+        }
+      }
+    }
+  },
+  "x-ms-paths": {
+    "/analyze?overload=stream": {
+      "post": {
+        "description": "This operation extracts a rich set of visual features based on the image content.",
+        "operationId": "AnalyzeImageInStream",
+        "consumes": [
+          "application/octet-stream",
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/VisualFeatures"
+          },
+          {
+            "name": "details",
+            "in": "query",
+            "description": "A string indicating which domain-specific details to return. Multiple values should be comma-separated. Valid visual feature types include:Celebrities - identifies celebrities if detected in the image.",
+            "type": "string",
+            "required": false,
+            "enum": [
+              "Celebrities",
+              "Landmarks"
+            ]
+          },
+          {
+            "$ref": "#/parameters/ServiceLanguage"
+          },
+          {
+            "$ref": "../../../Common/Parameters.json#/parameters/ImageStream"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The response include the extracted features in JSON format. Here is the definitions for enumeration types clipart = 0, ambiguous = 1, normal-clipart = 2, good-clipart = 3. Non-LineDrawing = 0,LineDrawing = 1.",
+            "schema": {
+              "$ref": "#/definitions/ImageAnalysis"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Analyze with Url request": {
+            "$ref": "./examples/SuccessfulAnalyzeWithStream.json"
+          }
+        }
+      }
+    },
+    "/generateThumbnail?overload=stream": {
+      "post": {
+        "description": "This operation generates a thumbnail image with the user-specified width and height. By default, the service analyzes the image, identifies the region of interest (ROI), and generates smart cropping coordinates based on the ROI. Smart cropping helps when you specify an aspect ratio that differs from that of the input image. A successful response contains the thumbnail image binary. If the request failed, the response contains an error code and a message to help determine what went wrong.",
+        "operationId": "GenerateThumbnailInStream",
+        "consumes": [
+          "application/octet-stream",
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/octet-stream"
+        ],
+        "parameters": [
+          {
+            "name": "width",
+            "type": "integer",
+            "in": "query",
+            "required": true,
+            "minimum": 1,
+            "maximum": 1023,
+            "description": "Width of the thumbnail. It must be between 1 and 1024. Recommended minimum of 50."
+          },
+          {
+            "name": "height",
+            "type": "integer",
+            "in": "query",
+            "required": true,
+            "minimum": 1,
+            "maximum": 1023,
+            "description": "Height of the thumbnail. It must be between 1 and 1024. Recommended minimum of 50."
+          },
+          {
+            "$ref": "../../../Common/Parameters.json#/parameters/ImageStream"
+          },
+          {
+            "name": "smartCropping",
+            "type": "boolean",
+            "in": "query",
+            "required": false,
+            "default": false,
+            "description": "Boolean flag for enabling smart cropping."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The generated thumbnail in binary format.",
+            "schema": {
+              "type": "file"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Generate Thumbnail request": {
+            "$ref": "./examples/SuccessfulGenerateThumbnailWithStream.json"
+          }
+        }
+      }
+    },
+    "/ocr?overload=stream": {
+      "post": {
+        "description": "Optical Character Recognition (OCR) detects printed text in an image and extracts the recognized characters into a machine-usable character stream.   Upon success, the OCR results will be returned. Upon failure, the error code together with an error message will be returned. The error code can be one of InvalidImageUrl, InvalidImageFormat, InvalidImageSize, NotSupportedImage,  NotSupportedLanguage, or InternalServerError.",
+        "operationId": "RecognizePrintedTextInStream",
+        "consumes": [
+          "application/octet-stream",
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/OcrLanguage"
+          },
+          {
+            "$ref": "#/parameters/DetectOrientation"
+          },
+          {
+            "$ref": "../../../Common/Parameters.json#/parameters/ImageStream"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The OCR results in the hierarchy of region/line/word. The results include text, bounding box for regions, lines and words. The angle, in degrees, of the detected text with respect to the closest horizontal or vertical direction. After rotating the input image clockwise by this angle, the recognized text lines become horizontal or vertical. In combination with the orientation property it can be used to overlay recognition results correctly on the original image, by rotating either the original image or recognition results by a suitable angle around the center of the original image. If the angle cannot be confidently detected, this property is not present. If the image contains text at different angles, only part of the text will be recognized correctly.",
+            "schema": {
+              "$ref": "#/definitions/OcrResult"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Ocr request": {
+            "$ref": "./examples/SuccessfulOcrWithStream.json"
+          }
+        }
+      }
+    },
+    "/describe?overload=stream": {
+      "post": {
+        "description": "This operation generates a description of an image in human readable language with complete sentences.  The description is based on a collection of content tags, which are also returned by the operation. More than one description can be generated for each image.  Descriptions are ordered by their confidence score. All descriptions are in English. Two input methods are supported -- (1) Uploading an image or (2) specifying an image URL.A successful response will be returned in JSON.  If the request failed, the response will contain an error code and a message to help understand what went wrong.",
+        "operationId": "DescribeImageInStream",
+        "consumes": [
+          "application/octet-stream",
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "maxCandidates",
+            "in": "query",
+            "description": "Maximum number of candidate descriptions to be returned.  The default is 1.",
+            "type": "string",
+            "required": false,
+            "default": "1"
+          },
+          {
+            "$ref": "#/parameters/ServiceLanguage"
+          },
+          {
+            "$ref": "../../../Common/Parameters.json#/parameters/ImageStream"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Image description object.",
+            "schema": {
+              "$ref": "#/definitions/ImageDescription"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Describe request": {
+            "$ref": "./examples/SuccessfulDescribeWithStream.json"
+          }
+        }
+      }
+    },
+    "/tag?overload=stream": {
+      "post": {
+        "description": "This operation generates a list of words, or tags, that are relevant to the content of the supplied image. The Computer Vision API can return tags based on objects, living beings, scenery or actions found in images. Unlike categories, tags are not organized according to a hierarchical classification system, but correspond to image content. Tags may contain hints to avoid ambiguity or provide context, for example the tag 'cello' may be accompanied by the hint 'musical instrument'. All tags are in English.",
+        "operationId": "TagImageInStream",
+        "consumes": [
+          "application/octet-stream",
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/ServiceLanguage"
+          },
+          {
+            "$ref": "../../../Common/Parameters.json#/parameters/ImageStream"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Image tags object.",
+            "schema": {
+              "$ref": "#/definitions/TagResult"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Tag request": {
+            "$ref": "./examples/SuccessfulTagWithStream.json"
+          }
+        }
+      }
+    },
+    "/models/{model}/analyze?overload=stream": {
+      "post": {
+        "description": "This operation recognizes content within an image by applying a domain-specific model.  The list of domain-specific models that are supported by the Computer Vision API can be retrieved using the /models GET request.  Currently, the API only provides a single domain-specific model: celebrities. Two input methods are supported -- (1) Uploading an image or (2) specifying an image URL. A successful response will be returned in JSON.  If the request failed, the response will contain an error code and a message to help understand what went wrong.",
+        "operationId": "AnalyzeImageByDomainInStream",
+        "consumes": [
+          "application/octet-stream",
+          "multipart/form-data"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "model",
+            "in": "path",
+            "description": "The domain-specific content to recognize.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "$ref": "#/parameters/ServiceLanguage"
+          },
+          {
+            "$ref": "../../../Common/Parameters.json#/parameters/ImageStream"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Analysis result based on the domain model",
+            "schema": {
+              "$ref": "#/definitions/DomainModelResults"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Domain Model analysis request": {
+            "$ref": "./examples/SuccessfulDomainModelWithStream.json"
+          }
+        }
+      }
+    },
+    "/recognizeText?overload=stream": {
+      "post": {
+        "description": "Recognize Text operation. When you use the Recognize Text interface, the response contains a field called 'Operation-Location'. The 'Operation-Location' field contains the URL that you must use for your Get Handwritten Text Operation Result operation.",
+        "operationId": "RecognizeTextInStream",
+        "parameters": [
+          {
+            "$ref": "#/parameters/HandwritingBoolean"
+          },
+          {
+            "$ref": "../../../Common/Parameters.json#/parameters/ImageStream"
+          }
+        ],
+        "consumes": [
+          "application/octet-stream"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "202": {
+            "description": "The service has accepted the request and will start processing later.",
+            "headers": {
+              "Operation-Location": {
+                "description": "URL to query for status of the operation. The operation ID will expire in 48 hours. ",
+                "type": "string"
+              }
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/ComputerVisionError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Successful Domain Model analysis request": {
+            "$ref": "./examples/SuccessfulRecognizeTextWithStream.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "TextOperationResult": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Status of the text operation.",
+          "enum": [
+            "Not Started",
+            "Running",
+            "Failed",
+            "Succeeded"
+          ],
+          "x-ms-enum": {
+            "name": "TextOperationStatusCodes",
+            "modelAsString": false
+          },
+          "x-nullable": false
+        },
+        "recognitionResult": {
+          "$ref": "#/definitions/RecognitionResult"
+        }
+      }
+    },
+    "RecognitionResult": {
+      "type": "object",
+      "properties": {
+        "lines": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Line"
+          }
+        }
+      }
+    },
+    "Line": {
+      "type": "object",
+      "properties": {
+        "boundingBox": {
+          "$ref": "#/definitions/BoundingBox"
+        },
+        "text": {
+          "type": "string"
+        },
+        "words": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Word"
+          }
+        }
+      }
+    },
+    "Word": {
+      "type": "object",
+      "properties": {
+        "boundingBox": {
+          "$ref": "#/definitions/BoundingBox"
+        },
+        "text": {
+          "type": "string"
+        }
+      }
+    },
+    "BoundingBox": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "x-nullable": false
+      }
+    },
+    "ImageAnalysis": {
+      "type": "object",
+      "description": "Result of AnalyzeImage operation.",
+      "properties": {
+        "categories": {
+          "type": "array",
+          "description": "An array indicating identified categories.",
+          "items": {
+            "$ref": "#/definitions/Category"
+          }
+        },
+        "adult": {
+          "$ref": "#/definitions/AdultInfo"
+        },
+        "color": {
+          "$ref": "#/definitions/ColorInfo"
+        },
+        "imageType": {
+          "$ref": "#/definitions/ImageType"
+        },
+        "tags": {
+          "type": "array",
+          "description": "A list of tags with confidence level.",
+          "items": {
+            "$ref": "#/definitions/ImageTag"
+          }
+        },
+        "description": {
+          "$ref": "#/definitions/ImageDescriptionDetails"
+        },
+        "faces": {
+          "type": "array",
+          "description": "An array of possible faces within the image.",
+          "items": {
+            "$ref": "#/definitions/FaceDescription"
+          }
+        },
+        "requestId": {
+          "type": "string",
+          "description": "Id of the request for tracking purposes."
+        },
+        "metadata": {
+          "$ref": "#/definitions/ImageMetadata"
+        }
+      }
+    },
+    "OcrResult": {
+      "type": "object",
+      "properties": {
+        "language": {
+          "type": "string",
+          "description": "The BCP-47 language code of the text in the image."
+        },
+        "textAngle": {
+          "type": "number",
+          "format": "double",
+          "description": "The angle, in degrees, of the detected text with respect to the closest horizontal or vertical direction. After rotating the input image clockwise by this angle, the recognized text lines become horizontal or vertical. In combination with the orientation property it can be used to overlay recognition results correctly on the original image, by rotating either the original image or recognition results by a suitable angle around the center of the original image. If the angle cannot be confidently detected, this property is not present. If the image contains text at different angles, only part of the text will be recognized correctly."
+        },
+        "orientation": {
+          "type": "string",
+          "description": "Orientation of the text recognized in the image. The value (up,down,left, or right) refers to the direction that the top of the recognized text is facing, after the image has been rotated around its center according to the detected text angle (see textAngle property)."
+        },
+        "regions": {
+          "type": "array",
+          "description": "An array of objects, where each object represents a region of recognized text.",
+          "items": {
+            "$ref": "#/definitions/OcrRegion"
+          }
+        }
+      }
+    },
+    "OcrRegion": {
+      "type": "object",
+      "description": "A region consists of multiple lines (e.g. a column of text in a multi-column document).",
+      "properties": {
+        "boundingBox": {
+          "type": "string",
+          "description": "Bounding box of a recognized region. The four integers represent the x-coordinate of the left edge, the y-coordinate of the top edge, width, and height of the bounding box, in the coordinate system of the input image, after it has been rotated around its center according to the detected text angle (see textAngle property), with the origin at the top-left corner, and the y-axis pointing down."
+        },
+        "lines": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OcrLine"
+          }
+        }
+      }
+    },
+    "OcrLine": {
+      "type": "object",
+      "description": "An object describing a single recognized line of text.",
+      "properties": {
+        "boundingBox": {
+          "type": "string",
+          "description": "Bounding box of a recognized line. The four integers represent the x-coordinate of the left edge, the y-coordinate of the top edge, width, and height of the bounding box, in the coordinate system of the input image, after it has been rotated around its center according to the detected text angle (see textAngle property), with the origin at the top-left corner, and the y-axis pointing down."
+        },
+        "words": {
+          "type": "array",
+          "description": "An array of objects, where each object represents a recognized word.",
+          "items": {
+            "$ref": "#/definitions/OcrWord"
+          }
+        }
+      }
+    },
+    "OcrWord": {
+      "type": "object",
+      "description": "Information on a recognized word.",
+      "properties": {
+        "boundingBox": {
+          "type": "string",
+          "description": "Bounding box of a recognized word. The four integers represent the x-coordinate of the left edge, the y-coordinate of the top edge, width, and height of the bounding box, in the coordinate system of the input image, after it has been rotated around its center according to the detected text angle (see textAngle property), with the origin at the top-left corner, and the y-axis pointing down."
+        },
+        "text": {
+          "type": "string",
+          "description": "String value of a recognized word."
+        }
+      }
+    },
+    "ListModelsResult": {
+      "type": "object",
+      "description": "Result of the List Domain Models operation.",
+      "properties": {
+        "models": {
+          "type": "array",
+          "readOnly": true,
+          "description": "An array of supported models.",
+          "items": {
+            "$ref": "#/definitions/ModelDescription"
+          }
+        }
+      }
+    },
+    "ModelDescription": {
+      "type": "object",
+      "description": "An object describing supported model by name and categories.",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "DomainModelResults": {
+      "type": "object",
+      "description": "Result of image analysis using a specific domain model including additional metadata.",
+      "properties": {
+        "result": {
+          "x-ms-client-flatten": true,
+          "type": "object",
+          "description": "Model-specific response"
+        },
+        "requestId": {
+          "type": "string",
+          "description": "Id of the REST API request."
+        },
+        "metadata": {
+          "$ref": "#/definitions/ImageMetadata"
+        }
+      }
+    },
+    "CelebrityResults": {
+      "type": "object",
+      "description": "List of celebrities recognized in the image.",
+      "properties": {
+        "celebrities": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CelebritiesModel"
+          }
+        },
+        "requestId": {
+          "type": "string",
+          "description": "Id of the REST API request."
+        },
+        "metadata": {
+          "$ref": "#/definitions/ImageMetadata"
+        }
+      }
+    },
+    "LandmarkResults": {
+      "type": "object",
+      "description": "List of landmarks recognized in the image.",
+      "properties": {
+        "landmarks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "A landmark recognized in the image",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the landmark."
+              },
+              "confidence": {
+                "type": "number",
+                "format": "double",
+                "description": "Confidence level for the landmark recognition."
+              }
+            }
+          }
+        },
+        "requestId": {
+          "type": "string",
+          "description": "Id of the REST API request."
+        },
+        "metadata": {
+          "$ref": "#/definitions/ImageMetadata"
+        }
+      }
+    },
+    "ImageDescription": {
+      "type": "object",
+      "description": "A collection of content tags, along with a list of captions sorted by confidence level, and image metadata.",
+      "properties": {
+        "description": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ImageDescriptionDetails"
+        }
+      }
+    },
+    "TagResult": {
+      "type": "object",
+      "description": "The results of a image tag operation, including any tags and image metadata.",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "description": "A list of tags with confidence level.",
+          "items": {
+            "$ref": "#/definitions/ImageTag"
+          }
+        },
+        "requestId": {
+          "type": "string",
+          "description": "Id of the REST API request."
+        },
+        "metadata": {
+          "$ref": "#/definitions/ImageMetadata"
+        }
+      }
+    },
+    "ImageDescriptionDetails": {
+      "type": "object",
+      "description": "A collection of content tags, along with a list of captions sorted by confidence level, and image metadata.",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "description": "A collection of image tags.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "captions": {
+          "type": "array",
+          "description": "A list of captions, sorted by confidence level.",
+          "items": {
+            "$ref": "#/definitions/ImageCaption"
+          }
+        },
+        "requestId": {
+          "type": "string",
+          "description": "Id of the REST API request."
+        },
+        "metadata": {
+          "$ref": "#/definitions/ImageMetadata"
+        }
+      }
+    },
+    "ImageCaption": {
+      "type": "object",
+      "description": "An image caption, i.e. a brief description of what the image depicts.",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The text of the caption"
+        },
+        "confidence": {
+          "type": "number",
+          "format": "double",
+          "description": "The level of confidence the service has in the caption"
+        }
+      }
+    },
+    "ImageTag": {
+      "type": "object",
+      "description": "An image caption, i.e. a brief description of what the image depicts.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The tag value"
+        },
+        "confidence": {
+          "type": "number",
+          "format": "double",
+          "description": "The level of confidence the service has in the caption"
+        }
+      }
+    },
+    "ImageMetadata": {
+      "type": "object",
+      "description": "Image metadata",
+      "properties": {
+        "width": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Image width"
+        },
+        "height": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Image height"
+        },
+        "format": {
+          "type": "string",
+          "description": "Image format"
+        }
+      }
+    },
+    "CelebritiesModel": {
+      "type": "object",
+      "description": "An object describing possible celebrity identification.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the celebrity."
+        },
+        "confidence": {
+          "type": "number",
+          "format": "double",
+          "description": "Level of confidence ranging from 0 to 1."
+        },
+        "faceRectangle": {
+          "$ref": "#/definitions/FaceRectangle"
+        }
+      }
+    },
+    "FaceRectangle": {
+      "type": "object",
+      "description": "An object describing face rectangle.",
+      "properties": {
+        "left": {
+          "type": "integer",
+          "description": "X-coordinate of the top left point of the face."
+        },
+        "top": {
+          "type": "integer",
+          "description": "Y-coordinate of the top left point of the face."
+        },
+        "width": {
+          "type": "integer",
+          "description": "Width measured from the top-left point of the face."
+        },
+        "height": {
+          "type": "integer",
+          "description": "Height measured from the top-left point of the face."
+        }
+      }
+    },
+    "FaceDescription": {
+      "type": "object",
+      "description": "An object describing a face identified in the image.",
+      "properties": {
+        "age": {
+          "type": "integer",
+          "description": "Possible age of the face."
+        },
+        "gender": {
+          "type": "string",
+          "description": "Possible gender of the face.",
+          "x-ms-enum": {
+            "name": "Gender-",
+            "modelAsString": false
+          },
+          "enum": [
+            "Male",
+            "Female"
+          ]
+        },
+        "faceRectangle": {
+          "$ref": "#/definitions/FaceRectangle"
+        }
+      }
+    },
+    "ImageType": {
+      "type": "object",
+      "description": "An object providing possible image types and matching confidence levels.",
+      "properties": {
+        "clipArtType": {
+          "type": "number",
+          "description": "Confidence level that the image is a clip art."
+        },
+        "lineDrawingType": {
+          "type": "number",
+          "description": "Confidence level that the image is a line drawing."
+        }
+      }
+    },
+    "ColorInfo": {
+      "type": "object",
+      "description": "An object providing additional metadata describing color attributes.",
+      "properties": {
+        "dominantColorForeground": {
+          "type": "string",
+          "description": "Possible dominant foreground color."
+        },
+        "dominantColorBackground": {
+          "type": "string",
+          "description": "Possible dominant background color."
+        },
+        "dominantColors": {
+          "type": "array",
+          "description": "An array of possible dominant colors.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "accentColor": {
+          "type": "string",
+          "description": "Possible accent color."
+        },
+        "isBWImg": {
+          "type": "boolean",
+          "description": "A value indicating if the image is black and white."
+        }
+      }
+    },
+    "AdultInfo": {
+      "type": "object",
+      "description": "An object describing whether the image contains adult-oriented content and/or is racy.",
+      "properties": {
+        "isAdultContent": {
+          "type": "boolean",
+          "x-nullable": false,
+          "description": "A value indicating if the image contains adult-oriented content."
+        },
+        "isRacyContent": {
+          "type": "boolean",
+          "x-nullable": false,
+          "description": "A value indicating if the image is race."
+        },
+        "adultScore": {
+          "type": "number",
+          "format": "double",
+          "x-nullable": false,
+          "description": "Score from 0 to 1 that indicates how much of adult content is within the image."
+        },
+        "racyScore": {
+          "type": "number",
+          "format": "double",
+          "x-nullable": false,
+          "description": "Score from 0 to 1 that indicates how suggestive is the image."
+        }
+      }
+    },
+    "Category": {
+      "type": "object",
+      "description": "An object describing identified category.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the category."
+        },
+        "score": {
+          "type": "number",
+          "format": "double",
+          "description": "Scoring of the category."
+        },
+        "detail": {
+          "$ref": "#/definitions/CategoryDetail"
+        }
+      }
+    },
+    "CategoryDetail": {
+      "type": "object",
+      "description": "An object describing additional category details.",
+      "properties": {
+        "celebrities": {
+          "type": "array",
+          "description": "An array of celebrities if any identified.",
+          "items": {
+            "$ref": "#/definitions/CelebritiesModel"
+          }
+        }
+      }
+    },
+    "ComputerVisionError": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The error code.",
+          "enum": [
+            "InvalidImageUrl",
+            "InvalidImageFormat",
+            "InvalidImageSize",
+            "NotSupportedVisualFeature",
+            "NotSupportedImage",
+            "InvalidDetails",
+            "NotSupportedLanguage",
+            "BadArgument",
+            "FailedToProcess",
+            "Timeout",
+            "InternalServerError",
+            "Unspecified",
+            "StorageException"
+          ],
+          "x-ms-enum": {
+            "name": "ComputerVisionErrorCodes",
+            "modelAsString": false
+          }
+        },
+        "message": {
+          "type": "string",
+          "description": "A message explaining the error reported by the service."
+        },
+        "requestId": {
+          "type": "string",
+          "description": "A unique request identifier."
+        }
+      }
+    },
+    "ServiceLanguage": {
+      "type": "string"
+    }
+  },
+  "parameters": {
+    "VisualFeatures": {
+      "name": "visualFeatures",
+      "in": "query",
+      "description": "A string indicating what visual feature types to return. Multiple values should be comma-separated. Valid visual feature types include:Categories - categorizes image content according to a taxonomy defined in documentation. Tags - tags the image with a detailed list of words related to the image content. Description - describes the image content with a complete English sentence. Faces - detects if faces are present. If present, generate coordinates, gender and age. ImageType - detects if image is clipart or a line drawing. Color - determines the accent color, dominant color, and whether an image is black&white.Adult - detects if the image is pornographic in nature (depicts nudity or a sex act).  Sexually suggestive content is also detected.",
+      "type": "array",
+      "x-ms-parameter-location": "method",
+      "required": false,
+      "collectionFormat": "csv",
+      "items": {
+        "type": "string",
+        "x-nullable": false,
+        "x-ms-enum": {
+          "name": "VisualFeatureTypes",
+          "modelAsString": false
+        },
+        "enum": [
+          "ImageType",
+          "Faces",
+          "Adult",
+          "Categories",
+          "Color",
+          "Tags",
+          "Description"
+        ]
+      }
+    },
+    "OcrLanguage": {
+      "name": "language",
+      "in": "query",
+      "description": "The BCP-47 language code of the text to be detected in the image. The default value is 'unk'",
+      "type": "string",
+      "required": false,
+      "x-ms-parameter-location": "method",
+      "x-nullable": false,
+      "x-ms-enum": {
+        "name": "OcrLanguages",
+        "modelAsString": false
+      },
+      "default": "unk",
+      "enum": [
+        "unk",
+        "zh-Hans",
+        "zh-Hant",
+        "cs",
+        "da",
+        "nl",
+        "en",
+        "fi",
+        "fr",
+        "de",
+        "el",
+        "hu",
+        "it",
+        "ja",
+        "ko",
+        "nb",
+        "pl",
+        "pt",
+        "ru",
+        "es",
+        "sv",
+        "tr",
+        "ar",
+        "ro",
+        "sr-Cyrl",
+        "sr-Latn",
+        "sk"
+      ]
+    },
+    "DetectOrientation": {
+      "name": "detectOrientation",
+      "in": "query",
+      "description": "Whether detect the text orientation in the image. With detectOrientation=true the OCR service tries to detect the image orientation and correct it before further processing (e.g. if it's upside-down). ",
+      "required": true,
+      "x-ms-parameter-location": "method",
+      "type": "boolean",
+      "default": true
+    },
+    "HandwritingBoolean": {
+      "name": "detectHandwriting",
+      "in": "query",
+      "description": "If 'true' is specified, handwriting recognition is performed. If this parameter is set to 'false' or is not specified, printed text recognition is performed.",
+      "required": false,
+      "x-ms-parameter-location": "method",
+      "type": "boolean",
+      "default": false
+    },
+    "ServiceLanguage": {
+      "name": "language",
+      "in": "query",
+      "description": "The desired language for output generation. If this parameter is not specified, the default value is &quot;en&quot;.Supported languages:en - English, Default. es - Spanish, ja - Japanese, pt - Portuguese, zh - Simplified Chinese.",
+      "type": "string",
+      "required": false,
+      "x-ms-parameter-location": "method",
+      "x-nullable": false,
+      "default": "en",
+      "enum": [
+        "en",
+        "es",
+        "ja",
+        "pt",
+        "zh"
+      ]
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/parameters-external/readme.txt
+++ b/modules/swagger-parser/src/test/resources/parameters-external/readme.txt
@@ -1,0 +1,1 @@
+These files are from Microsoft Azure's GitHub repository https://github.com/Azure/azure-rest-api-specs MIT licensed.

--- a/modules/swagger-parser/src/test/resources/parameters-external/readme.txt
+++ b/modules/swagger-parser/src/test/resources/parameters-external/readme.txt
@@ -1,1 +1,1 @@
-These files are from Microsoft Azure's GitHub repository https://github.com/Azure/azure-rest-api-specs MIT licensed.
+The files in 'data-plane' are from Microsoft Azure's GitHub repository https://github.com/Azure/azure-rest-api-specs MIT licensed.

--- a/modules/swagger-parser/src/test/resources/parameters-external/simple/externals-level-0.json
+++ b/modules/swagger-parser/src/test/resources/parameters-external/simple/externals-level-0.json
@@ -1,0 +1,51 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Some Store"
+  },
+  "paths": {
+    "/path-1": {
+      "get": {
+        "parameters": [ 
+          { 
+            "$ref": "externals-level-1.json#/parameters/P-Level1Thing1" 
+          }          
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all the stuff."
+          }
+        }
+      }
+    },
+    "/path-2": {
+      "get": {
+        "parameters": [ 
+          { 
+            "$ref": "externals-level-1.json#/parameters/P-Level1Thing2" 
+          }          
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all the stuff."
+          }
+        }
+      }
+    },
+    "/path-3": {
+      "get": {
+        "parameters": [ 
+          { 
+            "$ref": "externals-level-1.json#/parameters/P-Level1Thing3" 
+          }          
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all the stuff."
+          }
+        }
+      }
+    }    
+  }
+}

--- a/modules/swagger-parser/src/test/resources/parameters-external/simple/externals-level-1.json
+++ b/modules/swagger-parser/src/test/resources/parameters-external/simple/externals-level-1.json
@@ -1,0 +1,42 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Pets Store"
+  },
+  "parameters": {
+    "P-Level1Thing1": {
+      "in": "body",
+      "name": "Level1Thing1",
+      "schema": {
+        "type": "string"
+      }
+    },
+    "P-Level1Thing2": {
+      "name": "Level1Thing2",
+      "in": "body",
+      "required": true,
+      "schema": {
+        "$ref": "#/definitions/D-Level1Thing3"
+      }
+    },
+    "P-Level1Thing3": {
+      "name": "Level1Thing3",
+      "in": "body",
+      "required": true,
+      "schema": {
+        "$ref": "externals-level-2.json#/parameters/P-Level2Thing3"
+      }
+    }
+  },
+  "definitions": {
+    "D-Level1Thing3": {
+      "name": "Level1Thing3",
+      "type": "string"
+    },
+    "D-Level1Thing4": {
+      "name": "Level1Thing4",
+      "type": "string"
+    }
+  }
+}

--- a/modules/swagger-parser/src/test/resources/parameters-external/simple/externals-level-2.json
+++ b/modules/swagger-parser/src/test/resources/parameters-external/simple/externals-level-2.json
@@ -1,0 +1,42 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Pets Store"
+  },
+  "parameters": {
+    "P-Level2Thing1": {
+      "in": "body",
+      "name": "Level2Thing1",
+      "schema": {
+        "type": "string"
+      }
+    },
+    "P-Level2Thing2": {
+      "name": "Level2Thing2",
+      "in": "body",
+      "required": true,
+      "schema": {
+        "$ref": "#/definitions/D-Level2Thing3"
+      }
+    },
+    "P-Level2Thing3": {
+      "name": "Level2Thing3",
+      "in": "body",
+      "required": true,
+      "schema": {
+        "$ref": "#/definitions/D-Level2Thing4"
+      }
+    }
+  },
+  "definitions": {
+    "D-Level2Thing3": {
+      "name": "Level2Thing3",
+      "type": "string"
+    },
+    "D-Level2Thing4": {
+      "name": "Level2Thing4",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
Issue 1299 external parameters broken in Swagger parser 1.0.49 for Swagger 2.0 specs.

See `io.swagger.parser.SwaggerParserTest.testExternalParameters()`
