### PR TITLE
Fix #750 by reusing ExternalRefProcessor

### DIFF
--- a/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/util/RefUtils.java
@@ -2,6 +2,7 @@ package io.swagger.parser.util;
 
 import io.swagger.models.auth.AuthorizationValue;
 import io.swagger.models.refs.RefFormat;
+import io.swagger.parser.processors.ExternalRefProcessor;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -80,45 +81,7 @@ public class RefUtils {
     }
 
     public static String buildUrl(String rootPath, String relativePath) {
-        String[] rootPathParts = rootPath.split("/");
-        String [] relPathParts = relativePath.split("/");
-
-        if(rootPath == null || relativePath == null) {
-            return null;
-        }
-
-        int trimRoot = 0;
-        int trimRel = 0;
-
-        if(!"".equals(rootPathParts[rootPathParts.length - 1])) {
-            trimRoot = 1;
-        }
-        for(int i = 0; i < rootPathParts.length; i++) {
-            if("".equals(rootPathParts[i])) {
-                trimRel += 1;
-            }
-            else {
-                break;
-            }
-        }
-        for(int i = 0; i < relPathParts.length; i ++) {
-            if(".".equals(relPathParts[i])) {
-                trimRel += 1;
-            }
-            else if ("..".equals(relPathParts[i])) {
-                trimRel += 1;
-            }
-        }
-
-        String [] outputParts = new String[rootPathParts.length + relPathParts.length - trimRoot - trimRel];
-        System.arraycopy(rootPathParts, 0, outputParts, 0, rootPathParts.length - trimRoot);
-        System.arraycopy(relPathParts,
-                trimRel,
-                outputParts,
-                rootPathParts.length - trimRoot + trimRel - 1,
-                relPathParts.length - trimRel);
-
-        return StringUtils.join(outputParts, "/");
+        return ExternalRefProcessor.join(rootPath, relativePath);
     }
 
 

--- a/modules/swagger-parser/src/test/java/io/swagger/parser/util/RefUtilsTest.java
+++ b/modules/swagger-parser/src/test/java/io/swagger/parser/util/RefUtilsTest.java
@@ -297,4 +297,16 @@ public class RefUtilsTest {
         // relative locations
         assertEquals(ExternalRefProcessor.join("./foo#/definitions/Foo", "./bar#/definitions/Bar"), "./bar#/definitions/Bar");
     }
+
+    @Test
+    public void testRelativeRef() {
+        // Test for #750
+        assertEquals(
+                RefUtils.buildUrl(
+                        "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/storage/resource-manager/Microsoft.Storage/stable/2018-02-01/storage.json",
+                        "../../../../../common-types/resource-management/v1/types.json"
+                ),
+                "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/common-types/resource-management/v1/types.json"
+        );
+    }
 }


### PR DESCRIPTION
Use `ExternalRefProcessor` for `RefUtils#buildUrl` to avoid `ArrayOutOfBoundsException`

Fix #750