### PR TITLE
fix exception while file do not have '/'

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -125,6 +125,7 @@ public final class ExternalRefProcessor {
                 if (isAnExternalRefFormat(ref)) {
                     if (!ref.equals(RefFormat.URL)) {
                         String schemaFullRef = schema.get$ref();
+                        String parent = "";
                         if(file.contains("/"))
                         {
                             parent = file.substring(0, file.lastIndexOf('/'));

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -125,7 +125,10 @@ public final class ExternalRefProcessor {
                 if (isAnExternalRefFormat(ref)) {
                     if (!ref.equals(RefFormat.URL)) {
                         String schemaFullRef = schema.get$ref();
-                        String parent = file.substring(0, file.lastIndexOf('/'));
+                        if(file.contains("/"))
+                        {
+                            parent = file.substring(0, file.lastIndexOf('/'));
+                        }
                         if (!parent.isEmpty()) {
                             if (schemaFullRef.contains("#/")) {
                                 String[] parts = schemaFullRef.split("#/");


### PR DESCRIPTION
If the file do not have '/', these code will throw exception:
[main] WARN  io.swagger.v3.parser.OpenAPIV3Parser - Exception while resolving:
java.lang.StringIndexOutOfBoundsException: begin 0, end -1, length 23
        at java.base/java.lang.String.checkBoundsBeginEnd(String.java:3319)
        at java.base/java.lang.String.substring(String.java:1874)
        at io.swagger.v3.parser.processors.ExternalRefProcessor.processRefToExternalSchema(ExternalRefProcessor.java:128)