### PR TITLE
Handle multipleOf between 0 and 1

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -2189,7 +2189,7 @@ public class OpenAPIDeserializer {
 
         BigDecimal bigDecimal = getBigDecimal("multipleOf",node,false,location,result);
         if(bigDecimal != null) {
-            if(bigDecimal.intValue() > 0) {
+            if(bigDecimal.compareTo(BigDecimal.ZERO) > 0) {
                 schema.setMultipleOf(bigDecimal);
             }else{
                 result.warning(location,"multipleOf value must be > 0");

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/OpenAPIParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/OpenAPIParserTest.java
@@ -14,6 +14,8 @@ import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import io.swagger.v3.core.util.Json;
+import java.math.BigDecimal;
+import java.math.MathContext;
 import org.junit.Test;
 import org.testng.Assert;
 
@@ -587,6 +589,32 @@ public class OpenAPIParserTest {
 
         final Object baz = inputProperties.get("baz");
         assertEquals(baz.getClass(), StringSchema.class);
+    }
+
+    @Test
+    public void testMultipleOfBetweenZeroAndOne() {
+        String spec =
+                "openapi: 3.0.0\n" +
+                "info:\n" +
+                "  version: 0.0.0\n" +
+                "  title: \"test\"\n" +
+                "components:\n" +
+                "  schemas:\n" +
+                "    Test:\n" +
+                "      type: object\n" +
+                "      properties:\n" +
+                "        decimal_value:\n" +
+                "          type: number\n" +
+                "          multipleOf: 0.3\n";
+
+        OpenAPIParser openApiParser = new OpenAPIParser();
+        ParseOptions options = new ParseOptions();
+
+        OpenAPI openAPI = openApiParser.readContents(spec, null, options).getOpenAPI();
+        ObjectSchema schema = (ObjectSchema) openAPI.getComponents().getSchemas().get("Test");
+        Schema decimalValue = schema.getProperties().get("decimal_value");
+        BigDecimal multipleOf = decimalValue.getMultipleOf();
+        assertEquals(multipleOf, new BigDecimal("0.3", new MathContext(multipleOf.precision())));
     }
 }
 


### PR DESCRIPTION
This pull request fixes handling of `multipleOf` between 0 and 1, as specified in #1457. I've also added a test case for this specific scenario.

The existing code would call `intValue()`, which involves rounding. When that would happen, low values would round to 0, failing the ensuing test.

P.S.: Getting to the `else` branch trigger a `NullPointerException` because `result` is `null`. I haven't tried to fix that issue as I believe it would be a completely different beast.