### PR TITLE
read required elements in composed models.

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -1022,6 +1022,22 @@ public class SwaggerDeserializer {
 
             addProperties(location, node, result, model);
 
+            // need to set properties first
+            ArrayNode required = getArray("required", node, false, location, result);
+            if (required != null) {
+                List<String> requiredProperties = new ArrayList<String>();
+                for (JsonNode n : required) {
+                    if (n.getNodeType().equals(JsonNodeType.STRING)) {
+                        requiredProperties.add(((TextNode) n).textValue());
+                    } else {
+                        result.invalidType(location, "required", "string", n);
+                    }
+                }
+                if (requiredProperties.size() > 0) {
+                    model.setRequired(requiredProperties);
+                }
+            }
+
             return model;
         }
         return null;

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -1658,4 +1658,18 @@ public class SwaggerParserTest {
 
 
     }
+
+    @Test
+    public void testRequiredItemsInComposedModel() {
+        SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("src/test/resources/allOf-example/allOf.yaml", null, true);
+        assertNotNull(result);
+        final Swagger swagger = result.getSwagger();
+        final Model model = swagger.getDefinitions().get("UserRegister");
+        final ComposedModel composedModel = (ComposedModel) model;
+
+        assertNotNull(composedModel.getRequired());
+        assertFalse(composedModel.getRequired().isEmpty());
+
+        assertEquals("password", composedModel.getRequired().get(0));
+    }
 }

--- a/modules/swagger-parser/src/test/resources/allOf-example/allOf.yaml
+++ b/modules/swagger-parser/src/test/resources/allOf-example/allOf.yaml
@@ -1,0 +1,44 @@
+swagger: '2.0'
+info:
+  description: This is a simple API
+  version: 1.0.0
+  title: Simple User API
+host: localhost
+basePath: /v1
+schemes:
+  - https
+
+paths:
+  /user:
+    post:
+      consumes:
+        - application/json
+      produces:
+        - application/jsonÅÅÅ
+      parameters:
+        - in: body
+          name: checkUser
+          description: Check user
+          schema:
+            $ref: '#/definitions/User'
+      responses:
+        201:
+          description: item created
+
+definitions:
+  User:
+    type: object
+    required:
+      - email
+    properties:
+      email:
+        type: string
+  UserRegister:
+    allOf:
+      - $ref: '#/definitions/User'
+    type: object
+    required:
+      - password
+    properties:
+      password:
+        type: string


### PR DESCRIPTION
Required properties are not properly read from a composed schema, for example, in this example:

```yaml
definitions:
  User:
    type: object
    required:
      - email
    properties:
      email:
        type: string
  UserRegister:
    allOf:
      - $ref: '#/definitions/User'
    type: object
    required:
      - password
    properties:
      password:
        type: string
```

the required property `password` is not found when i call:

```java
final Model model = swagger.getDefinitions().get("UserRegister");
final ComposedModel composedModel = (ComposedModel) model;

composedModel.getRequired(); // empty or null
```

This issue is affecting `swagger-codegen` reported at https://github.com/swagger-api/swagger-codegen/issues/7058


