### PR TITLE
add setter to define max-code points

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/DeserializationUtils.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/DeserializationUtils.java
@@ -74,12 +74,18 @@ public class DeserializationUtils {
             return yamlCycleCheck;
         }
 
-        public Integer getMaxYamlCodePoints() { return maxYamlCodePoints; }
-
         public void setYamlCycleCheck(boolean yamlCycleCheck) {
             this.yamlCycleCheck = yamlCycleCheck;
         }
 
+        public Integer getMaxYamlCodePoints() {
+          return maxYamlCodePoints;
+        }
+
+        public void setMaxYamlCodePoints(Integer maxYamlCodePoints) {
+          this.maxYamlCodePoints = maxYamlCodePoints;
+        }
+        
         public Integer getMaxYamlAliasesForCollections() {
             return maxYamlAliasesForCollections;
         }


### PR DESCRIPTION
- streamline with all other options that are programmatically accessible
- simplify non-cli usage of the swagger-parser, where setting system.properties is unnatural