### PR TITLE
CVE-2022-25857/CVE-2022-38752: bump snake-yaml dependency to avoid versions with public CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
         </repository>
     </repositories>
     <properties>
-        <snakeyaml-version>1.30</snakeyaml-version>
+        <snakeyaml-version>1.31</snakeyaml-version>
         <swagger-parser-v2-version>1.0.61</swagger-parser-v2-version>
         <commons-io-version>2.11.0</commons-io-version>
         <slf4j-version>1.7.30</slf4j-version>

--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
         </repository>
     </repositories>
     <properties>
-        <snakeyaml-version>1.31</snakeyaml-version>
+        <snakeyaml-version>1.32</snakeyaml-version>
         <swagger-parser-v2-version>1.0.61</swagger-parser-v2-version>
         <commons-io-version>2.11.0</commons-io-version>
         <slf4j-version>1.7.30</slf4j-version>


### PR DESCRIPTION
The package org.yaml:snakeyaml from 0 and before 1.31 are vulnerable to Denial of Service (DoS) due missing to nested depth limitation for collections.