### PR TITLE
Add extension to keep track of original swagger version

### DIFF
--- a/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
+++ b/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
@@ -160,7 +160,7 @@ public class SwaggerConverter implements SwaggerParserExtension {
             openAPI.setExtensions(convert(swagger.getVendorExtensions()));
         }
         // Set extension to retain original version of OAS document.
-        openAPI.addExtension("x-original-version", swagger.getSwagger());
+        openAPI.addExtension("x-original-swagger-version", swagger.getSwagger());
 
         if (swagger.getExternalDocs() != null) {
             openAPI.setExternalDocs(convert(swagger.getExternalDocs()));

--- a/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
+++ b/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
@@ -159,6 +159,8 @@ public class SwaggerConverter implements SwaggerParserExtension {
         if (swagger.getVendorExtensions() != null) {
             openAPI.setExtensions(convert(swagger.getVendorExtensions()));
         }
+        // Set extension to retain original version of OAS document.
+        openAPI.addExtension("x-original-version", swagger.getSwagger());
 
         if (swagger.getExternalDocs() != null) {
             openAPI.setExternalDocs(convert(swagger.getExternalDocs()));


### PR DESCRIPTION
This is a proposed change to retain the original value of the "swagger" keyword when converting a OAS/Swagger 2.0 document to a 3.0 OAS document.