### PR TITLE
Fix and test for Parser cannot process 'allOf' correctly - issue #1367

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
@@ -9,12 +9,7 @@ import io.swagger.v3.oas.models.callbacks.Callback;
 import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.links.Link;
-import io.swagger.v3.oas.models.media.ArraySchema;
-import io.swagger.v3.oas.models.media.ComposedSchema;
-import io.swagger.v3.oas.models.media.MapSchema;
-import io.swagger.v3.oas.models.media.MediaType;
-import io.swagger.v3.oas.models.media.ObjectSchema;
-import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.*;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
@@ -462,6 +457,9 @@ public class ResolverFully {
                         }
                     }
                 }
+            }
+            if (resolved.getEnum() != null ){
+                targetSchema.setEnum(resolved.getEnum());
             }
             if (resolved.getExample() != null) {
                 examples.add(resolved.getExample());

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -84,6 +84,19 @@ public class OpenAPIV3ParserTest {
 
 
     @Test
+    public void testIssue1367() {
+        OpenAPIV3Parser openApiParser = new OpenAPIV3Parser();
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        options.setResolveCombinators(true);
+        options.setResolveFully(true);
+        options.setFlatten(true);
+        SwaggerParseResult parseResult = openApiParser.readLocation("issue-1367.yaml", null, options);
+        OpenAPI openAPI = parseResult.getOpenAPI();
+        assertTrue(((Schema)openAPI.getComponents().getSchemas().get("TestDTO").getProperties().get("choice")).getEnum() != null);
+    }
+
+    @Test
     public void testIssueFlattenAdditionalPropertiesSchemaInlineModelTrue() {
         OpenAPIV3Parser openApiParser = new OpenAPIV3Parser();
         ParseOptions options = new ParseOptions();
@@ -99,7 +112,6 @@ public class OpenAPIV3ParserTest {
         assertEquals(((ComposedSchema)openAPI.getComponents().getSchemas().get("Inline_response_map200")).getOneOf().get(0).get$ref(),"#/components/schemas/Macaw1");
         assertNotNull(openAPI.getComponents().getSchemas().get("Inline_response_map_items404"));
         assertEquals(((ComposedSchema)openAPI.getComponents().getSchemas().get("Inline_response_map_items404")).getAnyOf().get(0).get$ref(),"#/components/schemas/Macaw2");
-
     }
 
 

--- a/modules/swagger-parser-v3/src/test/resources/issue-1367.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1367.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+servers:
+  - url: /subscribed_products/v1.0.1
+info:
+  description: >-
+    API to get information on services currently subscribed by a specific user
+    or phone number.
+  version: 1.0.1
+  title: Products API definition for the 4th Platform
+  termsOfService: 'https://www.telefonica.es/es/'
+  contact:
+    name: 4th Platform Team
+    email: 4pf@tid.es
+x-fp-apiPrefix: /subscribed_products
+tags:
+  - name: subscribed_products
+    description: Operations available with products subscribed by a user
+paths:
+  '/TestDTO':
+    get:
+      operationId: description
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestDTO'
+components:
+  schemas:
+    TestDTO:
+      required:
+        - choice
+      type: object
+      properties:
+        choice:
+          description: Choice description
+          allOf:
+            - $ref: '#/components/schemas/TestEnum'
+    TestEnum:
+      type: string
+      enum:
+        - One
+        - Two
+        - Three


### PR DESCRIPTION
Fix and test for Parser cannot process 'allOf' correctly - issue #1367.

Changed in the ResolveFully Class, added the enum to the resolved final schema.