### PR TITLE
Keep required field when converting composed model to OpenAPI

### DIFF
--- a/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
+++ b/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
@@ -1194,6 +1194,7 @@ public class SwaggerConverter implements SwaggerParserExtension {
             composed.setTitle(composedModel.getTitle());
             composed.setExtensions(convert(composedModel.getVendorExtensions()));
             composed.setAllOf(composedModel.getAllOf().stream().map(this::convert).collect(Collectors.toList()));
+            composed.setRequired(composedModel.getRequired());
 
             addProperties(v2Model, composed);
 

--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -96,6 +96,7 @@ public class V2ConverterTest {
     private static final String ISSUE_1715_YAML = "issue-1715.yaml";
 
     private static final String ISSUE_1767_YAML = "issue-1767.yaml";
+    private static final String ISSUE_1796_YAML = "issue-1796.yaml";
 
     private static final String API_BATCH_PATH = "/api/batch/";
     private static final String PETS_PATH = "/pets";
@@ -875,6 +876,16 @@ public class V2ConverterTest {
         List<SecurityRequirement> secondOperationSecurityRequirements =
                 oas.getPaths().get("/api/secured/").getGet().getSecurity();
         assertNull(secondOperationSecurityRequirements);
+    }
+
+    @Test(description = "OpenAPI v2 converter - composed model should keep required properties")
+    public void testissue1796() throws Exception {
+        OpenAPI oas = getConvertedOpenAPIFromJsonFile(ISSUE_1796_YAML);
+        assertNotNull(oas);
+        ComposedSchema schema = (ComposedSchema) oas.getComponents().getSchemas().get("ComposedModel");
+        assertNotNull(schema.getRequired());
+        assertEquals(schema.getRequired().size(), 1);
+        assertEquals(schema.getRequired().get(0), "name");
     }
 
     @Test()

--- a/modules/swagger-parser-v2-converter/src/test/resources/issue-1796.yaml
+++ b/modules/swagger-parser-v2-converter/src/test/resources/issue-1796.yaml
@@ -1,0 +1,30 @@
+swagger: "2.0"
+info:
+  title: composed model conversion test
+  version: 1.0.0
+paths:
+  /composed:
+    get:
+      operationId: composed
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: "#/definitions/ComposedModel"
+definitions:
+  BaseModel:
+    type: object
+    required:
+      - uuid
+    properties:
+      uuid:
+        type: string
+  ComposedModel:
+    type: object
+    required:
+      - name
+    allOf:
+      - $ref: "#/definitions/BaseModel"
+    properties:
+      name:
+        type: string


### PR DESCRIPTION
Fixes #1796 

Make sure the `required` field don't get lost when it is having an `allOf` in Swagger and you want to convert it to OpenAPI