### PR TITLE
#1305 fixing parsing of empty securityRequirement

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -421,7 +421,7 @@ public class SwaggerDeserializer {
                     if (s.getRequirements().size() > 0) {
                         ss.add(s.getRequirements());
                     } else {
-                        ss.add(Collections.singletonMap("none", Collections.<String>emptyList()));
+                        ss.add(Collections.<String, List<String>>emptyMap());
                     }
                 }
             }

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -417,8 +417,12 @@ public class SwaggerDeserializer {
         if(security != null) {
             List<Map<String, List<String>>> ss = new ArrayList<>();
             for(SecurityRequirement s : security) {
-                if(s.getRequirements() != null && s.getRequirements().size() > 0) {
-                    ss.add(s.getRequirements());
+                if(s.getRequirements() != null) {
+                    if (s.getRequirements().size() > 0) {
+                        ss.add(s.getRequirements());
+                    } else {
+                        ss.add(Collections.singletonMap("none", Collections.<String>emptyList()));
+                    }
                 }
             }
             output.setSecurity(ss);

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/SwaggerDeserializerTest.java
@@ -635,8 +635,7 @@ public class SwaggerDeserializerTest {
         assertTrue(security.size() == 2);
 
         Map<String, List<String>> requirement1 = security.get(0);
-        assertTrue(requirement1.containsKey("none"));
-        assertTrue(requirement1.get("none").isEmpty());
+        assertTrue(requirement1.isEmpty());
 
         Map<String, List<String>> requirement2 = security.get(1);
         assertTrue(requirement2.containsKey("petstore_auth"));


### PR DESCRIPTION
Because in the v1 library operation.getSecurity() doesn't return a list of SecurityRequirements cfr the top-level security field in the swagger file, I opted for adding an empty Map to the list to represent the none security requirement.

We need swagger-parser to retain the unsecured security requirement on an operation level. Now it is stripped