### PR TITLE
Issue 1552: Deserializer should use definition to map schema in a response

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/SwaggerDeserializer.java
@@ -1199,7 +1199,19 @@ public class SwaggerDeserializer {
                     result.invalidType(location, "$ref", "string", node);
                 }
             } else {
-                output.responseSchema(Json.mapper().convertValue(schema, Model.class));
+                String l = null;
+                JsonNode ln = schema.get("name");
+                if (ln != null) {
+                    l = ln.asText();
+                } else {
+                    l = "['unknown']";
+                }
+                location += ".[" + l + "]";
+
+                Model model = definition(schema, location, result);
+                if (model != null) {
+                    output.responseSchema(model);
+                }
             }
 
         }

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/SwaggerParserTest.java
@@ -1715,4 +1715,17 @@ public class SwaggerParserTest {
         assertTrue(userAddress.getProperties().containsKey("city"));
         assertTrue(userAddress.getProperties().containsKey("street"));
     }
+
+    @Test
+    public void testIssue1552() throws Exception {
+        Swagger swagger = new SwaggerParser().read("src/test/resources/issue1552.yaml");
+
+        Assert.assertNotNull(swagger);
+        Assert.assertNotNull(swagger.getResponses().get("Response"));
+        Assert.assertNotNull(swagger.getResponses().get("Response").getResponseSchema().getProperties());
+        Assert.assertNotNull(swagger.getResponses().get("Response").getResponseSchema().getProperties().get("Report"));
+
+
+    }
+
 }

--- a/modules/swagger-parser/src/test/resources/issue1552.yaml
+++ b/modules/swagger-parser/src/test/resources/issue1552.yaml
@@ -1,0 +1,34 @@
+swagger: '2.0'
+info:
+  title: Some API
+  description: >-
+    This is the Som Api
+  version: 2.0.0
+basePath: /somepath
+schemes:
+  - https
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /somepath:
+    get:
+      description: >
+        my description
+      operationId: MyGet
+      responses:
+        '200':
+          $ref: '#/responses/Response'
+responses:
+  Response:
+    description: Response
+    schema:
+      type: object
+      required:
+        - Report
+      properties:
+        Report:
+          type: string
+      additionalProperties: false
+


### PR DESCRIPTION
Currently Schema attached to a response goes through the default jackson BeanSerializer. This lead to the schema being mapped incorrectly and properties of the schema are removed.

This PR fixes that by reusing the io.swagger.parser.util.SwaggerDeserializer#definition API to correctly deserialize a schema within a response. See #1552 