### PR TITLE
Fix for issue #1375

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -1727,10 +1727,7 @@ public class OpenAPIDeserializer {
         JsonNode example = node.get(nodeKey);
         if (example != null) {
             if (example.getNodeType().equals(JsonNodeType.STRING)) {
-                String value = getString(nodeKey, node, false, location, result);
-                if (StringUtils.isNotBlank(value)) {
-                    return value;
-                }
+                return getString(nodeKey, node, false, location, result);
             } if (example.getNodeType().equals(JsonNodeType.NUMBER)) {
                 Integer integerExample = getInteger(nodeKey, node, false, location, result);
                 if (integerExample != null) {

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -2327,6 +2327,26 @@ public class OpenAPIV3ParserTest {
     }
 
     @Test
+    public void testEmptyQueryParameterExample() {
+        final ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+
+        SwaggerParseResult result = new OpenAPIV3Parser()
+                .readLocation("src/test/resources/emptyQueryParameter.yaml", null, options);
+        assertEquals("", result.getOpenAPI().getPaths().get("/foo").getGet().getParameters().get(0).getExample());
+    }
+
+    @Test
+    public void testBlankQueryParameterExample() {
+        final ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+
+        SwaggerParseResult result = new OpenAPIV3Parser()
+                .readLocation("src/test/resources/blankQueryParameter.yaml", null, options);
+        assertEquals(" ", result.getOpenAPI().getPaths().get("/foo").getGet().getParameters().get(0).getExample());
+    }
+
+    @Test
     public void testRegressionIssue1236() {
         final ParseOptions options = new ParseOptions();
         options.setResolve(true);

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/OpenAPIDeserializerTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/OpenAPIDeserializerTest.java
@@ -2384,7 +2384,7 @@ public class OpenAPIDeserializerTest {
         Assert.assertEquals(petByStatusEndpoint.getGet().getParameters().get(0).getContent().get("text/plain").getExamples().get("list").getSummary(),"List of names");
         Assert.assertEquals(petByStatusEndpoint.getGet().getParameters().get(0).getContent().get("text/plain").getExamples().get("list").getValue(),"Bob,Diane,Mary,Bill");
         Assert.assertEquals(petByStatusEndpoint.getGet().getParameters().get(0).getContent().get("text/plain").getExamples().get("empty").getSummary(),"Empty");
-        Assert.assertNull(petByStatusEndpoint.getGet().getParameters().get(0).getContent().get("text/plain").getExamples().get("empty").getValue());
+        Assert.assertEquals(petByStatusEndpoint.getGet().getParameters().get(0).getContent().get("text/plain").getExamples().get("empty").getValue(),"");
 
         PathItem petEndpoint = paths.get("/pet");
         Assert.assertNotNull(petEndpoint.getPut());

--- a/modules/swagger-parser-v3/src/test/resources/blankQueryParameter.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/blankQueryParameter.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.2
+info:
+  title: Example references
+  version: 1.0.0
+paths:
+  /foo:
+    get:
+      parameters:
+        - name: paramName
+          in: query
+          example: " "
+      responses:
+        '200':
+          description: success

--- a/modules/swagger-parser-v3/src/test/resources/emptyQueryParameter.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/emptyQueryParameter.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.2
+info:
+  title: Example references
+  version: 1.0.0
+paths:
+  /foo:
+    get:
+      parameters:
+        - name: paramName
+          in: query
+          example: ""
+      responses:
+        '200':
+          description: success


### PR DESCRIPTION
Empty and blank query parameter examples were parsed to null.
Now they are parsed to an empty and blank string respectively.

Fixes #1375 