### PR TITLE
fix and test for issue 1758

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -1905,10 +1905,13 @@ public class OpenAPIDeserializer {
 				parameter = new Parameter();
 				String mungedRef = mungedRef(ref.textValue());
 				if (mungedRef != null) {
-					parameter.set$ref(mungedRef);
-				} else {
-					parameter.set$ref(ref.textValue());
-				}
+                    parameter.set$ref(mungedRef);
+                }else {
+                    parameter.set$ref(ref.textValue());
+                }
+                if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/parameters")||ref.textValue().startsWith("#/components/headers"))) {
+                    result.warning(location, "$ref is not pointing to #/components/parameters");
+                }
 				if (result.isOpenapi31()) {
 					String desc = getString("description", obj, false, location, result);
 					if (StringUtils.isNotBlank(desc)) {
@@ -2115,6 +2118,10 @@ public class OpenAPIDeserializer {
 				} else {
 					header.set$ref(ref.textValue());
 				}
+                if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/parameters")||ref.textValue().startsWith("#/components/headers"))) {
+                    result.warning(location, "$ref is not pointing to #/components/headers");
+                }
+
 				if (result.isOpenapi31()) {
 					String desc = getString("description", headerNode, false, location, result);
 					if (StringUtils.isNotBlank(desc)) {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -958,6 +958,9 @@ public class OpenAPIDeserializer {
 				} else {
 					pathItem.set$ref(ref.textValue());
 				}
+                if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/pathItems"))) {
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                }
 				if(result.isOpenapi31()){
 					String value = getString("summary", obj, false, location, result);
 					if (StringUtils.isNotBlank(value)) {
@@ -1535,6 +1538,9 @@ public class OpenAPIDeserializer {
 				} else {
 					link.set$ref(ref.textValue());
 				}
+                if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/links"))) {
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                }
 				if (result.isOpenapi31()) {
 					String desc = getString("description", linkNode, false, location, result);
 					if (StringUtils.isNotBlank(desc)) {
@@ -1659,6 +1665,9 @@ public class OpenAPIDeserializer {
 						} else {
 							callback.set$ref(ref.textValue());
 						}
+                        if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/callbacks"))) {
+                            result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                        }
 						return callback;
 					} else {
 						result.invalidType(location, "$ref", "string", node);
@@ -1910,7 +1919,7 @@ public class OpenAPIDeserializer {
                     parameter.set$ref(ref.textValue());
                 }
                 if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/parameters")||ref.textValue().startsWith("#/components/headers"))) {
-                    result.warning(location, "$ref is not pointing to #/components/parameters");
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
                 }
 				if (result.isOpenapi31()) {
 					String desc = getString("description", obj, false, location, result);
@@ -2119,7 +2128,7 @@ public class OpenAPIDeserializer {
 					header.set$ref(ref.textValue());
 				}
                 if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/parameters")||ref.textValue().startsWith("#/components/headers"))) {
-                    result.warning(location, "$ref is not pointing to #/components/headers");
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
                 }
 
 				if (result.isOpenapi31()) {
@@ -2284,6 +2293,9 @@ public class OpenAPIDeserializer {
 				} else {
 					securityScheme.set$ref(ref.textValue());
 				}
+                if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/securitySchemes"))) {
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                }
 				if (result.isOpenapi31()) {
 					String desc = getString("description", node, false, location, result);
 					if (StringUtils.isNotBlank(desc)) {
@@ -2705,6 +2717,9 @@ public class OpenAPIDeserializer {
                 if(schema.get$ref().startsWith("#/components/schemas")){// it's internal
                     String refName  = schema.get$ref().substring(schema.get$ref().lastIndexOf("/")+1);
                     localSchemaRefs.put(refName,location);
+                }
+                if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/schemas"))) {
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
                 }
 				return schema;
 			} else {
@@ -3168,6 +3183,9 @@ public class OpenAPIDeserializer {
 				} else {
 					example.set$ref(ref.textValue());
 				}
+                if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/examples"))) {
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                }
                 if(result.isOpenapi31()){
                     String value = getString("summary", node, false, location, result);
                     if (StringUtils.isNotBlank(value)) {
@@ -3307,6 +3325,9 @@ public class OpenAPIDeserializer {
 				} else {
 					apiResponse.set$ref(ref.textValue());
 				}
+                if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/responses"))) {
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                }
 				if(result.isOpenapi31()){
 					String value = getString("description", node, false, location, result);
 					if (StringUtils.isNotBlank(value)) {
@@ -3557,6 +3578,9 @@ public class OpenAPIDeserializer {
 				} else {
 					body.set$ref(ref.textValue());
 				}
+                if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/requestBodies"))) {
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                }
 				if (result.isOpenapi31()) {
 					String desc = getString("description", node, false, location, result);
 					if (StringUtils.isNotBlank(desc)) {
@@ -3813,6 +3837,9 @@ public class OpenAPIDeserializer {
 				} else {
 					schema.set$ref(ref.asText());
 				}
+                if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/schemas"))) {
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                }
 			} else {
 				result.invalidType(location, "$ref", "string", node);
 			}

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -959,7 +959,7 @@ public class OpenAPIDeserializer {
 					pathItem.set$ref(ref.textValue());
 				}
                 if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/pathItems"))) {
-                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type PathItem");
                 }
 				if(result.isOpenapi31()){
 					String value = getString("summary", obj, false, location, result);
@@ -1539,7 +1539,7 @@ public class OpenAPIDeserializer {
 					link.set$ref(ref.textValue());
 				}
                 if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/links"))) {
-                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type Link");
                 }
 				if (result.isOpenapi31()) {
 					String desc = getString("description", linkNode, false, location, result);
@@ -1666,7 +1666,7 @@ public class OpenAPIDeserializer {
 							callback.set$ref(ref.textValue());
 						}
                         if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/callbacks"))) {
-                            result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                            result.warning(location, "$ref target "+ref.textValue() +" is not of expected type Callback");
                         }
 						return callback;
 					} else {
@@ -1918,8 +1918,8 @@ public class OpenAPIDeserializer {
                 }else {
                     parameter.set$ref(ref.textValue());
                 }
-                if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/parameters")||ref.textValue().startsWith("#/components/headers"))) {
-                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/parameters") || ref.textValue().startsWith("#/components/headers"))) {
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type Parameter/Header");
                 }
 				if (result.isOpenapi31()) {
 					String desc = getString("description", obj, false, location, result);
@@ -2127,8 +2127,8 @@ public class OpenAPIDeserializer {
 				} else {
 					header.set$ref(ref.textValue());
 				}
-                if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/parameters")||ref.textValue().startsWith("#/components/headers"))) {
-                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/parameters") || ref.textValue().startsWith("#/components/headers"))) {
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type Header/Parameter");
                 }
 
 				if (result.isOpenapi31()) {
@@ -2294,7 +2294,7 @@ public class OpenAPIDeserializer {
 					securityScheme.set$ref(ref.textValue());
 				}
                 if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/securitySchemes"))) {
-                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type securitySchemes");
                 }
 				if (result.isOpenapi31()) {
 					String desc = getString("description", node, false, location, result);
@@ -2719,7 +2719,7 @@ public class OpenAPIDeserializer {
                     localSchemaRefs.put(refName,location);
                 }
                 if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/schemas"))) {
-                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type Schema");
                 }
 				return schema;
 			} else {
@@ -3184,7 +3184,7 @@ public class OpenAPIDeserializer {
 					example.set$ref(ref.textValue());
 				}
                 if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/examples"))) {
-                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type Examples");
                 }
                 if(result.isOpenapi31()){
                     String value = getString("summary", node, false, location, result);
@@ -3326,7 +3326,7 @@ public class OpenAPIDeserializer {
 					apiResponse.set$ref(ref.textValue());
 				}
                 if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/responses"))) {
-                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type Response");
                 }
 				if(result.isOpenapi31()){
 					String value = getString("description", node, false, location, result);
@@ -3349,7 +3349,7 @@ public class OpenAPIDeserializer {
 
 		ObjectNode headerObject = getObject("headers", node, false, location, result);
 		if (headerObject != null) {
-			Map<String, Header> headers = getHeaders(headerObject, location, result, false);
+			Map<String, Header> headers = getHeaders(headerObject, String.format("%s.%s", location, "headers"), result, false);
 			if (headers != null && headers.size() > 0) {
 				apiResponse.setHeaders(headers);
 			}
@@ -3357,7 +3357,7 @@ public class OpenAPIDeserializer {
 
 		ObjectNode linksObj = getObject("links", node, false, location, result);
 		if (linksObj != null) {
-			Map<String, Link> links = getLinks(linksObj, location, result, false);
+			Map<String, Link> links = getLinks(linksObj, String.format("%s.%s", location, "links"), result, false);
 			if (links != null && links.size() > 0) {
 				apiResponse.setLinks(links);
 			}
@@ -3579,7 +3579,7 @@ public class OpenAPIDeserializer {
 					body.set$ref(ref.textValue());
 				}
                 if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/requestBodies"))) {
-                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type RequestBody");
                 }
 				if (result.isOpenapi31()) {
 					String desc = getString("description", node, false, location, result);
@@ -3838,7 +3838,7 @@ public class OpenAPIDeserializer {
 					schema.set$ref(ref.asText());
 				}
                 if(ref.textValue().startsWith("#/components") && !(ref.textValue().startsWith("#/components/schemas"))) {
-                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type");
+                    result.warning(location, "$ref target "+ref.textValue() +" is not of expected type Schema");
                 }
 			} else {
 				result.invalidType(location, "$ref", "string", node);

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -95,13 +95,14 @@ public class OpenAPIV3ParserTest {
 
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getOpenAPI());
-        assertEquals(result.getMessages().size(),8);
+        assertEquals(result.getMessages().size(),9);
         assertTrue(result.getMessages().contains("paths.'/path1'.$ref target #/components/schemas/xFoo is not of expected type"));
         assertTrue(result.getMessages().contains("paths.'/foo'(get).parameters.$ref target #/components/schemas/xFoo is not of expected type"));
         assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.default.three.$ref target #/components/schemas/xFoo is not of expected type"));
         assertTrue(result.getMessages().contains("paths.'/foo'(get).requestBody.$ref target #/components/schemas/xFoo is not of expected type"));
         assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.200.user.$ref target #/components/schemas/xFoo is not of expected type"));
         assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.200.content.'application/json'.schema.$ref target #/components/parameters/pet is not of expected type"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.200.content.'application/json'.examples.one.$ref target #/components/schemas/xFoo is not of expected type"));
         assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.400.$ref target #/components/schemas/xFoo is not of expected type"));
         assertTrue(result.getMessages().contains("paths.'/foo'(get).callbacks.$ref target #/components/schemas/xFoo is not of expected type"));
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -96,15 +96,15 @@ public class OpenAPIV3ParserTest {
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getOpenAPI());
         assertEquals(result.getMessages().size(),9);
-        assertTrue(result.getMessages().contains("paths.'/path1'.$ref target #/components/schemas/xFoo is not of expected type"));
-        assertTrue(result.getMessages().contains("paths.'/foo'(get).parameters.$ref target #/components/schemas/xFoo is not of expected type"));
-        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.default.three.$ref target #/components/schemas/xFoo is not of expected type"));
-        assertTrue(result.getMessages().contains("paths.'/foo'(get).requestBody.$ref target #/components/schemas/xFoo is not of expected type"));
-        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.200.user.$ref target #/components/schemas/xFoo is not of expected type"));
-        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.200.content.'application/json'.schema.$ref target #/components/parameters/pet is not of expected type"));
-        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.200.content.'application/json'.examples.one.$ref target #/components/schemas/xFoo is not of expected type"));
-        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.400.$ref target #/components/schemas/xFoo is not of expected type"));
-        assertTrue(result.getMessages().contains("paths.'/foo'(get).callbacks.$ref target #/components/schemas/xFoo is not of expected type"));
+        assertTrue(result.getMessages().contains("paths.'/path1'.$ref target #/components/schemas/xFoo is not of expected type PathItem"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).parameters.$ref target #/components/schemas/xFoo is not of expected type Parameter/Header"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.default.headers.three.$ref target #/components/schemas/xFoo is not of expected type Header/Parameter"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).requestBody.$ref target #/components/schemas/xFoo is not of expected type RequestBody"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.200.links.user.$ref target #/components/schemas/xFoo is not of expected type Link"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.200.content.'application/json'.schema.$ref target #/components/parameters/pet is not of expected type Schema"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.200.content.'application/json'.examples.one.$ref target #/components/schemas/xFoo is not of expected type Examples"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.400.$ref target #/components/schemas/xFoo is not of expected type Response"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).callbacks.$ref target #/components/schemas/xFoo is not of expected type Callback"));
 
     }
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -91,37 +91,20 @@ public class OpenAPIV3ParserTest {
     @Test
     public void testIssue1758() throws Exception{
         ParseOptions options = new ParseOptions();
-        String issue1643 = "openapi: 3.0.3\n" +
-                "\n" +
-                "info: \n" +
-                "  title: Missing validation rule for schemas in Headers.\n" +
-                "  version: 1.0.0\n" +
-                "  \n" +
-                "paths: \n" +
-                "  /foo:\n" +
-                "    get:\n" +
-                "      description: ok\n" +
-                "      parameters:         \n" +
-                "      - $ref: '#/components/schemas/xFoo'\n" +
-                "      responses:\n" +
-                "        default:\n" +
-                "          description: ok\n" +
-                "          headers:\n" +
-                "            three:\n" +
-                "              $ref: '#/components/schemas/xFoo'\n" +
-                "           \n" +
-                "components:\n" +
-                "  schemas:\n" +
-                "    xFoo:\n" +
-                "      type: string\n" +
-                "      description: This isn't validated correctly";
-        SwaggerParseResult result = new OpenAPIV3Parser().readContents(issue1643, null, options);
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation("src/test/resources/issue1758.yaml", null, options);
 
         Assert.assertNotNull(result);
         Assert.assertNotNull(result.getOpenAPI());
-        assertEquals(result.getMessages().size(),2);
-        assertTrue(result.getMessages().contains("paths.'/foo'(get).parameters.$ref is not pointing to #/components/parameters"));
-        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.default.three.$ref is not pointing to #/components/headers"));
+        assertEquals(result.getMessages().size(),8);
+        assertTrue(result.getMessages().contains("paths.'/path1'.$ref target #/components/schemas/xFoo is not of expected type"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).parameters.$ref target #/components/schemas/xFoo is not of expected type"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.default.three.$ref target #/components/schemas/xFoo is not of expected type"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).requestBody.$ref target #/components/schemas/xFoo is not of expected type"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.200.user.$ref target #/components/schemas/xFoo is not of expected type"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.200.content.'application/json'.schema.$ref target #/components/parameters/pet is not of expected type"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).responses.400.$ref target #/components/schemas/xFoo is not of expected type"));
+        assertTrue(result.getMessages().contains("paths.'/foo'(get).callbacks.$ref target #/components/schemas/xFoo is not of expected type"));
+
     }
 
     @Test(description = "Test for not setting the schema type as default")

--- a/modules/swagger-parser-v3/src/test/resources/issue1758.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue1758.yaml
@@ -28,6 +28,9 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/parameters/pet'
+              examples:
+                one:
+                  $ref: '#/components/schemas/xFoo'
           links:
             user:
               $ref: '#/components/schemas/xFoo'       

--- a/modules/swagger-parser-v3/src/test/resources/issue1758.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue1758.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.3
+info:
+  title: Missing validation rule for schemas in Headers.
+  version: 1.0.0
+servers:
+- url: /
+paths:
+  /path1:
+    $ref: '#/components/schemas/xFoo'
+  /foo:
+    get:
+      description: ok
+      parameters:
+      - $ref: '#/components/schemas/xFoo'
+      requestBody:
+        $ref: '#/components/schemas/xFoo'
+      responses:
+        default:
+          description: ok
+          headers:
+            three:
+              $ref: '#/components/schemas/xFoo'
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/parameters/pet'
+          links:
+            user:
+              $ref: '#/components/schemas/xFoo'       
+        '400':
+          $ref: '#/components/schemas/xFoo'
+      callbacks:
+        mainHook:
+          $ref: "#/components/schemas/xFoo"
+components:
+  schemas:
+    xFoo:
+      type: string
+      description: This isn't validated correctly
+  parameters:
+    pet:
+      name: X-pet
+      in: header
+      required: false
+      schema:
+        type: string
+        format: uuid
+      


### PR DESCRIPTION
Fix and test for issue #1758.

Adds a validation message for parameters and headers when ref field in **internal references** are not being pointed at the right components tag.