### PR TITLE
bump snakeyaml to 2.0 and jackson to 2.14.2

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/DeserializationUtils.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/DeserializationUtils.java
@@ -200,7 +200,7 @@ public class DeserializationUtils {
     public static JsonNode readYamlTree(String contents, ParseOptions parseOptions, SwaggerParseResult deserializationUtilsResult) {
 
         if (parseOptions != null && parseOptions.isLegacyYamlDeserialization()) {
-            org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml(new SafeConstructor());
+            org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml();
             return Json.mapper().convertValue(yaml.load(contents), JsonNode.class);
         }
         try {
@@ -208,7 +208,7 @@ public class DeserializationUtils {
             if (options.isValidateYamlInput()) {
                 yaml = buildSnakeYaml(new CustomSnakeYamlConstructor());
             } else {
-                yaml = buildSnakeYaml(new SafeConstructor());
+                yaml = buildSnakeYaml(new SafeConstructor(new LoaderOptions()));
             }
             Object o = yaml.load(contents);
             if (options.isValidateYamlInput()) {
@@ -244,7 +244,7 @@ public class DeserializationUtils {
         return readYamlValue(contents, expectedType, false);
     }
     public static <T> T readYamlValue(String contents, Class<T> expectedType, boolean openapi31) {
-        org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml(new SafeConstructor());
+        org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml();
         ObjectMapper jsonMapper = openapi31 ? Json31.mapper() : Json.mapper();
         return jsonMapper.convertValue(yaml.load(contents), expectedType);
     }
@@ -265,7 +265,7 @@ public class DeserializationUtils {
             method.invoke(loaderOptions, false);
             method = LoaderOptions.class.getMethod("setCodePointLimit", int.class);
             method.invoke(loaderOptions, options.getMaxYamlCodePoints());
-            org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml(constructor, new Representer(), new DumperOptions(), loaderOptions, new CustomResolver());
+            org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml(constructor, new Representer(new DumperOptions()), new DumperOptions(), loaderOptions, new CustomResolver());
             return yaml;
         } catch (ReflectiveOperationException e) {
             //
@@ -396,7 +396,11 @@ public class DeserializationUtils {
 
     static class CustomSnakeYamlConstructor extends SafeConstructor {
 
-        private boolean checkNode(MappingNode node, Integer depth) {
+      public CustomSnakeYamlConstructor() {
+        super(new LoaderOptions());
+      }
+
+      private boolean checkNode(MappingNode node, Integer depth) {
             if (node.getValue() == null) return true;
             if (depth > options.getMaxYamlDepth()) return false;
             int currentDepth = depth;

--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
         </repository>
     </repositories>
     <properties>
-        <snakeyaml-version>1.33</snakeyaml-version>
+        <snakeyaml-version>2.0</snakeyaml-version>
         <swagger-parser-v2-version>1.0.64</swagger-parser-v2-version>
         <commons-io-version>2.11.0</commons-io-version>
         <slf4j-version>1.7.30</slf4j-version>
@@ -414,8 +414,8 @@
         <wiremock-version>2.15.0</wiremock-version>
         <surefire-version>2.22.2</surefire-version>
         <commons-lang-version>3.2.1</commons-lang-version>
-        <jackson-version>2.14.0</jackson-version>
-        <jackson-databind-version>2.14.0</jackson-databind-version>
+        <jackson-version>2.14.2</jackson-version>
+        <jackson-databind-version>2.14.2</jackson-databind-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
     </properties>


### PR DESCRIPTION
Hello,

This pull request is bumping `snakeyaml` to 2.0 and `jackson` (including `jackson-databind`) to 2.14.2.

There are CVEs linked to this libraries:
- https://github.com/swagger-api/swagger-parser/issues/1836
- https://github.com/swagger-api/swagger-core/issues/4323

I understand that the [CVE-2022-1471](https://nvd.nist.gov/vuln/detail/CVE-2022-1471) is not applicable to `swagger-parser` because the `SafeConstructor` is used.

However, I see that `snakeyaml` has been updated to version 2.0 on `swagger-core`.
I'm also facing conflict issues in projects where there are imports from `snakeyaml` `1.30+` and `2.0`.

IMO, it will be good that `swagger-parser` use `snakeyaml` `2.0`.

I've made the minimal changes: updating libraries version and use default constructor that is now safe by default with `2.0`.
Locally all tests are passing.

Regards, 
