### PR TITLE
fix schemas parse inconsistencies

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -1199,7 +1199,7 @@ public class SwaggerDeserializer {
                     result.invalidType(location, "$ref", "string", node);
                 }
             } else {
-                output.responseSchema(Json.mapper().convertValue(schema, Model.class));
+                output.responseSchema(definition(schema, location + ".schema", result));
             }
 
         }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -1667,6 +1667,39 @@ public class SwaggerParserTest {
     }
 
     @Test
+    public void testIssue1541() {
+        SwaggerParser parser = new SwaggerParser();
+        final Swagger swagger = parser.read("src/test/resources/issue-1541/main.yaml");
+        assertNotNull(swagger);
+
+        Model inlineSchema = swagger.getPaths()
+                .get("/inline_response")
+                .getGet()
+                .getResponses()
+                .get("200")
+                .getResponseSchema();
+
+        assertNotNull(inlineSchema);
+        assertNotNull(inlineSchema.getProperties());
+        assertNotNull(inlineSchema.getProperties().get("a"));
+        assertEquals("number", inlineSchema.getProperties().get("a").getType());
+
+        Model responseRef = swagger.getPaths()
+                .get("/ref_response")
+                .getGet()
+                .getResponses()
+                .get("200")
+                .getResponseSchema();
+
+        assertEquals("#/definitions/ref_response_object", responseRef.getReference());
+
+        Model refSchema = swagger.getDefinitions()
+                .get("ref_response_object");
+
+        assertEquals("number", refSchema.getProperties().get("a").getType());
+    }
+
+    @Test
     public void testRequiredItemsInComposedModel() {
         SwaggerDeserializationResult result = new SwaggerParser().readWithInfo("src/test/resources/allOf-example/allOf.yaml", null, true);
         assertNotNull(result);

--- a/modules/swagger-parser/src/test/resources/issue-1541/main.yaml
+++ b/modules/swagger-parser/src/test/resources/issue-1541/main.yaml
@@ -1,0 +1,38 @@
+swagger: '2.0'
+info:
+  title: 'Issue 1541'
+  version: '1.0'
+consumes:
+  - application/json
+paths:
+  /inline_response:
+    get:
+      responses:
+        '200':
+          description: ok
+          schema:
+            type: object
+            additionalProperties: false
+            properties:
+              a:
+                type: number
+  /ref_response:
+    get:
+      responses:
+        '200':
+          description: ok
+          schema:
+            $ref: '#/definitions/ref_response_object'
+definitions:
+  ref_response_object:
+    type: object
+    additionalProperties: false
+    properties:
+      a:
+        type: number
+      b:
+        type: object
+        additionalProperties: false
+        properties:
+          c: { type: number }
+          d: { type: string }


### PR DESCRIPTION
schemas an of inline responses are parsed different from ones in definitions.

This manifests it's self as a bug in the generator: https://github.com/OpenAPITools/openapi-generator/issues/9086 where `additionalProperties` behaves differently if it's in a response in-line or in definitions.