### PR TITLE
adding redirect response codes to remote url

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/RemoteUrl.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/RemoteUrl.java
@@ -150,7 +150,8 @@ public class RemoteUrl {
                 conn.setRequestProperty("User-Agent", USER_AGENT_HEADER_VALUE);
                 conn.connect();
                 url = ((HttpURLConnection) conn).getHeaderField("Location");
-            } while (301 == ((HttpURLConnection) conn).getResponseCode());
+            } while ((301 == ((HttpURLConnection) conn).getResponseCode())||(302 == ((HttpURLConnection) conn).getResponseCode())
+                    || (307 == ((HttpURLConnection) conn).getResponseCode())||(308 == ((HttpURLConnection) conn).getResponseCode()));
             InputStream in = conn.getInputStream();
 
             StringBuilder contents = new StringBuilder();

--- a/modules/swagger-parser-v3/src/test/resources/relativeTest.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/relativeTest.yaml
@@ -1,0 +1,10 @@
+RelativeObj:
+  type: object
+  properties:
+    lorem:
+      type: object
+      properties:
+        firstName:
+          type: string
+        lastName:
+          type: string


### PR DESCRIPTION
When loading API definitions from a URL, the parser only handles 301 redirects
https://github.com/swagger-api/swagger-parser/blob/master/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/RemoteUrl.java#L153
and cannot handle other 3xx redirects - 302, 303, etc.