### PR TITLE
add JavaTimeModule to Jackson ObjectMapper

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ObjectMapperFactory.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ObjectMapperFactory.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 public class ObjectMapperFactory {
     public static ObjectMapper createJson() {
@@ -28,6 +29,7 @@ public class ObjectMapperFactory {
 
     private static ObjectMapper create(JsonFactory jsonFactory, boolean includePathDeserializer, boolean includeResponseDeserializer) {
         ObjectMapper mapper = new ObjectMapper(jsonFactory);
+        mapper.registerModule(new JavaTimeModule());
 
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/ObjectMapperTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/ObjectMapperTest.java
@@ -1,0 +1,15 @@
+package io.swagger.v3.parser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ObjectMapperTest {
+    @Test
+    public void testJavaTimeModule() {
+        ObjectMapper mapper = ObjectMapperFactory.createJson();
+        Assert.assertTrue("JavaTimeModule found?",
+                mapper.getRegisteredModuleIds().contains(new JavaTimeModule().getTypeId()));
+    }
+}


### PR DESCRIPTION
Relates to https://github.com/swagger-api/swagger-parser/issues/1524 - also consistent with swagger-core ObjectMapperFactory that adds JavaTimeModule by default.