### PR TITLE
fix for issue 1767 - OpenAPI v2 converter

### DIFF
--- a/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
+++ b/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
@@ -653,7 +653,7 @@ public class SwaggerConverter implements SwaggerParserExtension {
             operation.setExternalDocs(convert(v2Operation.getExternalDocs()));
         }
 
-        if (v2Operation.getSecurity() != null && v2Operation.getSecurity().size() > 0) {
+        if (v2Operation.getSecurity() != null) {
             operation.setSecurity(convertSecurityRequirementsMap(v2Operation.getSecurity()));
         }
 

--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.security.OAuthFlow;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.tags.Tag;
 import io.swagger.v3.parser.converter.SwaggerConverter;
@@ -98,6 +99,8 @@ public class V2ConverterTest {
     private static final String ISSUE_1261_YAML = "issue-1261.yaml";
 
     private static final String ISSUE_1715_YAML = "issue-1715.yaml";
+
+    private static final String ISSUE_1767_YAML = "issue-1767.yaml";
 
     private static final String API_BATCH_PATH = "/api/batch/";
     private static final String PETS_PATH = "/pets";
@@ -862,6 +865,21 @@ public class V2ConverterTest {
         assertNotNull(requestBody.getExtensions());
         assertEquals(1, requestBody.getExtensions().size());
         assertEquals("bar", requestBody.getExtensions().get("x-foo"));
+    }
+
+    @Test(description = "OpenAPI v2 converter - security of operation should be set to empty list if that's the case")
+    public void testIssue1767() throws Exception {
+        OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_1767_YAML);
+        assertNotNull(oas);
+
+        List<SecurityRequirement> firstOperationSecurityRequirements =
+                oas.getPaths().get("/api/not-secured").getGet().getSecurity();
+        assertNotNull(firstOperationSecurityRequirements);
+        assertEquals(firstOperationSecurityRequirements.size(), 0);
+
+        List<SecurityRequirement> secondOperationSecurityRequirements =
+                oas.getPaths().get("/api/secured/").getGet().getSecurity();
+        assertNull(secondOperationSecurityRequirements);
     }
 
     @Test()

--- a/modules/swagger-parser-v2-converter/src/test/resources/issue-1767.yaml
+++ b/modules/swagger-parser-v2-converter/src/test/resources/issue-1767.yaml
@@ -1,0 +1,41 @@
+swagger: '2.0'
+basePath: /
+paths:
+  /api/not-secured:
+    get:
+      responses:
+        '200':
+          description: Success
+      summary: Not secured API
+      operationId: not_secured_api
+      security: []
+      tags:
+        - not-secured
+  /api/secured/:
+    get:
+      responses:
+        '200':
+          description: Success
+      summary: Secured API
+      operationId: secured_api
+      tags:
+        - secured
+info:
+  title: Sample spec
+  version: 0.1.0
+produces:
+  - application/json
+consumes:
+  - application/json
+securityDefinitions:
+  api_key:
+    type: apiKey
+    in: header
+    name: Authorization
+security:
+  - api_key: []
+tags:
+  - name: not-secured
+    description: API not secured
+  - name: secured
+    description: API secured


### PR DESCRIPTION
Set `security` property of operation to an empty list if that's the case in the parsed file.

Resolves #1767 