### PR TITLE
Issue 1886

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.parser.ResolverCache;
 import io.swagger.v3.parser.models.RefFormat;
 import io.swagger.v3.parser.models.RefType;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.LoggerFactory;
 
@@ -130,10 +131,11 @@ public final class ExternalRefProcessor {
                                 String[] parts = schemaFullRef.split("#/");
                                 String schemaFullRefFilePart = parts[0];
                                 String schemaFullRefInternalRefPart = parts[1];
-                                schemaFullRef = Paths.get(parent, schemaFullRefFilePart).normalize().toString() + "#/" + schemaFullRefInternalRefPart;
+                                schemaFullRef = Paths.get(parent, schemaFullRefFilePart).normalize() + "#/" + schemaFullRefInternalRefPart;
                             } else {
                                 schemaFullRef = Paths.get(parent, schemaFullRef).normalize().toString();
                             }
+                            schemaFullRef = FilenameUtils.separatorsToUnix(schemaFullRef);
                         }
                         schema.set$ref(processRefToExternalSchema(schemaFullRef, ref));
                     }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -3269,4 +3269,20 @@ public class OpenAPIV3ParserTest {
             }
         }
     }
+
+    @Test
+    public void testIssue1886() {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        options.setFlatten(true);
+        OpenAPIV3Parser openApiParser = new OpenAPIV3Parser();
+        SwaggerParseResult parseResult = openApiParser.readLocation("issue-1886/openapi.yaml", null, options);
+        OpenAPI openAPI = parseResult.getOpenAPI();
+        assertEqualsNoOrder(
+            openAPI.getComponents().getSchemas().keySet(),
+            Arrays.asList("ArrayPojo", "Enum1", "Enum1_1", "Enum2", "Enum3", "MapPojo", "SetPojo", "SimplePojo",
+                "TransactionsPatchRequestBody", "additional-properties", "array-pojo", "locale-translation-item",
+                "map-pojo", "set-pojo", "simple-pojo", "translation-item")
+        );
+    }
 }

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/components.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/components.yaml
@@ -1,0 +1,19 @@
+Enum1:
+  $ref: schemas/enum1.yaml
+Enum2:
+  type: string
+  enum: [a, b, c]
+  nullable: false
+Enum3:
+  type: string
+  enum: [x, y, z]
+  nullable: true
+
+SimplePojo:
+  $ref: schemas/simple-pojo.yaml
+ArrayPojo:
+  $ref: schemas/array-pojo.yaml
+MapPojo:
+  $ref: schemas/map-pojo.yaml
+SetPojo:
+  $ref: schemas/set-pojo.yaml

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/openapi.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/openapi.yaml
@@ -1,0 +1,71 @@
+openapi: 3.0.3
+
+info:
+  title: Arrangement Support
+  version: '1.0'
+  
+paths:
+  /simple-types:
+    $ref: paths/simple-types.yaml
+  /simple-types/{id}/{ids}:
+    $ref: paths/simple-types-ids.yaml
+  /array-types:
+    $ref: paths/array-types.yaml
+  /array-types/{id}/{ids}:
+    $ref: paths/array-types-ids.yaml
+  /set-types:
+    $ref: paths/set-types.yaml
+  /set-types/{id}/{ids}:
+    $ref: paths/set-types-ids.yaml
+  /map-types:
+    $ref: paths/map-types.yaml
+  /map-types/{id}/{ids}:
+    $ref: paths/map-types-ids.yaml
+  /transactions:
+    patch:
+      tags:
+      - transactions
+      summary: patch
+      description: Updates list of transactions
+      operationId: patchTransactions
+      requestBody:
+        description: Updates list of transactions
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/TransactionsPatchRequestBody'
+      responses:
+        "204":
+          description: OK
+
+components:
+  schemas:
+    TransactionsPatchRequestBody:
+      required:
+      - id
+      type: object
+      properties:
+        id:
+          maxLength: 300
+          type: string
+          description: Unique identification for the transaction as used in the external
+            system
+        arrangementId:
+          maxLength: 50
+          type: string
+          description: An external reference to the arrangement the transaction belongs
+            to
+        category:
+          maxLength: 50
+          type: string
+          description: Transaction category
+        billingStatus:
+          maxLength: 8
+          type: string
+        creationTime:
+          type: string
+          format: date-time
+          x-java-type: java.time.OffsetDateTime
+  

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/array-types-ids.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/array-types-ids.yaml
@@ -1,0 +1,40 @@
+parameters:
+  - name: id
+    required: true
+    in: path
+    schema:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+  - name: ids
+    in: path
+    required: true
+    schema:
+      type: array
+      items:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+delete:
+  tags:
+    - array-types
+  x-content-language: application/json
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            $ref: '../components.yaml#/ArrayPojo'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../components.yaml#/ArrayPojo'

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/array-types.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/array-types.yaml
@@ -1,0 +1,134 @@
+get:
+  tags:
+    - array-types
+  x-content-language: application/json
+  parameters:
+    - name: h-param
+      in: header
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: h-params
+      in: header
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: c-param
+      in: cookie
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: c-params
+      in: cookie
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-param
+      in: query
+      required: false
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: q-param-enum
+      in: query
+      required: false
+      schema:
+        $ref: '../components.yaml#/Enum1'
+    - name: q-param-req
+      in: query
+      required: true
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: q-param-enum-req
+      in: query
+      required: true
+      schema:
+        $ref: '../components.yaml#/Enum2'
+    - name: q-params
+      in: query
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-params-enum
+      in: query
+      schema:
+        type: array
+        items:
+          $ref: '../components.yaml#/Enum3'
+    - name: q-params-req
+      in: query
+      required: true
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-params-set
+      in: query
+      required: false
+      schema:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-params-set-req
+      in: query
+      required: true
+      schema:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '../components.yaml#/ArrayPojo'
+post:
+  tags:
+    - array-types
+  x-content-language: application/json
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components.yaml#/ArrayPojo'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '../components.yaml#/ArrayPojo'

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/map-types-ids.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/map-types-ids.yaml
@@ -1,0 +1,40 @@
+parameters:
+  - name: id
+    required: true
+    in: path
+    schema:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+  - name: ids
+    in: path
+    required: true
+    schema:
+      type: array
+      items:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+delete:
+  tags:
+    - simple-types
+  x-content-language: application/json
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            $ref: '../components.yaml#/SimplePojo'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../components.yaml#/SimplePojo'

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/map-types.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/map-types.yaml
@@ -1,0 +1,134 @@
+get:
+  tags:
+    - map-types
+  x-content-language: application/json
+  parameters:
+    - name: h-param
+      in: header
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: h-params
+      in: header
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: c-param
+      in: cookie
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: c-params
+      in: cookie
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-param
+      in: query
+      required: false
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: q-param-enum
+      in: query
+      required: false
+      schema:
+        $ref: '../components.yaml#/Enum1'
+    - name: q-param-req
+      in: query
+      required: true
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: q-param-enum-req
+      in: query
+      required: true
+      schema:
+        $ref: '../components.yaml#/Enum2'
+    - name: q-params
+      in: query
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-params-enum
+      in: query
+      schema:
+        type: array
+        items:
+          $ref: '../components.yaml#/Enum3'
+    - name: q-params-req
+      in: query
+      required: true
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-params-set
+      in: query
+      required: false
+      schema:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-params-set-req
+      in: query
+      required: true
+      schema:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '../components.yaml#/MapPojo'
+post:
+  tags:
+    - map-types
+  x-content-language: application/json
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components.yaml#/MapPojo'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '../components.yaml#/MapPojo'

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/set-types-ids.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/set-types-ids.yaml
@@ -1,0 +1,40 @@
+parameters:
+  - name: id
+    required: true
+    in: path
+    schema:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+  - name: ids
+    in: path
+    required: true
+    schema:
+      type: array
+      items:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+delete:
+  tags:
+    - simple-types
+  x-content-language: application/json
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            $ref: '../components.yaml#/SimplePojo'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../components.yaml#/SimplePojo'

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/set-types.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/set-types.yaml
@@ -1,0 +1,134 @@
+get:
+  tags:
+    - set-types
+  x-content-language: application/json
+  parameters:
+    - name: h-param
+      in: header
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: h-params
+      in: header
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: c-param
+      in: cookie
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: c-params
+      in: cookie
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-param
+      in: query
+      required: false
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: q-param-enum
+      in: query
+      required: false
+      schema:
+        $ref: '../components.yaml#/Enum1'
+    - name: q-param-req
+      in: query
+      required: true
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: q-param-enum-req
+      in: query
+      required: true
+      schema:
+        $ref: '../components.yaml#/Enum2'
+    - name: q-params
+      in: query
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-params-enum
+      in: query
+      schema:
+        type: array
+        items:
+          $ref: '../components.yaml#/Enum3'
+    - name: q-params-req
+      in: query
+      required: true
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-params-set
+      in: query
+      required: false
+      schema:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-params-set-req
+      in: query
+      required: true
+      schema:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '../components.yaml#/SetPojo'
+post:
+  tags:
+    - set-types
+  x-content-language: application/json
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components.yaml#/SetPojo'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '../components.yaml#/SetPojo'

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/simple-types-ids.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/simple-types-ids.yaml
@@ -1,0 +1,40 @@
+parameters:
+  - name: id
+    required: true
+    in: path
+    schema:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+  - name: ids
+    in: path
+    required: true
+    schema:
+      type: array
+      items:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+delete:
+  tags:
+    - simple-types
+  x-content-language: application/json
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            $ref: '../components.yaml#/SimplePojo'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../components.yaml#/SimplePojo'

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/simple-types.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/paths/simple-types.yaml
@@ -1,0 +1,134 @@
+get:
+  tags:
+    - simple-types
+  x-content-language: application/json
+  parameters:
+    - name: h-param
+      in: header
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: h-params
+      in: header
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: c-param
+      in: cookie
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: c-params
+      in: cookie
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-param
+      in: query
+      required: false
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: q-param-enum
+      in: query
+      required: false
+      schema:
+        $ref: '../components.yaml#/Enum1'
+    - name: q-param-req
+      in: query
+      required: true
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 36
+        pattern: '^[A-Z]+$'
+    - name: q-param-enum-req
+      in: query
+      required: true
+      schema:
+        $ref: '../components.yaml#/Enum2'
+    - name: q-params
+      in: query
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-params-enum
+      in: query
+      schema:
+        type: array
+        items:
+          $ref: '../components.yaml#/Enum3'
+    - name: q-params-req
+      in: query
+      required: true
+      schema:
+        type: array
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-params-set
+      in: query
+      required: false
+      schema:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+    - name: q-params-set-req
+      in: query
+      required: true
+      schema:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+          maxLength: 36
+          pattern: '^[A-Z]+$'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '../components.yaml#/SimplePojo'
+post:
+  tags:
+    - simple-types
+  x-content-language: application/json
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components.yaml#/SimplePojo'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '../components.yaml#/SimplePojo'

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/additional-properties.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/additional-properties.yaml
@@ -1,0 +1,12 @@
+title: AdditionalProperties
+type: object
+x-abstract: true
+properties:
+  additions:
+    x-extra-annotation: '@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY)'
+    type: object
+    additionalProperties:
+      type: string
+required:
+- additions
+description: Additional Properties

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/array-pojo.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/array-pojo.yaml
@@ -1,0 +1,74 @@
+title: ArrayPojo
+allOf:
+  - $ref: additional-properties.yaml
+x-implements:
+  - Cloneable
+properties:
+  pEnum1:
+    type: array
+    items:
+      $ref: '../components.yaml#/Enum1'
+  pEnum2:
+    type: array
+    items:
+      $ref: '../components.yaml#/Enum2'
+  pEnum3:
+    type: array
+    items:
+      $ref: '../components.yaml#/Enum3'
+  pInteger:
+    type: array
+    items:
+      type: integer
+      minimum: 0
+  pNumber:
+    type: array
+    items:
+      type: number
+      format: double
+      minimum: 0
+      maximum: 10
+      exclusiveMaximum: true
+  pDate:
+    type: array
+    items:
+      type: string
+      format: date
+  pDateTime:
+    type: array
+    items:
+      type: string
+      format: date-time
+  pString:
+    type: array
+    items:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+  pStringRequired:
+    type: array
+    items:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+  pStringNullable:
+    type: array
+    nullable: true
+    items:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+  pStringNullableRequired:
+    type: array
+    nullable: true
+    items:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+required:
+  - pStringRequired
+  - pStringNullableRequired

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/enum1.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/enum1.yaml
@@ -1,0 +1,8 @@
+title: Enum1
+type: integer
+enum: [ 200, 400, 404, 500 ]
+x-enum-varnames:
+  - HTTP_STATUS_OK
+  - HTTP_STATUS_BAD_REQUEST
+  - HTTP_STATUS_NOT_FOUND
+  - HTTP_STATUS_INTERNAL_SERVER_ERROR

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/locale-translation-item.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/locale-translation-item.yaml
@@ -1,0 +1,19 @@
+title: LocaleTranslationItem
+type: object
+allOf:
+  - $ref: additional-properties.yaml
+description: Locale Translation item
+properties:
+  fieldName:
+    type: string
+    minLength: 1
+    maxLength: 50
+    description: Defines the name of the field that is translated.
+  fieldValue:
+    type: string
+    minLength: 1
+    maxLength: 50
+    description: Defines the translated value of the field.
+required:
+  - fieldName
+  - fieldValue

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/map-pojo.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/map-pojo.yaml
@@ -1,0 +1,74 @@
+title: MapPojo
+allOf:
+  - $ref: additional-properties.yaml
+x-implements:
+  - Cloneable
+properties:
+  pEnum1:
+    type: object
+    additionalProperties:
+      $ref: '../components.yaml#/Enum1'
+  pEnum2:
+    type: object
+    additionalProperties:
+      $ref: '../components.yaml#/Enum2'
+  pEnum3:
+    type: object
+    additionalProperties:
+      $ref: '../components.yaml#/Enum3'
+  pInteger:
+    type: object
+    additionalProperties:
+      type: integer
+      minimum: 0
+  pNumber:
+    type: object
+    additionalProperties:
+      type: number
+      format: double
+      minimum: 0
+      maximum: 10
+      exclusiveMaximum: true
+  pDate:
+    type: object
+    additionalProperties:
+      type: string
+      format: date
+  pDateTime:
+    type: object
+    additionalProperties:
+      type: string
+      format: date-time
+  pString:
+    type: object
+    additionalProperties:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+  pStringRequired:
+    type: object
+    additionalProperties:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+  pStringNullable:
+    type: object
+    nullable: true
+    additionalProperties:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+  pStringNullableRequired:
+    type: object
+    nullable: true
+    additionalProperties:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+required:
+  - pStringRequired
+  - pStringNullableRequired

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/set-pojo.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/set-pojo.yaml
@@ -1,0 +1,85 @@
+title: SetPojo
+allOf:
+  - $ref: additional-properties.yaml
+x-implements:
+  - Cloneable
+properties:
+  pEnum1:
+    type: array
+    uniqueItems: true
+    items:
+      $ref: '../components.yaml#/Enum1'
+  pEnum2:
+    type: array
+    uniqueItems: true
+    items:
+      $ref: '../components.yaml#/Enum2'
+  pEnum3:
+    type: array
+    uniqueItems: true
+    items:
+      $ref: '../components.yaml#/Enum3'
+  pInteger:
+    type: array
+    uniqueItems: true
+    items:
+      type: integer
+      minimum: 0
+  pNumber:
+    type: array
+    uniqueItems: true
+    items:
+      type: number
+      format: double
+      minimum: 0
+      maximum: 10
+      exclusiveMaximum: true
+  pDate:
+    type: array
+    uniqueItems: true
+    items:
+      type: string
+      format: date
+  pDateTime:
+    type: array
+    uniqueItems: true
+    items:
+      type: string
+      format: date-time
+  pString:
+    type: array
+    uniqueItems: true
+    items:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+  pStringRequired:
+    type: array
+    uniqueItems: true
+    items:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+  pStringNullable:
+    type: array
+    nullable: true
+    uniqueItems: true
+    items:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+  pStringNullableRequired:
+    type: array
+    nullable: true
+    uniqueItems: true
+    items:
+      type: string
+      minLength: 1
+      maxLength: 36
+      pattern: '^[A-Z]+$'
+required:
+  - pStringRequired
+  - pStringNullableRequired

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/simple-pojo.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/simple-pojo.yaml
@@ -1,0 +1,57 @@
+title: SimplePojo
+allOf:
+  - $ref: additional-properties.yaml
+x-implements:
+  - Cloneable
+properties:
+  pEnum1:
+    $ref: '../components.yaml#/Enum1'
+  pEnum2:
+    $ref: '../components.yaml#/Enum2'
+  pEnum3:
+    $ref: '../components.yaml#/Enum3'
+  pInteger:
+    type: integer
+    minimum: 0
+  pNumber:
+    type: number
+    format: double
+    minimum: 0
+    maximum: 10
+    exclusiveMaximum: true
+  pDate:
+    type: string
+    format: date
+  pDateTime:
+    type: string
+    format: date-time
+  pString:
+    type: string
+    minLength: 1
+    maxLength: 36
+    pattern: '^[A-Z]+$'
+  pStringRequired:
+    type: string
+    minLength: 1
+    maxLength: 36
+    pattern: '^[A-Z]+$'
+  pStringNullable:
+    type: string
+    nullable: true
+    minLength: 1
+    maxLength: 36
+    pattern: '^[A-Z]+$'
+  pStringNullableRequired:
+    type: string
+    nullable: true
+    minLength: 1
+    maxLength: 36
+    pattern: '^[A-Z]+$'
+  translations:
+    type: array
+    uniqueItems: true
+    items:
+      $ref: translation-item.yaml
+required:
+  - pStringRequired
+  - pStringNullableRequired

--- a/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/translation-item.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1886/schemas/translation-item.yaml
@@ -1,0 +1,18 @@
+title: TranslationItem
+type: object
+allOf:
+  - $ref: additional-properties.yaml
+description: Translation item
+properties:
+  locale:
+    type: string
+    minLength: 1
+    maxLength: 50
+    description: Defines the translation natural language as specified in ISO 639-1,
+      and territory two-letter form of ISO 3166.
+  localeTranslations:
+    type: array
+    uniqueItems: true
+    items:
+      $ref: locale-translation-item.yaml
+


### PR DESCRIPTION
This PR is to fix https://github.com/swagger-api/swagger-parser/issues/1886

When parsing openapi definitions the results are different on Linux and Windows systems. It has been documented with the test: OpenAPIV3ParserTest#testIssue1886.

On Linux OS the schemas (with and without the fix) are resolved to:
ArrayPojo, Enum1, Enum1_1, Enum2, Enum3, MapPojo, SetPojo, SimplePojo, TransactionsPatchRequestBody, additional-properties, array-pojo, locale-translation-item, map-pojo, set-pojo, simple-pojo, translation-item

On Windows OS, without this fix, schemas are resolved to following names:
ArrayPojo, Enum1, Enum2, Enum3, MapPojo, SetPojo, SimplePojo, TransactionsPatchRequestBody, schemas\array-pojo, schemas\enum1, schemas\map-pojo, schemas\set-pojo, schemas\simple-pojo