### PR TITLE
Fix URISyntaxException for $ref to path with param

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -864,7 +864,7 @@ public final class ExternalRefProcessor {
         if (schema.get$ref() != null) {
             RefFormat ref = computeRefFormat(schema.get$ref());
             if (isAnExternalRefFormat(ref)) {
-                processRefSchema(schema, $ref);
+                processRefSchema(schema, file);
             } else {
                 processRefToExternalSchema(file + schema.get$ref(), RefFormat.RELATIVE);
             }


### PR DESCRIPTION
In case $ref refers to path with parameter, using whole $ref in processRefSchema as externalFile argument results in URISyntaxException

java.net.URISyntaxException: Illegal character in fragment at index 49: ../v1/checkout.yml#/paths/~1checkout~1orderItem~1{orderItemId}
	at java.base/java.net.URI$Parser.fail(URI.java:2915)
	at java.base/java.net.URI$Parser.checkChars(URI.java:3086)
	at java.base/java.net.URI$Parser.parse(URI.java:3130)
	at java.base/java.net.URI.<init>(URI.java:600)
	at io.swagger.v3.parser.processors.ExternalRefProcessor.join(ExternalRefProcessor.java:977)
	at io.swagger.v3.parser.processors.ExternalRefProcessor.constructRef(ExternalRefProcessor.java:928)
	at io.swagger.v3.parser.processors.ExternalRefProcessor.processRefSchema(ExternalRefProcessor.java:918)
	at io.swagger.v3.parser.processors.ExternalRefProcessor.processRefSchemaObject(ExternalRefProcessor.java:867)
	at io.swagger.v3.parser.processors.ExternalRefProcessor.processRefToExternalPathItem(ExternalRefProcessor.java:280)
	at io.swagger.v3.parser.processors.PathsProcessor.processReferencePath(PathsProcessor.java:299)
	at io.swagger.v3.parser.processors.PathsProcessor.processPaths(PathsProcessor.java:63)
	at io.swagger.v3.parser.OpenAPIResolver.resolve(OpenAPIResolver.java:49)

Using only file part (without fragment) produces expected result.