### PR TITLE
Allow null string values

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -846,7 +846,7 @@ public class OpenAPIDeserializer {
 			}
 		} else if (!v.isValueNode()) {
 			result.invalidType(location, key, "string", node);
-		} else {
+		} else if (!v.isNull()) {
 			value = v.asText();
 			if (uniqueValues != null && !uniqueValues.add(value)) {
 				result.unique(location, "operationId");


### PR DESCRIPTION
There is a difference between `"null"` and `null` in both JSON and YAML. Currently this difference is ignored and all null values are parsed as the string `"null"` when a schema `type` is set to `string`.