### PR TITLE
fix $ref parsing when it contains dot inside component name

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -794,7 +794,6 @@ public final class ExternalRefProcessor {
         if(renamedRef != null) {
             return renamedRef;
         }
-
         final Parameter parameter = cache.loadRef($ref, refFormat, Parameter.class);
 
         if(parameter == null) {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ParameterProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ParameterProcessor.java
@@ -43,8 +43,9 @@ public class ParameterProcessor {
         if($ref != null){
             RefFormat refFormat = computeRefFormat(parameter.get$ref());
             if (isAnExternalRefFormat(refFormat)){
-                final String newRef = externalRefProcessor.processRefToExternalParameter($ref, refFormat);
+                String newRef = externalRefProcessor.processRefToExternalParameter($ref, refFormat);
                 if (newRef != null) {
+                    newRef = "#/components/parameters/" + newRef;
                     parameter.set$ref(newRef);
                 }
             }
@@ -75,11 +76,9 @@ public class ParameterProcessor {
     }
 
    public List<Parameter> processParameters(List<Parameter> parameters) {
-
         if (parameters == null) {
             return null;
         }
-
         final List<Parameter> processedPathLevelParameters = new ArrayList<>();
         final List<Parameter> refParameters = new ArrayList<>();
 
@@ -92,7 +91,6 @@ public class ParameterProcessor {
                     //result.warning(location, "The parameter should use Reference Object to link to parameters that are defined at the OpenAPI Object's components/parameters.");
                     continue;
                 }
-
                 if(resolvedParameter == null) {
                     // can't resolve it!
                     processedPathLevelParameters.add(parameter);

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/PathsProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/PathsProcessor.java
@@ -65,11 +65,8 @@ public class PathsProcessor {
             PathItem pathItem = pathMap.get(pathStr);
 
             if (pathItem.get$ref() != null) {
-
                 PathItem resolvedPath = processReferencePath(pathItem);
-
                 String pathRef = pathItem.get$ref().split("#")[0];
-
                 if (resolvedPath != null) {
                     updateRefs(resolvedPath, pathRef);
                     //we need to put the resolved path into swagger object
@@ -83,7 +80,6 @@ public class PathsProcessor {
             //at this point we can process this path
             final List<Parameter> processedPathParameters = parameterProcessor.processParameters(pathItem.getParameters());
             pathItem.setParameters(processedPathParameters);
-
 
             final Map<PathItem.HttpMethod, Operation> operationMap = pathItem.readOperationsMap();
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3RefTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3RefTest.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import org.junit.Before;
 import org.junit.Test;
 import org.testng.Assert;
@@ -33,6 +35,31 @@ public class OpenAPIV3RefTest {
         options.setResolve(true);
         oas = new OpenAPIV3Parser().read("oas3-refs-test/openapi.json", null, options);
     }
+
+    @Test
+    public void testRefContainingDot() {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation("resolve-dot-containing-ref/standaloneSpec.yaml", null, options);
+
+        Assert.assertNotNull(result.getOpenAPI());
+        Assert.assertTrue(result.getMessages().isEmpty(), "No error messages should be present");
+        Assert.assertNotNull(result.getOpenAPI().getPaths().get("/endpoint").getGet().getParameters());
+        Assert.assertEquals(result.getOpenAPI().getPaths().get("/endpoint").getGet().getParameters().get(0).getName(), "FbtPrincipalIdentity");
+    }
+
+    @Test
+    public void testExternalRefContainingDot() {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation("resolve-dot-containing-ref/externalRefSpec.yaml", null, options);
+
+        Assert.assertNotNull(result.getOpenAPI());
+        Assert.assertTrue(result.getMessages().isEmpty(), "No error messages should be present");
+        Assert.assertNotNull(result.getOpenAPI().getPaths().get("/endpoint").getGet().getParameters());
+        Assert.assertEquals(result.getOpenAPI().getPaths().get("/endpoint").getGet().getParameters().get(0).getName(), "FbtPrincipalIdentity");
+    }
+
     @Test
     public void testParameterExampleRefProcessed() {
         String paramName = "correlation_id";
@@ -85,3 +112,4 @@ public class OpenAPIV3RefTest {
         assertEquals(adopterAlias.getItems().getAllOf().size(), 2, "Processed schemas items");
     }
 }
+

--- a/modules/swagger-parser-v3/src/test/resources/resolve-dot-containing-ref/externalRefDomain.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/resolve-dot-containing-ref/externalRefDomain.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: Test domain
+  description: Domain for testing
+  version: '1.0.0'
+components:
+  parameters:
+    FbtPrincipalIdentity_V3.1:
+      name: FbtPrincipalIdentity
+      in: query
+      schema:
+        type: string
+    FbtPrincipalIdentity_V31:
+      name: FbtPrincipalIdentity
+      in: query
+      schema:
+        type: string

--- a/modules/swagger-parser-v3/src/test/resources/resolve-dot-containing-ref/externalRefSpec.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/resolve-dot-containing-ref/externalRefSpec.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+  description: Test API with dot-containing $ref
+paths:
+  /endpoint:
+    get:
+      summary: summary
+      operationId: id
+      description: Test description
+      parameters:
+        - $ref: 'resolve-dot-containing-ref/externalRefDomain.yaml#/components/parameters/FbtPrincipalIdentity_V3.1'
+      responses:
+        '200':
+          description: get description
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/item'
+components:
+  schemas:
+    item:
+      type: object

--- a/modules/swagger-parser-v3/src/test/resources/resolve-dot-containing-ref/standaloneSpec.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/resolve-dot-containing-ref/standaloneSpec.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+  description: Test API with dot-containing $ref
+paths:
+  /endpoint:
+    get:
+      summary: summary
+      operationId: id
+      description: Test description
+      parameters:
+        - $ref: '#/components/parameters/FbtPrincipalIdentity_V3.1'
+      responses:
+        '200':
+          description: get description
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/item'
+components:
+  parameters:
+    FbtPrincipalIdentity_V3.1:
+      name: FbtPrincipalIdentity
+      in: query
+      schema:
+        type: string
+    FbtPrincipalIdentity_V31:
+      name: FbtPrincipalIdentity
+      in: query
+      schema:
+        type: string
+  schemas:
+    item:
+      type: object

--- a/pom.xml
+++ b/pom.xml
@@ -372,7 +372,7 @@
         <swagger-parser-v2-version>1.0.75</swagger-parser-v2-version>
         <commons-io-version>2.19.0</commons-io-version>
         <slf4j-version>2.0.9</slf4j-version>
-        <swagger-core-version>2.2.32</swagger-core-version>
+        <swagger-core-version>2.2.34</swagger-core-version>
         <swagger-core-v2-version>1.6.16</swagger-core-v2-version>
         <junit-version>4.13.2</junit-version>
         <testng-version>7.11.0</testng-version>


### PR DESCRIPTION
Before merge:
- [ ] Bump swagger-core and update it's version in pom