### PR TITLE
Adding missing keys to OAS 3.1 set

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -110,10 +110,8 @@ public class OpenAPIDeserializer {
 			"parameters", "examples", "requestBodies", "headers", "securitySchemes", "links", "callbacks"));
 	protected static Set<String> SCHEMA_KEYS = new LinkedHashSet<>(Arrays.asList("$ref", "title", "multipleOf",
 			"maximum", "format", "exclusiveMaximum", "minimum", "exclusiveMinimum", "maxLength", "minLength",
-			"pattern",
-			"maxItems", "minItems", "uniqueItems", "maxProperties", "minProperties", "required", "enum", "type",
-			"allOf",
-			"oneOf", "anyOf", "not", "items", "properties", "additionalProperties", "description", "format", "default",
+			"pattern", "maxItems", "minItems", "uniqueItems", "maxProperties", "minProperties", "required", "enum", "type",
+			"allOf", "oneOf", "anyOf", "not", "items", "properties", "additionalProperties", "description", "default",
 			"nullable", "discriminator", "readOnly", "writeOnly", "xml", "externalDocs", "example", "deprecated"));
 	protected static Set<String> EXAMPLE_KEYS = new LinkedHashSet<>(Arrays.asList("$ref", "summary", "description",
 			"value", "externalValue"));
@@ -136,64 +134,63 @@ public class OpenAPIDeserializer {
 
 	// 3.1
 	// TODO use a map instead for 3.0 and 3.1. Care about compatibility
-    // TODO OAS3.1 - ensure all OAS 3.1 new keywords are added to the various sets
 	protected static Set<String> ROOT_KEYS_31 = new LinkedHashSet<>(Arrays.asList("openapi", "info", "servers", "paths",
 			"components", "security", "tags", "externalDocs", "webhooks", "jsonSchemaDialect"));
-	protected static Set<String> RESERVED_KEYWORDS_31 = new LinkedHashSet<>(Arrays.asList("x-oai-","x-oas-"));
+	protected static Set<String> RESERVED_KEYWORDS_31 = new LinkedHashSet<>(Arrays.asList("x-oai-","x-oas-")); 
 	protected static Set<String> INFO_KEYS_31 = new LinkedHashSet<>(Arrays.asList("title","summary", "description", "termsOfService"
 			, "contact", "license", "version"));
 	protected static Set<String> CONTACT_KEYS_31 = new LinkedHashSet<>(Arrays.asList("name", "url", "email"));
 	protected static Set<String> LICENSE_KEYS_31 = new LinkedHashSet<>(Arrays.asList("name", "url", "identifier"));
-	protected static Set<String> TAG_KEYS_31 = new LinkedHashSet<>(Arrays.asList("description", "name", "externalDocs"));
+	protected static Set<String> TAG_KEYS_31 = new LinkedHashSet<>(Arrays.asList("description", "name", "externalDocs")); 
 	protected static Set<String> RESPONSE_KEYS_31 = new LinkedHashSet<>(Arrays.asList("$ref", "description", "headers",
-			"content", "links"));
+			"content", "links")); 
 	protected static Set<String> SERVER_KEYS_31 = new LinkedHashSet<>(Arrays.asList("url", "description", "variables"));
 	protected static Set<String> SERVER_VARIABLE_KEYS_31 = new LinkedHashSet<>(Arrays.asList("enum", "default",
-			"description"));
+			"description")); 
 	protected static Set<String> PATHITEM_KEYS_31 = new LinkedHashSet<>(Arrays.asList("$ref", "summary", "description",
-			"get", "put", "post", "delete", "head", "patch", "options", "trace", "servers", "parameters"));
+			"get", "put", "post", "delete", "head", "patch", "options", "trace", "servers", "parameters")); 
 	protected static Set<String> OPERATION_KEYS_31 = new LinkedHashSet<>(Arrays.asList("tags", "summary", "description",
 			"externalDocs", "operationId", "parameters", "requestBody", "responses", "callbacks", "deprecated",
 			"security",
-			"servers"));
+			"servers")); 
 	protected static Set<String> PARAMETER_KEYS_31 = new LinkedHashSet<>(Arrays.asList("$ref", "name", "in", "description"
 			, "required", "deprecated", "allowEmptyValue", "style", "explode", "allowReserved", "schema", "example",
 			"examples"
-			, "content"));
+			, "content")); 
 	protected static Set<String> REQUEST_BODY_KEYS_31 = new LinkedHashSet<>(Arrays.asList("$ref", "description", "content"
-			, "required"));
+			, "required")); 
 	protected static Set<String> SECURITY_SCHEME_KEYS_31 = new LinkedHashSet<>(Arrays.asList("$ref", "type", "name", "in"
-			, "description", "flows", "scheme", "bearerFormat", "openIdConnectUrl"));
-	protected static Set<String> EXTERNAL_DOCS_KEYS_31 = new LinkedHashSet<>(Arrays.asList("description", "url"));
+			, "description", "flows", "scheme", "bearerFormat", "openIdConnectUrl")); 
+	protected static Set<String> EXTERNAL_DOCS_KEYS_31 = new LinkedHashSet<>(Arrays.asList("description", "url")); 
 	protected static Set<String> COMPONENTS_KEYS_31 = new LinkedHashSet<>(Arrays.asList("schemas", "responses", "pathItems",
-			"parameters", "examples", "requestBodies", "headers", "securitySchemes", "links", "callbacks"));
-    // TODO OAS3.1 - ensure all schema 2020/12 + OAS 3.1 vocabulary keys are added
+			"parameters", "examples", "requestBodies", "headers", "securitySchemes", "links", "callbacks")); 
+
 	protected static Set<String> SCHEMA_KEYS_31 = new LinkedHashSet<>(Arrays.asList("$ref", "title", "multipleOf",
 			"maximum", "format", "exclusiveMaximum", "minimum", "exclusiveMinimum", "maxLength", "minLength",
-			"pattern",
-			"maxItems", "minItems", "uniqueItems", "maxProperties", "minProperties", "required", "enum", "type",
-			"allOf",
-			"oneOf", "anyOf", "not", "items", "properties", "additionalProperties", "patternProperties", "description",
-			"format", "default", "discriminator", "readOnly", "writeOnly", "xml", "externalDocs", "example", "deprecated",
-			"const", "examples", "$id", "$comment", "if", "then", "else", "unevaluatedProperties", "prefixItems"));
+			"pattern", "maxItems", "minItems", "uniqueItems", "maxProperties", "minProperties", "required", "enum", "type",
+			"allOf", "oneOf", "anyOf", "not", "items", "properties", "additionalProperties", "description",
+            "default", "discriminator", "readOnly", "writeOnly", "xml", "externalDocs", "example", "deprecated",
+			"const", "examples", "$id", "$comment", "if", "then", "else", "unevaluatedProperties", "prefixItems",
+            "contains","contentEncoding","contentMediaType","$anchor","$schema","contentSchema","propertyNames",
+            "dependentSchemas","dependentRequired","minContains","maxContains","patternProperties"));
 	protected static Set<String> EXAMPLE_KEYS_31 = new LinkedHashSet<>(Arrays.asList("$ref", "summary", "description",
-			"value", "externalValue"));
+			"value", "externalValue")); 
 	protected static Set<String> HEADER_KEYS_31 = new LinkedHashSet<>(Arrays.asList("$ref", "name", "in", "description",
 			"required", "deprecated", "allowEmptyValue", "style", "explode", "allowReserved", "schema", "example",
 			"examples",
 			"content"));
 	protected static Set<String> LINK_KEYS_31 = new LinkedHashSet<>(Arrays.asList("$ref", "operationRef", "operationId",
-			"parameters", "requestBody", "description", "server"));
+			"parameters", "requestBody", "description", "server")); 
 	protected static Set<String> MEDIATYPE_KEYS_31 = new LinkedHashSet<>(Arrays.asList("schema", "example", "examples",
-			"encoding"));
+			"encoding")); 
 	protected static Set<String> XML_KEYS_31 = new LinkedHashSet<>(Arrays.asList("name", "namespace", "prefix",
-			"attribute", "wrapped"));
+			"attribute", "wrapped")); 
 	protected static Set<String> OAUTHFLOW_KEYS_31 = new LinkedHashSet<>(Arrays.asList("authorizationUrl", "tokenUrl",
-			"refreshUrl", "scopes"));
+			"refreshUrl", "scopes")); 
 	protected static Set<String> OAUTHFLOWS_KEYS_31 = new LinkedHashSet<>(Arrays.asList("implicit", "password",
-			"clientCredentials", "authorizationCode"));
+			"clientCredentials", "authorizationCode")); 
 	protected static Set<String> ENCODING_KEYS_31 = new LinkedHashSet<>(Arrays.asList("contentType", "headers", "style",
-			"explode", "allowReserved"));
+			"explode", "allowReserved")); 
 
 	protected static Map<String, Map<String, Set<String>>> KEYS = new LinkedHashMap<>();
 

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -3610,7 +3610,7 @@ public class OpenAPIDeserializer {
 		ObjectNode itemsNode = getObject("items", node, false, location, result);
 
 		if ((allOfArray != null) || (anyOfArray != null) || (oneOfArray != null)) {
-			Schema composedSchema = new Schema();
+            JsonSchema composedSchema = new JsonSchema();
 
 			if (allOfArray != null) {
 
@@ -3644,7 +3644,7 @@ public class OpenAPIDeserializer {
 			}
 		}
 		if (itemsNode != null && result.isDefaultSchemaTypeObject()) {
-			ArraySchema items = new ArraySchema();
+            ArraySchema items = new ArraySchema();
 			if (itemsNode.getNodeType().equals(JsonNodeType.OBJECT)) {
 				items.setItems(getSchema(itemsNode, location, result));
 			} else if (itemsNode.getNodeType().equals(JsonNodeType.ARRAY)) {
@@ -3656,7 +3656,7 @@ public class OpenAPIDeserializer {
 			}
 			schema = items;
 		}else if (itemsNode != null) {
-			JsonSchema items = new JsonSchema();
+			ArraySchema items = new ArraySchema();
 			if (itemsNode.getNodeType().equals(JsonNodeType.OBJECT)) {
 				items.setItems(getJsonSchema(itemsNode, location, result));
 			} else if (itemsNode.getNodeType().equals(JsonNodeType.ARRAY)) {
@@ -3714,13 +3714,13 @@ public class OpenAPIDeserializer {
 				schema =
 						unevaluatedProperties.equals(Boolean.FALSE)
 								? new ObjectSchema()
-								: new Schema();
+								: new JsonSchema();
 			}
 			schema.setUnevaluatedProperties(unevaluatedProperties);
 		}
 
 		if (schema == null) {
-			schema = new Schema();
+			schema = new JsonSchema();
 		}
 
 		JsonNode ref = node.get("$ref");

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -133,7 +133,6 @@ public class OpenAPIDeserializer {
 			"explode", "allowReserved"));
 
 	// 3.1
-	// TODO use a map instead for 3.0 and 3.1. Care about compatibility
 	protected static Set<String> ROOT_KEYS_31 = new LinkedHashSet<>(Arrays.asList("openapi", "info", "servers", "paths",
 			"components", "security", "tags", "externalDocs", "webhooks", "jsonSchemaDialect"));
 	protected static Set<String> RESERVED_KEYWORDS_31 = new LinkedHashSet<>(Arrays.asList("x-oai-","x-oas-")); 
@@ -170,7 +169,7 @@ public class OpenAPIDeserializer {
 			"pattern", "maxItems", "minItems", "uniqueItems", "maxProperties", "minProperties", "required", "enum", "type",
 			"allOf", "oneOf", "anyOf", "not", "items", "properties", "additionalProperties", "description",
             "default", "discriminator", "readOnly", "writeOnly", "xml", "externalDocs", "example", "deprecated",
-			"const", "examples", "$id", "$comment", "if", "then", "else", "unevaluatedProperties", "prefixItems",
+			"const", "examples", "$id", "$comment", "if", "then", "else", "unevaluatedProperties","unevaluatedItems", "prefixItems",
             "contains","contentEncoding","contentMediaType","$anchor","$schema","contentSchema","propertyNames",
             "dependentSchemas","dependentRequired","minContains","maxContains","patternProperties"));
 	protected static Set<String> EXAMPLE_KEYS_31 = new LinkedHashSet<>(Arrays.asList("$ref", "summary", "description",

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OAI31DeserializationTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OAI31DeserializationTest.java
@@ -1,5 +1,7 @@
 package io.swagger.v3.parser.test;
 
+import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.core.util.Yaml31;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
@@ -13,6 +15,46 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 public class OAI31DeserializationTest {
+
+    @Test(description = "Test OAS31 new Schema keys deserialization")
+    public void testSchemaKeysOAS31() {
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation( "3.1.0/petstore-3.1_more.yaml", null, null);
+        assertNotNull(result.getOpenAPI());
+        OpenAPI openAPI = result.getOpenAPI();
+
+        assertTrue(result.getMessages().size() == 0);
+        Schema schema2020_12 = openAPI.getComponents().getSchemas().get("Schema2020_12");
+        assertEquals(schema2020_12.getConst(), "const text");
+        assertEquals(schema2020_12.get$id(), "schemaId");
+        assertEquals(schema2020_12.get$comment(), "comment for testing");
+        assertNotNull(schema2020_12.getIf().getProperties().get("country"));
+        assertNotNull(schema2020_12.getThen().getProperties().get("maple_trees"));
+        assertNotNull(schema2020_12.getElse().getProperties().get("accept"));
+        assertTrue(schema2020_12.getUnevaluatedProperties() instanceof Schema);
+        Schema unevaluatedProperty = (Schema)schema2020_12.getUnevaluatedProperties();
+        assertTrue(unevaluatedProperty.getTypes().contains("object"));
+        assertEquals(schema2020_12.getContentMediaType(), "text/html");
+        assertEquals(schema2020_12.get$anchor(), "anchor text");
+        assertEquals(schema2020_12.get$schema(), "https://json-schema.org/draft/2020-12/schema");
+        assertNotNull(schema2020_12.getExamples().get(0));
+        assertEquals(schema2020_12.getContentEncoding(), "base64");
+        assertEquals(schema2020_12.getMinContains(), Integer.valueOf(2));
+        assertEquals(schema2020_12.getMaxContains(), Integer.valueOf(4));
+        assertTrue(schema2020_12.getPrefixItems().get(0) instanceof Schema);
+        Schema prefixItems = (Schema)schema2020_12.getPrefixItems().get(0);
+        assertEquals(prefixItems.getDescription(), "Name");
+        assertTrue(schema2020_12.getContains().getTypes().contains("integer"));
+        assertTrue(schema2020_12.getContentSchema().getTypes().contains("string"));
+        assertEquals(schema2020_12.getPropertyNames().getPattern(), "^[A-Za-z_][A-Za-z0-9_]*$");
+        assertTrue(schema2020_12.getDependentSchemas().get("credit_card") instanceof Schema);
+        Schema dependantSchema = (Schema)schema2020_12.getDependentSchemas().get("credit_card");
+        assertEquals(dependantSchema.getRequired().get(0), "billing_address");
+        assertTrue(schema2020_12.getDependentRequired().containsKey("credit_card"));
+        assertTrue(schema2020_12.getPatternProperties().get("^S_") instanceof Schema);
+        Schema patternProperties = (Schema)schema2020_12.getPatternProperties().get("^S_");
+        assertTrue(schema2020_12.getUnevaluatedItems().getTypes().contains("object"));
+        assertTrue(patternProperties.getTypes().contains("string"));
+    }
 
     @Test(description = "Test basic OAS31 deserialization/validation")
     public void testBasicOAS31() {
@@ -67,7 +109,6 @@ public class OAI31DeserializationTest {
         //$ref siblings
         assertNotNull(openAPI.getComponents().getSchemas().get("Pet").get$ref());
         assertNotNull(openAPI.getComponents().getSchemas().get("Pet").getProperties());
-
     }
 
     @Test(description = "Test basic OAS30 deserialization/validation if added the fields of OAS3.1")
@@ -558,9 +599,9 @@ public class OAI31DeserializationTest {
         assertNotNull(patientPersonSchema.getUnevaluatedProperties());
         assertTrue(patientPersonSchema.getUnevaluatedProperties() instanceof Boolean);
         assertFalse(((Boolean)patientPersonSchema.getUnevaluatedProperties()).booleanValue());
-
         //unevaluatedItems
         assertNotNull(profile.getUnevaluatedItems());
+
     }
 
     @Test(description = "Test siblings with $ref for if - then - else, dependentRequired, dependentSchemas")
@@ -656,6 +697,7 @@ public class OAI31DeserializationTest {
         //dependentSchemas
         assertNotNull(openAPI.getComponents().getSchemas().get("PaymentMethod"));
         Schema paymentMethod = openAPI.getComponents().getSchemas().get("PaymentMethod");
+
     }
 
     @Test(description = "Test examples in JSONSchema")

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OAI31DeserializationTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OAI31DeserializationTest.java
@@ -54,6 +54,7 @@ public class OAI31DeserializationTest {
         Schema patternProperties = (Schema)schema2020_12.getPatternProperties().get("^S_");
         assertTrue(schema2020_12.getUnevaluatedItems().getTypes().contains("object"));
         assertTrue(patternProperties.getTypes().contains("string"));
+        System.out.println(schema2020_12);
     }
 
     @Test(description = "Test basic OAS31 deserialization/validation")

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/petstore-3.1_more.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/petstore-3.1_more.yaml
@@ -119,6 +119,78 @@ components:
         $ref: "#/components/schemas/Pet"
         description: desc
         format: int32
+    Schema2020_12:
+      type: object
+      title: schema 2020-12
+      required:
+        - country
+      properties:
+        country:
+          enum:
+            - usa
+            - canada
+            - eu
+          default: eu
+          type: string
+          widget: Select
+      if:
+        properties:
+          country:
+            const: canada
+            type: string
+      then:
+        properties:
+          maple_trees:
+            type: number
+      else:
+        required:
+          - accept
+        properties:
+          accept:
+            const: "true"
+            type: boolean
+      const: const text
+      examples:
+        - sample1 
+        - sample2
+      $id: schemaId
+      $comment: comment for testing
+      propertyNames:
+        pattern: "^[A-Za-z_][A-Za-z0-9_]*$"
+      unevaluatedProperties:
+        type: object
+      unevaluatedItems:
+        type: object
+      prefixItems:
+        - description: Name
+          type: string
+        - description: Age
+          type: integer
+      contains:
+        type: integer
+      maxContains: 4
+      minContains: 2
+      $anchor: anchor text
+      $schema: https://json-schema.org/draft/2020-12/schema
+      contentSchema:
+        type: string
+      dependentSchemas:
+        credit_card:
+          required:
+            - billing_address
+          properties:
+            billing_address:
+              type: string
+      dependentRequired:
+        credit_card:
+          - billing_address
+      patternProperties:
+        ^S_:
+          type: string
+        ^I_:
+          type: integer
+      contentEncoding: base64
+      contentMediaType: text/html
     Error:
       required:
         - code


### PR DESCRIPTION
Adding missing keys to OAS 3.1 set in parser deserializer, to avoid them being add as extensions.