### PR TITLE
Add test to expose issue 1572 - spaces in path to doc using relative server

### DIFF
--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/OpenAPIDeserializerTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/OpenAPIDeserializerTest.java
@@ -4167,4 +4167,14 @@ public class OpenAPIDeserializerTest {
                 "        valid: false\n");
     }
 
+    @Test
+    public void testIssue1572() {
+        OpenAPIV3Parser parser = new OpenAPIV3Parser();
+        ParseOptions options = new ParseOptions();
+        options.setInferSchemaType(false);
+        SwaggerParseResult result = parser.readLocation("./src/test/resources/space in name/issue-1572.yaml", null, options);
+
+        assertNotNull(result.getOpenAPI());
+    }
+
 }

--- a/modules/swagger-parser-v3/src/test/resources/space in name/issue-1572.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/space in name/issue-1572.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.3
+info:
+  title: Test issue 1572 - space in path to OpenAPI doc
+  version: "1"
+servers:
+  - url: /
+paths:
+  /:
+    get:
+      responses:
+        200:
+          description: Normal


### PR DESCRIPTION
#1572 shows that when a document is read from a location with spaces (or other URI-invalid characters) and has a relative server path, an error parsing the document occurs.

This PR starts by exposing the issue through a new test.