### PR TITLE
feat: introduce cache loaded extensions in OpenAPIDeserializer

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/SchemaProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/SchemaProcessor.java
@@ -47,7 +47,6 @@ public class SchemaProcessor {
             return;
         }
         if (openapi31) {
-            // TODO use as singleton somewhere loaded as static used by both here and deserializer
             List<JsonSchemaParserExtension> jsonschemaExtensions = OpenAPIDeserializer.getJsonSchemaParserExtensions();
             for (JsonSchemaParserExtension jsonschemaExtension: jsonschemaExtensions) {
                 if (jsonschemaExtension.resolveSchema(schema, cache, openAPI, openapi31)) {


### PR DESCRIPTION
This PR provides a cache mechanism that stores the extensions loaded per classloader.
Due to the caching mechanism the performance for loading the extensions (jsonSchemaParserExtensions) is improved.
This PR closes #1909 