### PR TITLE
OpenAPIDeserializer add seam for converting JsonNode to Object

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -67,7 +67,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.text.ParseException;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -260,9 +262,6 @@ public class OpenAPIDeserializer {
 	private static final String COOKIE_PARAMETER = "cookie";
 	private static final String PATH_PARAMETER = "path";
 	private static final String HEADER_PARAMETER = "header";
-	private static final Pattern RFC3339_DATE_TIME_PATTERN = Pattern.compile("^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):" +
-			"(\\d{2}):(\\d{2})(\\.\\d+)?((Z)|([+-]\\d{2}:\\d{2}))$");
-	private static final Pattern RFC3339_DATE_PATTERN = Pattern.compile("^(\\d{4})-(\\d{2})-(\\d{2})$");
 	private static final String REFERENCE_SEPARATOR = "#/";
 
     private static final int MAX_EXTENSION_ENTRIES = 20;
@@ -297,7 +296,7 @@ public class OpenAPIDeserializer {
     public SwaggerParseResult deserialize(JsonNode rootNode, String path, ParseOptions options, boolean isOaiAuthor) {
         basePath = path;
         this.rootNode = rootNode;
-        rootMap = new ObjectMapper().convertValue(rootNode, Map.class);
+        rootMap = convertValue(rootNode, Map.class);
 		SwaggerParseResult result = new SwaggerParseResult();
         try {
             ParseResult rootParse = new ParseResult();
@@ -317,6 +316,13 @@ public class OpenAPIDeserializer {
             }
         }
 		return result;
+	}
+
+	protected <T> T convertValue(JsonNode fromValue, Class<T> toValueType) {
+		if(Object.class.equals(toValueType)) {
+			return Json.mapper().convertValue(fromValue, toValueType);
+		}
+		return new ObjectMapper().convertValue(fromValue, toValueType);
 	}
 
 	public OpenAPI parseRoot(JsonNode node, ParseResult result, String path) {
@@ -517,7 +523,7 @@ public class OpenAPIDeserializer {
 		Set<String> keys = getKeys(node);
 		for (String key : keys) {
 			if (key.startsWith("x-")) {
-				extensions.put(key, Json.mapper().convertValue(node.get(key), Object.class));
+				extensions.put(key, convertValue(node.get(key), Object.class));
 			}
 		}
 
@@ -3201,23 +3207,10 @@ public class OpenAPIDeserializer {
 	 * Returns null if this string can't be parsed as Date.
 	 */
 	private Date toDate(String dateString) {
-		Matcher matcher = RFC3339_DATE_PATTERN.matcher(dateString);
-
 		Date date = null;
-		if (matcher.matches()) {
-			String year = matcher.group(1);
-			String month = matcher.group(2);
-			String day = matcher.group(3);
-
-			try {
-				date =
-						new Calendar.Builder()
-								.setDate(Integer.parseInt(year), Integer.parseInt(month) - 1,
-										Integer.parseInt(day))
-								.build()
-								.getTime();
-			} catch (Exception ignore) {
-			}
+		try {
+			date = new Date(LocalDate.parse(dateString).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli());
+		} catch (Exception ignore) {
 		}
 
 		return date;
@@ -4251,7 +4244,7 @@ public class OpenAPIDeserializer {
 		for (String key : schemaKeys) {
 			validateReservedKeywords(specKeys, key, location, result);
 			if (!specKeys.get("SCHEMA_KEYS").contains(key) && !key.startsWith("x-")) {
-				extensions.put(key, Json.mapper().convertValue(node.get(key), Object.class));
+				extensions.put(key, convertValue(node.get(key), Object.class));
 				schema.setExtensions(extensions);
 			}
 		}

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV31ParserSchemaTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV31ParserSchemaTest.java
@@ -1,5 +1,6 @@
 package io.swagger.v3.parser.test;
 
+import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,12 +26,14 @@ import java.util.Random;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
 
 public class OpenAPIV31ParserSchemaTest {
     protected int serverPort = getDynamicPort();
     protected WireMockServer wireMockServer;
+
+    private static SwaggerParseResult readLocation(String pathname, ParseOptions p) {
+        return new OpenAPIV3Parser().readLocation(new File(pathname).getAbsoluteFile().toURI().toString(), null, p);
+    }
 
     private static int getDynamicPort() {
         return new Random().ints(10000, 20000).findFirst().getAsInt();
@@ -167,7 +170,7 @@ public class OpenAPIV31ParserSchemaTest {
     public void test$idUrlExternal() throws Exception {
         ParseOptions p = new ParseOptions();
         p.setResolve(true);
-        SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readLocation(new File("src/test/resources/3.1.0/dereference/schema/$id-uri-external/root.json").getAbsolutePath(), null, p);
+        SwaggerParseResult swaggerParseResult = readLocation("src/test/resources/3.1.0/dereference/schema/$id-uri-external/root.json", p);
         compare("$id-uri-external", swaggerParseResult);
     }
 
@@ -175,7 +178,7 @@ public class OpenAPIV31ParserSchemaTest {
     public void test$idUrlEnclosing() throws Exception {
         ParseOptions p = new ParseOptions();
         p.setResolve(true);
-        SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readLocation(new File("src/test/resources/3.1.0/dereference/schema/$id-uri-enclosing/root.json").getAbsolutePath(), null, p);
+        SwaggerParseResult swaggerParseResult = readLocation("src/test/resources/3.1.0/dereference/schema/$id-uri-enclosing/root.json", p);
         compare("$id-uri-enclosing", swaggerParseResult);
     }
 
@@ -183,14 +186,14 @@ public class OpenAPIV31ParserSchemaTest {
     public void test$idUrlDirect() throws Exception {
         ParseOptions p = new ParseOptions();
         p.setResolve(true);
-        SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readLocation(new File("src/test/resources/3.1.0/dereference/schema/$id-uri-direct/root.json").getAbsolutePath(), null, p);
+        SwaggerParseResult swaggerParseResult = readLocation("src/test/resources/3.1.0/dereference/schema/$id-uri-direct/root.json", p);
         compare("$id-uri-direct", swaggerParseResult);
     }
     @Test
     public void test$idUrlUnresolvable() throws Exception {
         ParseOptions p = new ParseOptions();
         p.setResolve(true);
-        SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readLocation(new File("src/test/resources/3.1.0/dereference/schema/$id-unresolvable/root.json").getAbsolutePath(), null, p);
+        SwaggerParseResult swaggerParseResult = readLocation("src/test/resources/3.1.0/dereference/schema/$id-unresolvable/root.json", p);
         compare("$id-unresolvable", swaggerParseResult);
     }
 
@@ -198,7 +201,7 @@ public class OpenAPIV31ParserSchemaTest {
     public void testAnchorExt() throws Exception {
         ParseOptions p = new ParseOptions();
         p.setResolve(true);
-        SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readLocation(new File("src/test/resources/3.1.0/dereference/schema/$anchor-external/root.json").getAbsolutePath(), null, p);
+        SwaggerParseResult swaggerParseResult = readLocation("src/test/resources/3.1.0/dereference/schema/$anchor-external/root.json", p);
         compare("$anchor-external", swaggerParseResult);
     }
 
@@ -206,7 +209,7 @@ public class OpenAPIV31ParserSchemaTest {
     public void testAnchorInt() throws Exception {
         ParseOptions p = new ParseOptions();
         p.setResolve(true);
-        SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readLocation(new File("src/test/resources/3.1.0/dereference/schema/$anchor-internal/root.json").getAbsolutePath(), null, p);
+        SwaggerParseResult swaggerParseResult = readLocation("src/test/resources/3.1.0/dereference/schema/$anchor-internal/root.json", p);
         compare("$anchor-internal", swaggerParseResult);
     }
 
@@ -214,7 +217,7 @@ public class OpenAPIV31ParserSchemaTest {
     public void testAnchorUnresolve() throws Exception {
         ParseOptions p = new ParseOptions();
         p.setResolve(true);
-        SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readLocation(new File("src/test/resources/3.1.0/dereference/schema/$anchor-not-found/root.json").getAbsolutePath(), null, p);
+        SwaggerParseResult swaggerParseResult = readLocation("src/test/resources/3.1.0/dereference/schema/$anchor-not-found/root.json", p);
         compare("$anchor-not-found", swaggerParseResult);
     }
 
@@ -223,7 +226,7 @@ public class OpenAPIV31ParserSchemaTest {
         ObjectMapper mapper = Json31.mapper().copy();
         mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
         mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
-        String actual = mapper.writer(new DefaultPrettyPrinter()).writeValueAsString(result.getOpenAPI());
+        String actual = mapper.writer(new DefaultPrettyPrinter().withObjectIndenter(new DefaultIndenter().withLinefeed("\n"))).writeValueAsString(result.getOpenAPI());
         org.testng.Assert.assertEquals(actual,
                 FileUtils.readFileToString(new File("src/test/resources/3.1.0/dereference/schema/" + dir + "/dereferenced.json")));
     }


### PR DESCRIPTION
This PR does the following:
+ OpenAPIDeserializer.java add seam allowing alternative ways to convertValues from JsonNodes. (TeaVM doesnt handler use of ObjectMapper)
+ OpenAPIDeserializer.java use jsr310 consistently for date processing (TeaVM doesnt have Calendar.Builder)
+ OpenAPIV31ParserSchemaTest.java changed so that the build also runs on windows

Background:
I'm using TeaVM to transpile the project into javascript. Minor changes were necessary to enable reduced use of jackson and use more common jdk apis which the transpiler supports.