### PR TITLE
external $ref without / caused exception

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -110,7 +110,11 @@ public final class ExternalRefProcessor {
                 RefFormat ref = computeRefFormat(schema.get$ref());
                 if (isAnExternalRefFormat(ref)) {
                     String schemaFullRef = schema.get$ref();
-                    String parent = file.substring(0, file.lastIndexOf(File.separatorChar));
+                    String parent = "";
+                    int i = file.lastIndexOf('/');
+                    if (i >= 0) {
+                        parent = file.substring(0, i);
+                    }
                     if (!parent.isEmpty()) {
                         schemaFullRef = Paths.get(parent, schemaFullRef).normalize().toString();
                     }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -2729,4 +2729,17 @@ public class OpenAPIV3ParserTest {
         Assert.assertNotNull(cat);
     }
 
+    // Relative external refs failed on windows due to \ issue
+    @Test
+    public void testRelativePathIssue1543() {
+        OpenAPIV3Parser parser = new OpenAPIV3Parser();
+        ParseOptions options = new ParseOptions();
+        options.setResolveFully(true);
+        options.setResolve(true);
+        SwaggerParseResult readResult = parser.readLocation("src/test/resources/issue-1543/openapi.yaml", null, options);
+
+        if (readResult.getMessages().size() > 0) {
+        	Assert.assertFalse(readResult.getMessages().get(0).contains("end -1"));
+        }
+    }
 }

--- a/modules/swagger-parser-v3/src/test/resources/issue-1543/openapi.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1543/openapi.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.1
+info:
+  title: Innotech API backend
+  description: >
+    API for the Innotech backend
+  version: 1.0.0
+
+paths:
+
+  ## Miscellaneous ###################################################################
+  "/misc/ping":
+    get:
+      tags:
+        - Ping
+      operationId: getPing
+      parameters:
+        - in: query
+          name: param
+          schema:
+            type: string
+            maxLength: 255
+          required: true
+      responses:
+        "200":
+          description: Ping response
+          content:
+            application/json:
+              schema:
+                $ref: "schemas/_index.yaml#/pingResponse"

--- a/modules/swagger-parser-v3/src/test/resources/issue-1543/schemas/PingResponse.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1543/schemas/PingResponse.yaml
@@ -1,0 +1,6 @@
+# schemas/PingResponse.yaml
+type: object
+properties:
+  answer:
+    type: string
+    maxLength: 255

--- a/modules/swagger-parser-v3/src/test/resources/issue-1543/schemas/_index.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1543/schemas/_index.yaml
@@ -1,0 +1,3 @@
+# schemas/_index.yaml
+pingResponse:
+  $ref: 'PingResponse.yaml'


### PR DESCRIPTION

Fixes #1543
... subtring(0, indexOf ... causes StringIndexOutOfBounds if the char searched for is missing. This meant that refs like $ref("another_file.json#/thing") could not be parsed. In addition, File.sparatorChar was used to find separators in directory part of ref, causing most every parsing attempt to fail on windows. We should probably require "/" to be used as path separator.