### PR TITLE
Fixes issue 1975: bug in const processing, const values of all types now processable

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -4155,7 +4155,7 @@ public class OpenAPIDeserializer {
 			schema.setPatternProperties(patternProperties);
 		}
 
-		Object constValue = getObject("const", node, false, location, result);
+		Object constValue = getAnyType("const", node, location, result);
 		if (constValue != null) {
 			schema.setConst(constValue);
 		}

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -4155,10 +4155,9 @@ public class OpenAPIDeserializer {
 			schema.setPatternProperties(patternProperties);
 		}
 
-		//const is a String
-		value = getString("const", node, false, location, result);
-		if (value != null) {
-			schema.setConst(value);
+		Object constValue = getObject("const", node, false, location, result);
+		if (constValue != null) {
+			schema.setConst(constValue);
 		}
 
 		value = getString("contentEncoding", node, false, location, result);

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/issue-1975.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/issue-1975.yaml
@@ -1,0 +1,64 @@
+openapi: 3.1.0
+servers:
+  - url: https://someserver.com/v1
+info:
+  title: openapi 3.1.0 sample spec
+  version: 0.0.1
+  description: sample spec for testing openapi functionality, built from json schema
+    tests for draft2020-12
+tags: []
+paths: {}
+components:
+  schemas:
+    ConstValidation:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const: 2
+    ConstWithObject:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const:
+        foo: bar
+        baz: bax
+    ConstWithArray:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const:
+        - foo: bar
+    ConstWithNull:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const: null
+    ConstWithFalseDoesNotMatch0:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const: false
+    ConstWithTrueDoesNotMatch1:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const: true
+    ConstWithArrayFalseDoesNotMatch0:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const:
+        - false
+    ConstWithArrayTrueDoesNotMatch1:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const:
+        - true
+    ConstWithAFalseDoesNotMatchA0:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const:
+        a: false
+    ConstWithATrueDoesNotMatchA1:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const:
+        a: true
+    ConstWith0DoesNotMatchOtherZeroLikeTypes:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const: 0
+    ConstWith1DoesNotMatchTrue:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const: 1
+    ConstWith20MatchesIntegerAndFloatTypes:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const: -2.0
+    ConstFloatAndIntegersAreEqualUpTo64BitRepresentationLimits:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const: 9007199254740992
+    ConstNulCharactersInStrings:
+      $schema: https://json-schema.org/draft/2020-12/schema
+      const: "hello\0there"


### PR DESCRIPTION
Changes const type from String to Object
Per json schema docs, const stores one values of any json schema type
- [json schema spec const definition](https://json-schema.org/draft/2020-12/json-schema-validation#name-const)
- [understanding const docs](https://json-schema.org/understanding-json-schema/reference/const)
- real world examples of const values in the json schema test suite, the schema value stored in the `"schema"` key: https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/const.json#L6

Verification:
- java tests added verifying ingestion of json null/string/number/object/array/boolean

If merged, this will close out these issues:
- https://github.com/swagger-api/swagger-parser/issues/1975
- https://github.com/swagger-api/swagger-parser/issues/1966

