### PR TITLE
Fix issue #1501: External schema name is correctly constructed

### DIFF
--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
@@ -777,7 +777,8 @@ public class OpenAPIResolverTest {
         assertEquals("referred", ((Schema)openAPI.getPaths().get("/oldPerson").getPost().getResponses().get("200").getContent().get("*/*").getSchema().getProperties().get("location")).getExample());
         assertEquals("referred", ((Schema)openAPI.getPaths().get("/yetAnotherPerson").getPost().getResponses().get("200").getContent().get("*/*").getSchema().getProperties().get("location")).getExample());
         assertEquals("local", ((Schema) openAPI.getComponents().getSchemas().get("PersonObj").getProperties().get("location")).getExample());
-        assertEquals("referred", ((Schema) openAPI.getComponents().getSchemas().get("PersonObj_2").getProperties().get("location")).getExample());
+        assertEquals("referred", ((Schema) openAPI.getComponents().getSchemas().get("PersonObj_1").getProperties().get("location")).getExample());
+        assertEquals("referred-again", ((Schema) openAPI.getComponents().getSchemas().get("PersonObj_2").getProperties().get("location")).getExample());
     }
 
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -1082,7 +1082,7 @@ public class OpenAPIV3ParserTest {
         Schema pet = openAPI.getComponents().getSchemas().get("Pet");
         Assert.assertNotNull(pet);
         Assert.assertTrue(pet.getDiscriminator().getMapping().containsKey("Cat"));
-        Assert.assertTrue(pet.getDiscriminator().getMapping().get("Cat").equals("#/components/schemas/Cat_2"));
+        Assert.assertTrue(pet.getDiscriminator().getMapping().get("Cat").equals("#/components/schemas/Cat_1"));
     }
 
     @Test
@@ -1687,7 +1687,7 @@ public class OpenAPIV3ParserTest {
 
         assertEquals(composedCat.getAllOf().size(), 3);
         assertEquals(composedCat.getAllOf().get(0).get$ref(), "#/components/schemas/pet");
-        assertEquals(composedCat.getAllOf().get(1).get$ref(), "#/components/schemas/foo_2");
+        assertEquals(composedCat.getAllOf().get(1).get$ref(), "#/components/schemas/foo_1");
 
         return openAPI;
     }

--- a/modules/swagger-parser-v3/src/test/resources/refs-name-conflict/a.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/refs-name-conflict/a.yaml
@@ -38,6 +38,17 @@ paths:
             '*/*':
               schema:
                 $ref: './refs-name-conflict/b.yaml#/components/schemas/PersonObj'
+  /thisAintAnotherPerson:
+    post:
+      summary: Create no more persons
+      description: Create no more persons
+      responses:
+        '200':
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: './refs-name-conflict/c.yaml#/components/schemas/PersonObj'
 components:
   schemas:
     PersonObj:

--- a/modules/swagger-parser-v3/src/test/resources/refs-name-conflict/c.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/refs-name-conflict/c.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.1
+servers: []
+info:
+  version: ''
+  title: ''
+paths: {}
+components:
+  schemas:
+    PersonObj:
+      properties:
+        location:
+          type: string
+          example: referred-again


### PR DESCRIPTION
Calculation of schema name in external ref processor takes into account that more than 2 schemas may have the same name.
The counting of schemas starts from `1` instead of `2`.

Note: the warn level of the logger in line 62 seemed too high for a normal operation so I lowered it. Let me know if you think it was `warn` for an abnormal operation.

Closes #1501 