### PR TITLE
fix 1511 for windows build

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -125,9 +125,16 @@ public final class ExternalRefProcessor {
                 if (isAnExternalRefFormat(ref)) {
                     if (!ref.equals(RefFormat.URL)) {
                         String schemaFullRef = schema.get$ref();
-                        String parent = file.substring(0, file.lastIndexOf(File.separatorChar));
+                        String parent = file.substring(0, file.lastIndexOf('/'));
                         if (!parent.isEmpty()) {
-                            schemaFullRef = Paths.get(parent, schemaFullRef).normalize().toString();
+                            if (schemaFullRef.contains("#/")) {
+                                String[] parts = schemaFullRef.split("#/");
+                                String schemaFullRefFilePart = parts[0];
+                                String schemaFullRefInternalRefPart = parts[1];
+                                schemaFullRef = Paths.get(parent, schemaFullRefFilePart).normalize().toString() + "#/" + schemaFullRefInternalRefPart;
+                            } else {
+                                schemaFullRef = Paths.get(parent, schemaFullRef).normalize().toString();
+                            }
                         }
                         schema.set$ref(processRefToExternalSchema(schemaFullRef, ref));
                     }


### PR DESCRIPTION
Fix tests :
 - OpenAPIV3ParserTest.testLoadExternalNestedDefinitions,
 - OpenAPIV3ParserTest.testLoadExternalNestedDefinitionsWithReferenceWithinSameFolder
 - OpenAPIV3ParserTest.testRelativePathIssue1543

Not fix tests :
 - OpenAPIV3ParserTest.testLoadExternalNestedDefinitionsWithReferenceOnDifferentFolderLevels
 - OpenAPIV3ParserTest.testLoadExternalNestedDefinitionsWithReferenceWithinSubfolder