### PR TITLE
fix: nested example references not resolved when path parameter in reference chain

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -968,7 +968,7 @@ public final class ExternalRefProcessor {
             if (example.get$ref() != null) {
                 RefFormat ref = computeRefFormat(example.get$ref());
                 if (isAnExternalRefFormat(ref)) {
-                    processRefExample(example, $ref);
+                    processRefExample(example, file);
                 } else {
                     processRefToExternalExample(file + example.get$ref(), RefFormat.RELATIVE);
                 }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -3362,6 +3362,20 @@ public class OpenAPIV3ParserTest {
         assertEquals(openAPI.getComponents().getSchemas().get("PetCreate").getProperties().size(), 2);
     }
 
+    @Test(description = "should resolve nested referenced examples even when parent reference contains path parameter")
+    public void testIssue2244() {
+        OpenAPIV3Parser openApiParser = new OpenAPIV3Parser();
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        SwaggerParseResult parseResult = openApiParser.readLocation("issue-2244/openapi.yaml", null, options);
+        OpenAPI openAPI = parseResult.getOpenAPI();
+
+        assertNotNull(openAPI.getComponents().getExamples(), "should have resolved the component examples");
+        Set<String> exampleNames = new HashSet<>();
+        exampleNames.add("ReproducerExample");
+        assertEquals(openAPI.getComponents().getExamples().keySet(), exampleNames);
+    }
+
     @Test(description = "responses should be inline")
     public void testFullyResolveResponses() {
         ParseOptions options = new ParseOptions();

--- a/modules/swagger-parser-v3/src/test/resources/issue-2244/components.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2244/components.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.3
+
+components:
+  schemas:
+    ReproducerObject:
+      type: object
+      properties:
+        id:
+          type: integer
+  examples:
+    ReproducerExample:
+      value:
+        id: 1

--- a/modules/swagger-parser-v3/src/test/resources/issue-2244/openapi.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2244/openapi.yaml
@@ -1,0 +1,10 @@
+openapi: 3.0.3
+
+info:
+  title: Reproducer
+  description: Reproducer for the issue
+  version: 1.0.0
+
+paths:
+  /reproducers/{id}:
+    $ref: "operations.yaml#/paths/~1reproducers~1{id}"

--- a/modules/swagger-parser-v3/src/test/resources/issue-2244/operations.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2244/operations.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+
+paths:
+  /reproducers/{id}:
+    post:
+      description: Reproducer
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "components.yaml#/components/schemas/ReproducerObject"
+              examples:
+                normal:
+                  $ref: "components.yaml#/components/examples/ReproducerExample"


### PR DESCRIPTION
# Pull Request

## Description

Fixes: #2244 

The second parameter of `processRefExample` is the "externalFile" but current implementation provided the reference, which isn't correct. That behavior is now fixed with this PR and aligns with what's done for `processRefSchemaObject`.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)
