### PR TITLE
fix for issue #1335 - OAS3: Resolved YAML doesn't include Example components from domains

### DIFF
--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -2262,6 +2262,16 @@ public class OpenAPIV3ParserTest {
     }
 
     @Test
+    public void testIssue1335() {
+        final ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+
+        SwaggerParseResult result = new OpenAPIV3Parser()
+                .readLocation("src/test/resources/issue1335.yaml", null, options);
+        assertNotNull(result.getOpenAPI().getComponents().getExamples().get("ex1"));
+    }
+
+    @Test
     public void testRegressionIssue1236() {
         final ParseOptions options = new ParseOptions();
         options.setResolve(true);

--- a/modules/swagger-parser-v3/src/test/resources/domain-issue-1335.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/domain-issue-1335.yaml
@@ -1,0 +1,15 @@
+components:
+  responses:
+    200ok:
+      description: ok
+      content:
+        application/json:
+          schema:
+            type: string
+          examples:
+            ex1:
+              $ref: '#/components/examples/ex1'
+
+  examples:
+    ex1:
+      value: hello

--- a/modules/swagger-parser-v3/src/test/resources/issue1335.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue1335.yaml
@@ -1,0 +1,10 @@
+openapi: 3.0.2
+info:
+  title: Example references
+  version: 1.0.0
+paths:
+  /foo:
+    get:
+      responses:
+        '200':
+          $ref: './domain-issue-1335.yaml#/components/responses/200ok'


### PR DESCRIPTION
Fix for issue #1335 -  OAS3: Resolved YAML doesn't include Example components from domains