### PR TITLE
Bugfix 1955 Schema refs of array parameters are not resolved for renamed schema components

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/PathsProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/PathsProcessor.java
@@ -245,7 +245,7 @@ public class PathsProcessor {
                 for(String key : properties.keySet()) {
                     Schema property = properties.get(key);
                     if (property != null) {
-                        updateRefs(property, pathRef);
+                        updateRefs(property, "");
                     }
                 }
             }
@@ -254,22 +254,22 @@ public class PathsProcessor {
             ComposedSchema composedSchema = (ComposedSchema) model;
             if (composedSchema.getAllOf() != null) {
                 for (Schema innerModel : composedSchema.getAllOf()) {
-                    updateRefs(innerModel, pathRef);
+                    updateRefs(innerModel, "");
                 }
             }if (composedSchema.getAnyOf() != null) {
                 for(Schema innerModel : composedSchema.getAnyOf()) {
-                    updateRefs(innerModel, pathRef);
+                    updateRefs(innerModel, "");
                 }
             }if (composedSchema.getOneOf() != null) {
                 for (Schema innerModel : composedSchema.getOneOf()) {
-                    updateRefs(innerModel, pathRef);
+                    updateRefs(innerModel, "");
                 }
             }
         }
         else if(model instanceof ArraySchema) {
             ArraySchema arraySchema = (ArraySchema) model;
             if(arraySchema.getItems() != null) {
-                updateRefs(arraySchema.getItems(), pathRef);
+                updateRefs(arraySchema.getItems(), "");
             }
         }
     }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/processors/PathsProcessorTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/processors/PathsProcessorTest.java
@@ -4,13 +4,20 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.PathItem.HttpMethod;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import org.testng.annotations.Test;
 
+import java.net.URL;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import static java.lang.String.format;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class PathsProcessorTest {
 
@@ -41,6 +48,36 @@ public class PathsProcessorTest {
 
         assertOperationsHasParameters(openAPI, "/ref/test/{id}/operationlevelparam");
     }
+
+    @Test
+    public void testProcessPaths_refsToRenamedSchemasResolved() {
+		URL mergeSpecLocation = getClass().getClassLoader().getResource("issue-1955/merged_spec12.yaml");
+		Objects.requireNonNull(mergeSpecLocation);
+		ParseOptions parseOptions = new ParseOptions();
+		parseOptions.setResolve(true);
+
+		SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readLocation(mergeSpecLocation.toString(), null, parseOptions);
+
+		swaggerParseResult.getOpenAPI()
+				.getPaths().values().stream()
+				.flatMap(path -> path.readOperationsMap().values().stream())
+				.flatMap(operation -> operation.getParameters().stream())
+				.map(Parameter::getSchema)
+				.forEach(this::assertSchemaNoExternalRefs);
+	}
+
+	private void assertSchemaNoExternalRefs(Schema<?> schema) {
+		if (schema.get$ref() != null) {
+			assertSchemaRefInternal(schema.get$ref());
+		}
+		if (schema.getItems() != null && schema.getItems().get$ref() != null) {
+			assertSchemaRefInternal(schema.getItems().get$ref());
+		}
+	}
+
+	private void assertSchemaRefInternal(String ref) {
+		assertTrue(ref.startsWith("#"));
+	}
 
     private void assertOperationsHasParameters(OpenAPI openAPI, String path) {
         PathItem pathItem = openAPI.getPaths().get(path);

--- a/modules/swagger-parser-v3/src/test/resources/issue-1955/merged_spec12.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1955/merged_spec12.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.1
+info:
+  title: merged spec
+  version: 1.0.0
+servers:
+  - url: http://localhost:8080
+
+paths:
+
+  /getEmptyOne:
+    $ref: "./spec1.yaml#/paths/~1getEmptyOne"
+
+  /getEmptyTwo:
+    $ref: "./spec2.yaml#/paths/~1getEmptyTwo"

--- a/modules/swagger-parser-v3/src/test/resources/issue-1955/spec1.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1955/spec1.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.1
+info:
+  title: spec 1
+  version: 1.0.0
+servers:
+  - url: http://localhost:8080
+
+paths:
+
+  /getEmptyOne:
+    get:
+      operationId: getEmptyOne
+      parameters:
+        - name: element
+          in: query
+          schema:
+            $ref: '#/components/schemas/myType'
+        - name: elements
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/myType'
+      responses:
+        "204":
+          description: empty
+
+components:
+  schemas:
+
+    myType:
+      type: string

--- a/modules/swagger-parser-v3/src/test/resources/issue-1955/spec2.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1955/spec2.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.1
+info:
+  title: spec 2
+  version: 1.0.0
+servers:
+  - url: http://localhost:8080
+
+paths:
+
+  /getEmptyTwo:
+    get:
+      operationId: getEmptyTwo
+      parameters:
+        - name: element
+          in: query
+          schema:
+            $ref: '#/components/schemas/myType'
+        - name: elements
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/myType'
+      responses:
+        "204":
+          description: empty
+
+components:
+  schemas:
+
+    myType:
+      type: integer

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
                         <artifactId>surefire-junit4</artifactId>
                         <version>3.0.0</version>
                     </dependency>
+                    <dependency>
+                        <groupId>org.testng</groupId>
+                        <artifactId>testng</artifactId>
+                        <version>${testng-version}</version>
+                    </dependency>
                 </dependencies>
                 <configuration>
                     <testNGArtifactName>none:none</testNGArtifactName>


### PR DESCRIPTION
Fix for https://github.com/swagger-api/swagger-parser/issues/1955
It also fixes https://github.com/swagger-api/swagger-parser/issues/1918