### PR TITLE
#SWOS-242: test cases for ClassCastException when resolving external refs

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ResolverCache.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ResolverCache.java
@@ -3,6 +3,7 @@ package io.swagger.v3.parser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
@@ -107,7 +108,13 @@ public class ResolverCache {
         Object previouslyResolvedEntity = resolutionCache.get(ref);
 
         if (previouslyResolvedEntity != null) {
-            return expectedType.cast(previouslyResolvedEntity);
+            if(expectedType.equals(Header.class)){
+                if (expectedType.getClass().equals(previouslyResolvedEntity.getClass())) {
+                    return expectedType.cast(previouslyResolvedEntity);
+                }
+            }else {
+                return expectedType.cast(previouslyResolvedEntity);
+            }
         }
 
         //we have not resolved this particular ref

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -98,8 +98,11 @@ public class OpenAPIV3ParserTest {
         OpenAPIV3Parser parser = new OpenAPIV3Parser();
         ParseOptions options = new ParseOptions();
         options.setResolve(true);
+        options.setResolveFully(true);
 
         final SwaggerParseResult openAPI = parser.readContents(pathFile, null, options);
+        Yaml.prettyPrint(openAPI);
+
         assertEquals(openAPI.getMessages().size(), 0);
     }
 
@@ -108,8 +111,10 @@ public class OpenAPIV3ParserTest {
         OpenAPIV3Parser parser = new OpenAPIV3Parser();
         ParseOptions options = new ParseOptions();
         options.setResolve(true);
+        options.setResolveFully(true);
 
         final SwaggerParseResult openAPI = parser.readLocation("src/test/resources/same-refs-different-model-valid.yaml", null, options);
+        Yaml.prettyPrint(openAPI);
         assertEquals(openAPI.getMessages().size(), 0);
     }
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -83,6 +83,37 @@ public class OpenAPIV3ParserTest {
     protected WireMockServer wireMockServer;
 
     @Test
+    public void testIssueSameRefsDifferentModel() throws IOException {
+        String pathFile = FileUtils.readFileToString(new File("src/test/resources/same-refs-different-model-domain.yaml"), "UTF-8");
+        WireMock.stubFor(get(urlPathMatching("/issue-domain"))
+                .willReturn(aResponse()
+                        .withStatus(HttpURLConnection.HTTP_OK)
+                        .withHeader("Content-type", "application/json")
+                        .withBody(pathFile
+                                .getBytes(StandardCharsets.UTF_8))));
+
+        pathFile = FileUtils.readFileToString(new File("src/test/resources/same-refs-different-model.yaml"), "UTF-8");
+        pathFile = pathFile.replace("${dynamicPort}", String.valueOf(this.serverPort));
+
+        OpenAPIV3Parser parser = new OpenAPIV3Parser();
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+
+        final SwaggerParseResult openAPI = parser.readContents(pathFile, null, options);
+        assertEquals(openAPI.getMessages().size(), 0);
+    }
+
+    @Test
+    public void testIssueSameRefsDifferentModelValid() {
+        OpenAPIV3Parser parser = new OpenAPIV3Parser();
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+
+        final SwaggerParseResult openAPI = parser.readLocation("src/test/resources/same-refs-different-model-valid.yaml", null, options);
+        assertEquals(openAPI.getMessages().size(), 0);
+    }
+
+    @Test
     public void testIssue1398() {
         ParseOptions options = new ParseOptions();
         SwaggerParseResult result = new OpenAPIV3Parser().readLocation("issue1398.yaml", null, options);

--- a/modules/swagger-parser-v3/src/test/resources/same-refs-different-model-domain.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/same-refs-different-model-domain.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.0
+
+components:
+  parameters:
+    requestid:
+      name: X-requestid
+      in: header
+      required: false
+      schema:
+        type: string
+        format: uuid

--- a/modules/swagger-parser-v3/src/test/resources/same-refs-different-model-valid.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/same-refs-different-model-valid.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: issue
+  version: 1.0.01
+
+paths:
+  /bar:
+    parameters:
+      - $ref: '#/components/parameters/requestid'
+    delete:
+      responses:
+        '204':
+          description: Deleted
+          headers:
+            X-requestid:
+              $ref: '#/components/parameters/requestid'
+
+components:
+  parameters:
+    requestid:
+      name: X-requestid
+      in: header
+      required: false
+      schema:
+        type: string
+        format: uuid

--- a/modules/swagger-parser-v3/src/test/resources/same-refs-different-model.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/same-refs-different-model.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  title: issue
+  version: 1.0.01
+
+paths:
+  /bar:
+    parameters:
+      - $ref: 'http://localhost:${dynamicPort}/issue-domain/#/components/parameters/requestid'
+    delete:
+      responses:
+        '204':
+          description: Deleted
+          headers:
+            X-requestid:
+              $ref: 'http://localhost:${dynamicPort}/issue-domain/#/components/parameters/requestid'


### PR DESCRIPTION
I'm facing `java.lang.ClassCastException` when my specification has two similar $refs for different models. When $refs point to components from the same specification everything works fine.

`
java.lang.ClassCastException: Cannot cast io.swagger.v3.oas.models.parameters.HeaderParameter to io.swagger.v3.oas.models.headers.Header
	at java.base/java.lang.Class.cast(Class.java:3816)
	at io.swagger.v3.parser.ResolverCache.loadRef(ResolverCache.java:110)
	at io.swagger.v3.parser.processors.ExternalRefProcessor.processRefToExternalHeader(ExternalRefProcessor.java:455)
	at io.swagger.v3.parser.processors.HeaderProcessor.processHeader(HeaderProcessor.java:42)
	at io.swagger.v3.parser.processors.ResponseProcessor.processResponse(ResponseProcessor.java:66)
	at io.swagger.v3.parser.processors.OperationProcessor.processOperation(OperationProcessor.java:67)
	at io.swagger.v3.parser.processors.PathsProcessor.processPaths(PathsProcessor.java:84)
	at io.swagger.v3.parser.OpenAPIResolver.resolve(OpenAPIResolver.java:49)
	at io.swagger.v3.parser.OpenAPIV3Parser.resolve(OpenAPIV3Parser.java:175)
	at io.swagger.v3.parser.OpenAPIV3Parser.readContents(OpenAPIV3Parser.java:154)
	at io.swagger.v3.parser.OpenAPIV3Parser.readContents(OpenAPIV3Parser.java:99)
`
