### PR TITLE
#1553 fails to generate spec on relative server urls on Windows

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -145,17 +145,10 @@ public class OpenAPIDeserializer {
 
 	public SwaggerParseResult deserialize(JsonNode rootNode, String path) {
 		SwaggerParseResult result = new SwaggerParseResult();
-		try {
-
-			ParseResult rootParse = new ParseResult();
-			OpenAPI api = parseRoot(rootNode, rootParse, path);
-			result.setOpenAPI(api);
-			result.setMessages(rootParse.getMessages());
-
-		} catch (Exception e) {
-			result.setMessages(Arrays.asList(e.getMessage()));
-
-		}
+		ParseResult rootParse = new ParseResult();
+		OpenAPI api = parseRoot(rootNode, rootParse, path);
+		result.setOpenAPI(api);
+		result.setMessages(rootParse.getMessages());
 		return result;
 	}
 
@@ -480,7 +473,7 @@ public class OpenAPIDeserializer {
 		if (StringUtils.isNotBlank(value)) {
 			if (!isValidURL(value) && path != null) {
 				try {
-					final URI absURI = new URI(path);
+					final URI absURI = new URI(path.replaceAll("\\\\", "/"));
 					if ("http".equals(absURI.getScheme()) || "https".equals(absURI.getScheme())) {
 						value = absURI.resolve(new URI(value)).toString();
 					}

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/OpenAPIParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/OpenAPIParserTest.java
@@ -624,5 +624,14 @@ public class OpenAPIParserTest {
         BigDecimal multipleOf = decimalValue.getMultipleOf();
         assertEquals(multipleOf, new BigDecimal("0.3", new MathContext(multipleOf.precision())));
     }
+
+    @Test
+    public void testConvertWindowsPathsToUnixWhenResolvingServerPaths() {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        SwaggerParseResult result = new OpenAPIParser().readLocation("exampleSpecs\\specs\\issue1553.yaml", null, options);
+
+        assertEquals("/api/customer1/v1", result.getOpenAPI().getServers().get(0).getUrl());
+    }
 }
 

--- a/modules/swagger-parser/src/test/resources/exampleSpecs/specs/issue1553.yaml
+++ b/modules/swagger-parser/src/test/resources/exampleSpecs/specs/issue1553.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.2
+info:
+  title: Sample API
+  description: A small example to demonstrate individual problems
+  version: 0.1.9
+servers:
+  - url: /api/customer1/v1
+    description: Server
+paths:
+  /pets:
+    patch:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '200':
+          description: Updated
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - pet_type
+      properties:
+        pet_type:
+          type: string
+        name:
+          type: string
+        birth_date:
+          type: string
+          format: date


### PR DESCRIPTION
When parsing API specs with relative server URLs when the path to the spec is specified with Windows directory separators (\) instead of UNIX (/), swagger-parser fails to generate OpenAPI object with no error message.

This is the cause of #1553 and most likely of https://github.com/OpenAPITools/openapi-generator/issues/8266 as well