### PR TITLE
Fix for issue-1621

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/RefUtils.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/RefUtils.java
@@ -46,7 +46,11 @@ public class RefUtils {
             plausibleName = filePathElements[filePathElements.length - 1];
 
             final String[] split = plausibleName.split("\\.");
+            // Fix for issue-1621
             plausibleName = split[0];
+            for (int i = 1; i < split.length - 1; i++) {
+                plausibleName += "." + split[i];
+            }
         }
 
         return plausibleName;

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/OpenAPIParserTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/OpenAPIParserTest.java
@@ -41,6 +41,26 @@ public class OpenAPIParserTest {
     }
 
     @Test
+    public void testIssue1621() {
+        final ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(true);
+        parseOptions.setResolveFully(true);
+        parseOptions.setResolveCombinators(false);
+        OpenAPIParser openAPIParser = new OpenAPIParser();
+        SwaggerParseResult swaggerParseResult = openAPIParser.readLocation("issue-1621/example.openapi.yaml", null, parseOptions);
+        assertEquals(0, swaggerParseResult.getMessages().size());
+        OpenAPI api = swaggerParseResult.getOpenAPI();
+        assertEquals("POST Example", api.getPaths()
+                .get("/example")
+                .getPost()
+                .getRequestBody()
+                .getContent()
+                .get("application/json")
+                .getSchema()
+                .getTitle());
+    }
+
+    @Test
     public void testIssue749() {
         ParseOptions options = new ParseOptions();
         options.setResolve(true);

--- a/modules/swagger-parser/src/test/resources/issue-1621/example.get.yaml
+++ b/modules/swagger-parser/src/test/resources/issue-1621/example.get.yaml
@@ -1,0 +1,1 @@
+title: GET Example

--- a/modules/swagger-parser/src/test/resources/issue-1621/example.openapi.yaml
+++ b/modules/swagger-parser/src/test/resources/issue-1621/example.openapi.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.1
+info:
+  title: Example OpenAPI spec
+  version: 0.0.1
+paths:
+  '/example':
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExamplePost'
+      responses:
+        204:
+          description: No content
+components:
+  schemas:
+    # Renaming this key from `Example` to `ExampleGet` stops the issue from occurring
+    # Removing this key stops the issue from occurring
+    Example:
+      $ref: example.get.yaml
+    ExamplePost:
+      $ref: example.post.yaml

--- a/modules/swagger-parser/src/test/resources/issue-1621/example.post.yaml
+++ b/modules/swagger-parser/src/test/resources/issue-1621/example.post.yaml
@@ -1,0 +1,1 @@
+title: POST Example


### PR DESCRIPTION
Hi team,

This PR is to solve issue #1621  (OpenAPIParser is resolving the wrong schema for an operation)
This issue happens when the referenced file name contains more than 1 dot.

Please review the PR and merge the same.

Thanks,
Mohammed Rizwan