### PR TITLE
Update ReferenceUtils to better support windows filesystem

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/reference/ReferenceUtils.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/reference/ReferenceUtils.java
@@ -70,7 +70,13 @@ public class ReferenceUtils {
 
     public static String readURI(String absoluteUri, List<AuthorizationValue> auths) throws Exception {
         URI resolved = new URI(absoluteUri);
-        if (StringUtils.isBlank(resolved.getScheme())) {
+        if (resolved.getScheme().startsWith("http")) {
+            return readHttp(absoluteUri, auths);
+        } else if (resolved.getScheme().startsWith("file")) {
+            return readFile(absoluteUri);
+        } else if (resolved.getScheme().startsWith("classpath")) {
+            return readClasspath(absoluteUri);
+        } else {
             // try file
             String content = null;
             try {
@@ -82,14 +88,7 @@ public class ReferenceUtils {
                 content = readClasspath(absoluteUri);
             }
             return content;
-        }  else if (resolved.getScheme().startsWith("http")) {
-            return readHttp(absoluteUri, auths);
-        } else if (resolved.getScheme().startsWith("file")) {
-            return readFile(absoluteUri);
-        } else if (resolved.getScheme().startsWith("classpath")) {
-            return readClasspath(absoluteUri);
         }
-        throw new RuntimeException("scheme not supported for uri: " + absoluteUri);
     }
 
     public static JsonNode deserializeIntoTree(String content) throws Exception {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/reference/ReferenceUtils.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/reference/ReferenceUtils.java
@@ -70,25 +70,26 @@ public class ReferenceUtils {
 
     public static String readURI(String absoluteUri, List<AuthorizationValue> auths) throws Exception {
         URI resolved = new URI(absoluteUri);
-        if (resolved.getScheme().startsWith("http")) {
-            return readHttp(absoluteUri, auths);
-        } else if (resolved.getScheme().startsWith("file")) {
-            return readFile(absoluteUri);
-        } else if (resolved.getScheme().startsWith("classpath")) {
-            return readClasspath(absoluteUri);
-        } else {
-            // try file
-            String content = null;
-            try {
-                content = readFile(absoluteUri);
-            } catch (Exception e) {
-                //
+        if (StringUtils.isNotBlank(resolved.getScheme())) {
+            if (resolved.getScheme().startsWith("http")) {
+                return readHttp(absoluteUri, auths);
+            } else if (resolved.getScheme().startsWith("file")) {
+                return readFile(absoluteUri);
+            } else if (resolved.getScheme().startsWith("classpath")) {
+                return readClasspath(absoluteUri);
             }
-            if (StringUtils.isBlank(content)) {
-                content = readClasspath(absoluteUri);
-            }
-            return content;
         }
+        // If no matches exists, try file
+        String content = null;
+        try {
+            content = readFile(absoluteUri);
+        } catch (Exception e) {
+            //
+        }
+        if (StringUtils.isBlank(content)) {
+            content = readClasspath(absoluteUri);
+        }
+        return content;
     }
 
     public static JsonNode deserializeIntoTree(String content) throws Exception {


### PR DESCRIPTION
Occurs on windows filesystems:

when absoluteUri is something like "C:/openapi.yml", the "scheme" part in URI object is resolved into "C". So it passes through all the statements and lands on an exception being thrown. A more resilient approach is to always default to reading from file when the scheme cannot be determined