### PR TITLE
[Composite types] When allOf contains only one type don't generate union classes

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -2686,14 +2686,17 @@ public class OpenAPIDeserializer {
 			ComposedSchema composedSchema = new ComposedSchema();
 
 			if (allOfArray != null) {
-
-				for (JsonNode n : allOfArray) {
-					if (n.isObject()) {
-						schema = getSchema((ObjectNode) n, location, result);
-						composedSchema.addAllOfItem(schema);
+				if (allOfArray.size() > 1) {
+					for (JsonNode n : allOfArray) {
+						if (n.isObject()) {
+							schema = getSchema((ObjectNode) n, location, result);
+							composedSchema.addAllOfItem(schema);
+						}
 					}
+					schema = composedSchema;
+				} else if (allOfArray.size() == 1) {
+					schema = getSchema((ObjectNode) allOfArray.get(0), location, result);
 				}
-				schema = composedSchema;
 			}
 			if (anyOfArray != null) {
 


### PR DESCRIPTION
Hello all,

I don't know if this may be of interest, but I think I saw some issues logged here and there of people asking for this kind of behaviour.
I originally wanted to make it optional, but I did't find any way to have some kind of configuration.

Thanks for the awesome work everybody and best regards.