### PR TITLE
[Issue 2048] NullPointerException in SchemaProcessor.processArraySchema()

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/SchemaProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/SchemaProcessor.java
@@ -65,6 +65,9 @@ public class SchemaProcessor {
 
     public void processSchemaType(Schema schema){
 
+        if (schema == null) {
+            return;
+        }
         if (schema instanceof ArraySchema) {
             processArraySchema((ArraySchema) schema);
         }
@@ -215,7 +218,7 @@ public class SchemaProcessor {
     public void processArraySchema(ArraySchema arraySchema) {
 
         final Schema items = arraySchema.getItems();
-        if (items.get$ref() != null) {
+        if (items != null && items.get$ref() != null) {
             processReferenceSchema(items);
         }else{
             processSchemaType(items);

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/InlineModelResolver.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/InlineModelResolver.java
@@ -735,6 +735,9 @@ public class InlineModelResolver {
     }
 
     private boolean isObjectSchema(Schema schema) {
+        if (schema == null) {
+            return false;
+        }
         return schema instanceof ObjectSchema
                 || "object".equalsIgnoreCase(schema.getType())
                 || (schema.getType() == null && schema.getProperties() != null && !schema.getProperties().isEmpty()

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
@@ -1464,4 +1464,13 @@ public class OpenAPIResolverTest {
         return new Random().ints(50000, 60000).findFirst().getAsInt();
     }
 
+    @Test
+    public void testResolveArraySchemaItemsNullPointerException() {
+        final ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        final String actualLocation = "C:/Users/ggregory/git/r/api-gateway/ais-swagger-test-fixtures/src/test/resources/APIs-guru/openapi-directory-master/APIs/clearblade.com/3.0/swagger.yaml";
+        final OpenAPI output = new OpenAPIV3Parser().read(actualLocation, null, options);
+        new OpenAPIResolver(output, null, actualLocation).resolve();
+    }
+    
 }


### PR DESCRIPTION
Issue: https://github.com/swagger-api/swagger-parser/issues/2048
PR: https://github.com/swagger-api/swagger-parser/pull/2049

```
Caused by: java.lang.NullPointerException: Cannot invoke
"io.swagger.v3.oas.models.media.Schema.get$ref()" because "items" is
null
	at io.swagger.v3.parser.processors.SchemaProcessor.processArraySchema(SchemaProcessor.java:218)
	at io.swagger.v3.parser.processors.SchemaProcessor.processSchemaType(SchemaProcessor.java:69)
	at io.swagger.v3.parser.processors.SchemaProcessor.processPropertySchema(SchemaProcessor.java:139)
	at io.swagger.v3.parser.processors.SchemaProcessor.processSchemaType(SchemaProcessor.java:76)
	at io.swagger.v3.parser.processors.SchemaProcessor.processSchema(SchemaProcessor.java:61)
	at io.swagger.v3.parser.processors.ComponentsProcessor.processSchemas(ComponentsProcessor.java:231)
	at io.swagger.v3.parser.processors.ComponentsProcessor.processComponents(ComponentsProcessor.java:145)
	at io.swagger.v3.parser.OpenAPIResolver.resolve(OpenAPIResolver.java:73)
        ...
```
The above is from a log and I don't have a easy way to create a reproducer. You'll notice though that most call sites of `ArraySchema.getItems()` in this repo do check for a null result value, but not _all_ call sites.