### PR TITLE
Could io.swagger.parser.v3:swagger-parser-v2-converter:2.0.27-SNAPSHOT drop off redundant dependencies to loose weight?

### DIFF
--- a/modules/swagger-parser-v2-converter/pom.xml
+++ b/modules/swagger-parser-v2-converter/pom.xml
@@ -66,10 +66,6 @@
                     <groupId>com.sun.mail</groupId>
                     <artifactId>mailapi</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.github.java-json-tools</groupId>
-                    <artifactId>btf</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/modules/swagger-parser-v2-converter/pom.xml
+++ b/modules/swagger-parser-v2-converter/pom.xml
@@ -41,6 +41,16 @@
             <groupId>io.swagger</groupId>
             <artifactId>swagger-core</artifactId>
             <version>${swagger-core-v2-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-compat-qual</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>
@@ -51,6 +61,15 @@
             <groupId>io.swagger</groupId>
             <artifactId>swagger-compat-spec-parser</artifactId>
             <version>${swagger-parser-v2-version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>mailapi</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.java-json-tools</groupId>
+                    <artifactId>btf</artifactId>
+                </exclusion>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
@@ -66,6 +85,16 @@
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser-v3</artifactId>
             <version>${project.parent.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.validation</groupId>
+                    <artifactId>jakarta.validation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/modules/swagger-parser-v2-converter/pom.xml
+++ b/modules/swagger-parser-v2-converter/pom.xml
@@ -70,6 +70,7 @@
                     <groupId>com.github.java-json-tools</groupId>
                     <artifactId>btf</artifactId>
                 </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>


### PR DESCRIPTION
Hi, I am a user of project **_io.swagger.parser.v3:swagger-parser-v2-converter:2.0.27-SNAPSHOT_**. I found that its pom file introduced **_53_** dependencies. However, among them, **_7_** libraries (**_13%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for this project. 
This PR helps **_io.swagger.parser.v3:swagger-parser-v2-converter:2.0.27-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards