### PR TITLE
when the same component used in two different places in two different apis then parser fails

### DIFF
--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -639,6 +639,52 @@ public class OpenAPIV3ParserTest {
     }
 
     @Test
+    public void testSameComponentInRequestAndResponseHeaders() throws IOException {
+        String pathFile = FileUtils.readFileToString(new File("src/test/resources/same-header-different-place-domain.yaml"), "UTF-8");
+        WireMock.stubFor(get(urlPathMatching("/issue-domain"))
+                .willReturn(aResponse()
+                        .withStatus(HttpURLConnection.HTTP_OK)
+                        .withHeader("Content-type", "application/json")
+                        .withBody(pathFile
+                                .getBytes(StandardCharsets.UTF_8))));
+
+        pathFile = FileUtils.readFileToString(new File("src/test/resources/same-header-different-place.yaml"), "UTF-8");
+        pathFile = pathFile.replace("${dynamicPort}", String.valueOf(this.serverPort));
+
+        OpenAPIV3Parser parser = new OpenAPIV3Parser();
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        options.setResolveFully(true);
+        final SwaggerParseResult openAPI = parser.readContents(pathFile, null, options);
+        Yaml.prettyPrint(openAPI);
+
+        assertEquals(openAPI.getMessages().size(), 0);
+    }
+
+    @Test
+    public void testSameComponentInRequestAndResponseHeadersValid() throws IOException {
+        String pathFile = FileUtils.readFileToString(new File("src/test/resources/same-header-different-place-domain.yaml"), "UTF-8");
+        WireMock.stubFor(get(urlPathMatching("/issue-domain"))
+                .willReturn(aResponse()
+                        .withStatus(HttpURLConnection.HTTP_OK)
+                        .withHeader("Content-type", "application/json")
+                        .withBody(pathFile
+                                .getBytes(StandardCharsets.UTF_8))));
+
+        pathFile = FileUtils.readFileToString(new File("src/test/resources/same-header-different-place-valid.yaml"), "UTF-8");
+        pathFile = pathFile.replace("${dynamicPort}", String.valueOf(this.serverPort));
+
+        OpenAPIV3Parser parser = new OpenAPIV3Parser();
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        options.setResolveFully(true);
+        final SwaggerParseResult openAPI = parser.readContents(pathFile, null, options);
+        Yaml.prettyPrint(openAPI);
+
+        assertEquals(openAPI.getMessages().size(), 0);
+    }
+
+    @Test
     public void testIssue1398() {
         ParseOptions options = new ParseOptions();
         SwaggerParseResult result = new OpenAPIV3Parser().readLocation("issue1398.yaml", null, options);

--- a/modules/swagger-parser-v3/src/test/resources/same-header-different-place-domain.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/same-header-different-place-domain.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+
+components:
+  parameters:
+    testHeader:
+      name: testHeader
+      in: header
+      schema:
+        type: string
+
+    anotherHeader:
+      name: testHeader
+      in: header
+      schema:
+        type: string

--- a/modules/swagger-parser-v3/src/test/resources/same-header-different-place-valid.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/same-header-different-place-valid.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  version: "1.0.0"
+  title: Simple Inventory API
+paths:
+  /api:
+    get:
+      parameters:
+        - $ref: 'http://localhost:${dynamicPort}/issue-domain/#/components/parameters/testHeader'
+      responses:
+        '200':
+          description: yet another success
+          headers:
+            testHeader:
+              $ref: 'http://localhost:${dynamicPort}/issue-domain/#/components/parameters/anotherHeader'
+  /api2:
+    get:
+      parameters:
+        - $ref: 'http://localhost:${dynamicPort}/issue-domain/#/components/parameters/testHeader'
+      responses:
+        '200':
+          description: yet another success
+          headers:
+            testHeader:
+              $ref: 'http://localhost:${dynamicPort}/issue-domain/#/components/parameters/testHeader'

--- a/modules/swagger-parser-v3/src/test/resources/same-header-different-place.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/same-header-different-place.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  version: "1.0.0"
+  title: Simple Inventory API
+paths:
+  /api:
+    get:
+      parameters:
+        - $ref: 'http://localhost:${dynamicPort}/issue-domain/#/components/parameters/testHeader'
+      responses:
+        '200':
+          description: yet another success
+          headers:
+            testHeader:
+              $ref: 'http://localhost:${dynamicPort}/issue-domain/#/components/parameters/testHeader'
+  /api2:
+    get:
+      parameters:
+        - $ref: 'http://localhost:${dynamicPort}/issue-domain/#/components/parameters/testHeader'
+      responses:
+        '200':
+          description: yet another success
+          headers:
+            testHeader:
+              $ref: 'http://localhost:${dynamicPort}/issue-domain/#/components/parameters/testHeader'


### PR DESCRIPTION
Hi, I'm getting ClassCastException when the same parameter from $ref is used in different places in different APIs. In this PR I've added a test case for this problem.

Exception:
```
java.lang.ClassCastException: Cannot cast io.swagger.v3.oas.models.headers.Header to io.swagger.v3.oas.models.parameters.Parameter
	at java.base/java.lang.Class.cast(Class.java:3816)
	at io.swagger.v3.parser.ResolverCache.loadRef(ResolverCache.java:116)
	at io.swagger.v3.parser.processors.ParameterProcessor.processParameters(ParameterProcessor.java:86)
	at io.swagger.v3.parser.processors.OperationProcessor.processOperation(OperationProcessor.java:39)
	at io.swagger.v3.parser.processors.PathsProcessor.processPaths(PathsProcessor.java:84)
	at io.swagger.v3.parser.OpenAPIResolver.resolve(OpenAPIResolver.java:49)
	at io.swagger.v3.parser.OpenAPIV3Parser.resolve(OpenAPIV3Parser.java:183)
	at io.swagger.v3.parser.OpenAPIV3Parser.readContents(OpenAPIV3Parser.java:162)
	at io.swagger.v3.parser.OpenAPIV3Parser.readContents(OpenAPIV3Parser.java:99)
```

