### PR TITLE
Issue #1586: Update commons-io from 2.6 to 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,7 +367,7 @@
     </repositories>
     <properties>
         <swagger-parser-v2-version>1.0.55</swagger-parser-v2-version>
-        <commons-io-version>2.6</commons-io-version>
+        <commons-io-version>2.11.0</commons-io-version>
         <slf4j-version>1.7.30</slf4j-version>
         <swagger-core-version>2.1.10</swagger-core-version>
         <swagger-core-v2-version>1.6.2</swagger-core-v2-version>


### PR DESCRIPTION
This PR does the following:

* #1586 