### PR TITLE
Add fallback to Thread Context Class Loader for resource loading

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ClasspathHelper.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ClasspathHelper.java
@@ -13,13 +13,17 @@ public class ClasspathHelper {
         String file = FilenameUtils.separatorsToUnix(location);
 
         InputStream inputStream = ClasspathHelper.class.getResourceAsStream(file);
-
+        
         if(inputStream == null) {
             inputStream = ClasspathHelper.class.getClassLoader().getResourceAsStream(file);
         }
 
         if(inputStream == null) {
             inputStream = ClassLoader.getSystemResourceAsStream(file);
+        }
+
+        if(inputStream == null) {
+            inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(file);
         }
 
         if(inputStream != null) {


### PR DESCRIPTION
This commit adds a fallback to `Thread.currentThread().getContextClassLoader().getResourceAsStream(file)` in the `ClasspathHelper` class.

Previously, if the `ClasspathHelper.class.getResourceAsStream(file)` and `ClassLoader.getSystemResourceAsStream(file)` methods returned `null`, no further attempts were made to load the resource, which caused issues in Quarkus applications in dev mode.

This commit adds an additional fallback to `Thread.currentThread().getContextClassLoader().getResourceAsStream(file)` to improve compatibility with the Quarkus class loading model.

Related Issue: #1968