### PR TITLE
Validate the api key 'in' attribute is cookie header or query.

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -2426,6 +2426,10 @@ public class OpenAPIDeserializer {
 				.filter(in -> in.toString().equals(securitySchemeIn))
 				.findFirst();
 
+		if (inRequired && securitySchemeIn != null && !matchingIn.isPresent()) {
+			result.invalidType(location, "in", "cookie|header|query", node);
+		}
+
 		securityScheme.setIn(matchingIn.orElse(null));
 
 		value = getString("scheme", node, schemeRequired, location, result);

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/NetworkReferenceTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/NetworkReferenceTest.java
@@ -92,7 +92,7 @@ public class NetworkReferenceTest {
         OpenAPI openAPI = result.getOpenAPI();
 
         assertNotNull(result.getMessages());
-        assertEquals(result.getMessages().size(), 19);
+        assertEquals(result.getMessages().size(), 20);
         assertNotNull(openAPI);
         assertTrue(result.getMessages().contains("attribute components.requestBodies.NewItem.asdasd is unexpected (./ref.yaml)"));
         assertTrue(result.getMessages().contains("attribute components.requestBodies.NewItem.descasdasdription is unexpected (./ref.yaml)"));
@@ -103,6 +103,7 @@ public class NetworkReferenceTest {
         assertTrue(result.getMessages().contains("attribute components.parameters.skipParam.[skip].in is not of type `[query|header|path|cookie]` (./ref.yaml)"));
         assertTrue(result.getMessages().contains("attribute components.securitySchemes.api_key.namex is unexpected (./ref.yaml)"));
         assertTrue(result.getMessages().contains("attribute components.securitySchemes.api_key.name is missing (./ref.yaml)"));
+        assertTrue(result.getMessages().contains("attribute components.securitySchemes.api_key.in is not of type `cookie|header|query` (./ref.yaml)"));
         assertTrue(result.getMessages().contains("attribute components.callbacks.webhookVerificationEvent.postx is unexpected (./ref.yaml)"));
         assertTrue(result.getMessages().contains("attribute components.headers.X-Rate-Limit-Limit.descriptasdd is unexpected (./ref.yaml)"));
         assertTrue(result.getMessages().contains("attribute components.links.unsubscribe.parametersx is unexpected (./ref.yaml)"));

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -3058,7 +3058,6 @@ public class OpenAPIV3ParserTest {
         options.setResolve(true);
         SwaggerParseResult result = new OpenAPIV3Parser().readLocation("./swos-443/root.yaml", null, options);
         OpenAPI openAPI = result.getOpenAPI();
-
         assertNotNull(openAPI);
         assertNotNull(result.getMessages());
         assertEquals(result.getMessages().size(), 20);

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -3058,9 +3058,10 @@ public class OpenAPIV3ParserTest {
         options.setResolve(true);
         SwaggerParseResult result = new OpenAPIV3Parser().readLocation("./swos-443/root.yaml", null, options);
         OpenAPI openAPI = result.getOpenAPI();
+
         assertNotNull(openAPI);
         assertNotNull(result.getMessages());
-        assertEquals(result.getMessages().size(), 19);
+        assertEquals(result.getMessages().size(), 20);
         assertTrue(result.getMessages().contains("attribute components.requestBodies.NewItem.asdasd is unexpected (./ref.yaml)"));
         assertTrue(result.getMessages().contains("attribute components.requestBodies.NewItem.descasdasdription is unexpected (./ref.yaml)"));
         assertTrue(result.getMessages().contains("attribute components.responses.GeneralError.descrsaiption is unexpected (./ref.yaml)"));
@@ -3070,6 +3071,7 @@ public class OpenAPIV3ParserTest {
         assertTrue(result.getMessages().contains("attribute components.parameters.skipParam.[skip].in is not of type `[query|header|path|cookie]` (./ref.yaml)"));
         assertTrue(result.getMessages().contains("attribute components.securitySchemes.api_key.namex is unexpected (./ref.yaml)"));
         assertTrue(result.getMessages().contains("attribute components.securitySchemes.api_key.name is missing (./ref.yaml)"));
+        assertTrue(result.getMessages().contains("attribute components.securitySchemes.api_key.in is not of type `cookie|header|query` (./ref.yaml)"));
         assertTrue(result.getMessages().contains("attribute components.callbacks.webhookVerificationEvent.postx is unexpected (./ref.yaml)"));
         assertTrue(result.getMessages().contains("attribute components.headers.X-Rate-Limit-Limit.descriptasdd is unexpected (./ref.yaml)"));
         assertTrue(result.getMessages().contains("attribute components.links.unsubscribe.parametersx is unexpected (./ref.yaml)"));

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/OpenAPIDeserializerTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/OpenAPIDeserializerTest.java
@@ -492,6 +492,59 @@ public class OpenAPIDeserializerTest {
     }
 
     @Test
+    public void testSecurityDefinitionApiKeyWithMissingAttributeIn() {
+        String yaml = "openapi: 3.0.0\n" +
+                "components:\n" +
+                "  securitySchemes:\n" +
+                "    api_key:\n" +
+                "      type: apiKey\n" +
+                "      name: X-API-KEY";
+
+        OpenAPIV3Parser parser = new OpenAPIV3Parser();
+        SwaggerParseResult result = parser.readContents(yaml, null, null);
+        List<String> messageList = result.getMessages();
+        Set<String> messages = new HashSet<>(messageList);
+
+        assertTrue(messages.contains("attribute components.securitySchemes.api_key.in is missing"));
+    }
+
+    @Test
+    public void testSecurityDefinitionApiKeyWithInvalidAttributeIn() {
+        String yaml = "openapi: 3.0.0\n" +
+                "components:\n" +
+                "  securitySchemes:\n" +
+                "    api_key:\n" +
+                "      type: apiKey\n" +
+                "      name: X-API-KEY\n" +
+                "      in: cukie";
+
+        OpenAPIV3Parser parser = new OpenAPIV3Parser();
+        SwaggerParseResult result = parser.readContents(yaml, null, null);
+        List<String> messageList = result.getMessages();
+        Set<String> messages = new HashSet<>(messageList);
+
+        assertTrue(messages.contains("attribute components.securitySchemes.api_key.in is not of type `cookie|header|query`"));
+    }
+
+    @Test
+    public void testSecurityDefinitionApiKeyValid() {
+        String yaml = "openapi: 3.0.0\n" +
+                "components:\n" +
+                "  securitySchemes:\n" +
+                "    api_key:\n" +
+                "      type: apiKey\n" +
+                "      name: X-API-KEY\n" +
+                "      in: cookie";
+
+        OpenAPIV3Parser parser = new OpenAPIV3Parser();
+        SwaggerParseResult result = parser.readContents(yaml, null, null);
+        List<String> messageList = result.getMessages();
+        Set<String> messages = new HashSet<>(messageList);
+
+        assertFalse(messages.contains("attribute components.securitySchemes.api_key.in is not of type `cookie|header|query`"));
+    }
+
+    @Test
     public void testRootInfo() {
         String json = "{\n" +
                 "\t\"openapi\": \"3.0.0\",\n" +


### PR DESCRIPTION
This is a valid API key definition.

```yaml
components:
  securitySchemes:
    ApiKeyAuth:        # arbitrary name for the security scheme
      type: apiKey
      in: header       # can be "header", "query" or "cookie"
      name: X-API-KEY  # name of the header, query parameter or cookie
```

There already is validation that checks the `in` attribute is present. The purpose of this PR is to validate that the attribute value is one of "header", "query", or "cookie".

[Swagger docs](https://swagger.io/docs/specification/authentication/api-keys/) for reference.