### PR TITLE
[Issue 2046] NPE in OpenAPIV3Parser.read(String, List<AuthorizationValue>, ParseOptions)

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIV3Parser.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIV3Parser.java
@@ -122,8 +122,10 @@ public class OpenAPIV3Parser implements SwaggerParserExtension {
         SwaggerParseResult parsed;
         for (SwaggerParserExtension extension : parserExtensions) {
             parsed = extension.readLocation(location, auths, resolve);
-            for (String message : parsed.getMessages()) {
-                LOGGER.info("{}: {}", extension, message);
+            if (parsed.getMessages() != null) {
+                for (String message : parsed.getMessages()) {
+                    LOGGER.info("{}: {}", extension, message);
+                }
             }
             final OpenAPI result = parsed.getOpenAPI();
             if (result != null) {


### PR DESCRIPTION
Issue: https://github.com/swagger-api/swagger-parser/issues/2046
PR: https://github.com/swagger-api/swagger-parser/pull/2047
```
java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because the return value of "io.swagger.v3.parser.core.models.SwaggerParseResult.getMessages()" is null
	at io.swagger.v3.parser.OpenAPIV3Parser.read(OpenAPIV3Parser.java:125)
	at ...
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
```
The test is convoluted because the real test would be in the main parser module plus a dependency on this module, which one cannot do due to circularity, but, note that the NPE and fix are "real" and have been tested in production on my end.
