### PR TITLE
Allow user to override the Code Point Limit required by SnakeYaml

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/DeserializationUtils.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/DeserializationUtils.java
@@ -40,7 +40,7 @@ public class DeserializationUtils {
         private Long maxYamlReferences = System.getProperty("maxYamlReferences") == null ? 10000000L : Long.valueOf(System.getProperty("maxYamlReferences"));
         private boolean validateYamlInput = System.getProperty("validateYamlInput") == null ? true : Boolean.valueOf(System.getProperty("validateYamlInput"));
         private boolean yamlCycleCheck = System.getProperty("yamlCycleCheck") == null ? true : Boolean.valueOf(System.getProperty("yamlCycleCheck"));
-
+        private Integer maxYamlCodePoints = System.getProperty("maxYamlCodePoints") == null ? 3 * 1024 * 1024 : Integer.valueOf(System.getProperty("maxYamlCodePoints"));
 
         private Integer maxYamlAliasesForCollections = System.getProperty("maxYamlAliasesForCollections") == null ? Integer.MAX_VALUE : Integer.valueOf(System.getProperty("maxYamlAliasesForCollections"));
         private boolean yamlAllowRecursiveKeys = System.getProperty("yamlAllowRecursiveKeys") == null ? true : Boolean.valueOf(System.getProperty("yamlAllowRecursiveKeys"));
@@ -73,6 +73,8 @@ public class DeserializationUtils {
         public boolean isYamlCycleCheck() {
             return yamlCycleCheck;
         }
+
+        public Integer getMaxYamlCodePoints() { return maxYamlCodePoints; }
 
         public void setYamlCycleCheck(boolean yamlCycleCheck) {
             this.yamlCycleCheck = yamlCycleCheck;
@@ -261,6 +263,8 @@ public class DeserializationUtils {
             method.invoke(loaderOptions, options.isYamlAllowRecursiveKeys());
             method = LoaderOptions.class.getMethod("setAllowDuplicateKeys", boolean.class);
             method.invoke(loaderOptions, false);
+            method = LoaderOptions.class.getMethod("setCodePointLimit", int.class);
+            method.invoke(loaderOptions, options.getMaxYamlCodePoints());
             org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml(constructor, new Representer(), new DumperOptions(), loaderOptions, new CustomResolver());
             return yaml;
         } catch (ReflectiveOperationException e) {


### PR DESCRIPTION
With this patch, a user may set the system property 'maxYamlCodePoints' in order to override the default 3MiB limit configured in the org.yaml.snakeyaml package by default. This limit was implemented to prevent certain Denial-of-Service (DOS) attacks, but users should be given the opportunity to override this value for valid configurations which exceed the limit, such as the Redfish OpenAPI specification (developed by DMTF), which weighs in at 4.9MiB.

This patch was tested to work with openapi-generator-cli v6.3.0.

This PR closes #1871 

Signed-off-by: Ethan D. Twardy <ethan.twardy@gmail.com>