### PR TITLE
fix NPE when URL matcher is null in Remote Url

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/RemoteUrl.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/RemoteUrl.java
@@ -115,11 +115,13 @@ public class RemoteUrl {
                 final List<AuthorizationValue> header = new ArrayList<>();
                 if (auths != null && auths.size() > 0) {
                     for (AuthorizationValue auth : auths) {
-                        if (auth.getUrlMatcher().test(inUrl)) {
-                            if ("query".equals(auth.getType())) {
-                                appendValue(inUrl, auth, query);
-                            } else if ("header".equals(auth.getType())) {
-                                appendValue(inUrl, auth, header);
+                        if (auth.getUrlMatcher()!= null) {
+                            if (auth.getUrlMatcher().test(inUrl)) {
+                                if ("query".equals(auth.getType())) {
+                                    appendValue(inUrl, auth, query);
+                                } else if ("header".equals(auth.getType())) {
+                                    appendValue(inUrl, auth, header);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
fix NPE when URL matcher is null in Remote Url