### PR TITLE
When parameter style is invalid, return a helpful message instead of throwing an NPE

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -1561,7 +1561,7 @@ public class OpenAPIDeserializer {
         Boolean explode = getBoolean("explode", obj, false, location, result);
         if (explode != null) {
             parameter.setExplode(explode);
-        } else if(parameter.getStyle().equals(StyleEnum.FORM)){
+        } else if(StyleEnum.FORM.equals(parameter.getStyle())){
             parameter.setExplode(Boolean.TRUE);
         } else {
             parameter.setExplode(Boolean.FALSE);
@@ -2666,7 +2666,7 @@ public class OpenAPIDeserializer {
             } else if (value.equals(Parameter.StyleEnum.SPACEDELIMITED.toString())) {
                 parameter.setStyle(Parameter.StyleEnum.SPACEDELIMITED);
             } else {
-                result.invalidType(location, "style", "string", obj);
+                result.invalidType(location, "style", "StyleEnum", obj);
             }
         }
     }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/OpenAPIDeserializerTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/OpenAPIDeserializerTest.java
@@ -1173,6 +1173,56 @@ public class OpenAPIDeserializerTest {
     }
 
     @Test
+    public void testStyleInvalid() {
+        String json =
+            "{"
+            + "    \"openapi\": \"3.0.0\","
+            + "    \"info\": {"
+            + "        \"title\": \"realize\","
+            + "        \"version\": \"0.0.0\""
+            + "    },"
+            + "    \"paths\": {"
+            + "        \"/realize/{param}\": {"
+            + "            \"post\": {"
+            + "                \"parameters\": ["
+            + "                    {"
+            + "                        \"name\": \"param\","
+            + "                        \"in\": \"path\","
+            + ""
+            + "                        \"style\": \"DERP\","
+            + "                        \"required\": true,"
+            + ""
+            + "                        \"schema\": {"
+            + "                            \"type\": \"string\","
+            + "                            \"nullable\": false,"
+            + "                            \"minLength\": 1"
+            + "                        }"
+            + "                    }"
+            + "                ],"
+            + "                \"responses\": {"
+            + "                    \"200\": {"
+            + "                        \"description\": \"Success\","
+            + "                        \"content\": {"
+            + "                            \"application/json\": {"
+            + "                                \"schema\": {"
+            + "                                    \"type\": \"object\""
+            + "                                }"
+            + "                            }"
+            + "                        }"
+            + "                    }"
+            + "                }"
+            + "            }"
+            + "        }"
+            + "    }"
+            + "}"
+            ;
+        OpenAPIV3Parser parser = new OpenAPIV3Parser();
+        SwaggerParseResult result = parser.readContents(json, null, null);
+        assertTrue(result.getMessages().size() == 1);
+        assertEquals(result.getMessages().get(0), "attribute paths.'/realize/{param}'(post).parameters.[param].style is not of type `StyleEnum`");
+    }
+
+    @Test
     public void testDeserializeWithMessages() {
         String yaml = "openapi: '3.0.0'\n" +
                 "info:\n" +


### PR DESCRIPTION
This fixes the NPE (see issue #1409) and also alters the resulting error message to more accurately describe the problem.