### PR TITLE
fix: do not generate duplicate components when using mixed references

### DIFF
--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -30,6 +30,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.*;
 
 import static java.util.Arrays.asList;
@@ -3295,7 +3296,7 @@ public class OpenAPIV3ParserTest {
         OpenAPI openAPI = parseResult.getOpenAPI();
         assertEqualsNoOrder(
             openAPI.getComponents().getSchemas().keySet(),
-            Arrays.asList("ArrayPojo", "Enum1", "Enum1_1", "Enum2", "Enum3", "MapPojo", "SetPojo", "SimplePojo",
+            Arrays.asList("ArrayPojo", "Enum1", "Enum2", "Enum3", "MapPojo", "SetPojo", "SimplePojo",
                 "TransactionsPatchRequestBody", "additional-properties", "array-pojo", "locale-translation-item",
                 "map-pojo", "set-pojo", "simple-pojo", "translation-item")
         );
@@ -3311,6 +3312,26 @@ public class OpenAPIV3ParserTest {
         Yaml.prettyPrint(openAPI);
         assertEquals(openAPI.getComponents().getSchemas().get("PetCreate").getRequired().size(), 1);
         assertEquals(openAPI.getComponents().getSchemas().get("PetCreate").getProperties().size(), 2);
+    }
+
+    @Test(description = "Should not create duplicate components when using mixed reference patters")
+    public void testIssue2217ExternalReferenceResolution() {
+        OpenAPIV3Parser openApiParser = new OpenAPIV3Parser();
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        options.setFlatten(true);
+
+        SwaggerParseResult parseResult = openApiParser.readLocation("issue-2217/main.yaml", null, options);
+        OpenAPI openAPI = parseResult.getOpenAPI();
+
+        Assert.assertNotNull(openAPI, "OpenAPI should be parsed successfully");
+
+        // Assert that EmployeeInfo_1 object does not appear in the parsed spec
+        Assert.assertNotNull(openAPI.getComponents(), "Components should exist");
+        if (openAPI.getComponents().getSchemas() != null) {
+            Assert.assertFalse(openAPI.getComponents().getSchemas().containsKey("EmployeeInfo_1"),
+                    "EmployeeInfo_1 should not be created during external reference resolution");
+        }
     }
 
     @Test(description = "responses should be inline")

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/ResolverCacheTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/ResolverCacheTest.java
@@ -258,4 +258,33 @@ public class ResolverCacheTest {
         cache.putRenamedRef("foo", "bar");
         assertEquals(cache.getRenamedRef("foo"), "bar");
     }
+
+    @Test
+    public void testRenameCacheNormalizationExternalAndLocalPart() {
+        ResolverCache cache = new ResolverCache(openAPI, auths, null);
+
+        assertNull(cache.getRenamedRef("./components.yaml#/foo"));
+        cache.putRenamedRef("./components.yaml#/foo", "bar");
+        assertEquals(cache.getRenamedRef("./components.yaml#/foo"), "bar");
+        assertEquals(cache.getRenamedRef("components.yaml#/foo"), "bar");
+    }
+
+    @Test
+    public void testRenameCacheNormalizationNoLocalPart() {
+        ResolverCache cache = new ResolverCache(openAPI, auths, null);
+
+        assertNull(cache.getRenamedRef("./components.yaml"));
+        cache.putRenamedRef("./components.yaml", "bar");
+        assertEquals(cache.getRenamedRef("./components.yaml"), "bar");
+        assertEquals(cache.getRenamedRef("components.yaml"), "bar");
+    }
+
+    @Test
+    public void testRenameCacheNormalizationNoExternalPart() {
+        ResolverCache cache = new ResolverCache(openAPI, auths, null);
+
+        assertNull(cache.getRenamedRef("#/foo"));
+        cache.putRenamedRef("#/foo", "bar");
+        assertEquals(cache.getRenamedRef("#/foo"), "bar");
+    }
 }

--- a/modules/swagger-parser-v3/src/test/resources/issue-2217/fragments.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2217/fragments.yaml
@@ -1,0 +1,62 @@
+openapi: "3.0.0"
+info:
+  version: 1.1.0
+  title: fr_fragments
+paths: {}
+components:
+  schemas:
+    CreatedByEmployeeId:
+      type: string
+    EmployeesInfoPage:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/EmployeeInfo'
+        pageResponse:
+          $ref: pagination.yaml#/components/schemas/PageResponse
+    ArrayOfGroupsInfo:
+      type: array
+      items:
+        $ref: '#/components/schemas/GroupInfo'
+    EmployeeInfo:
+      type: object
+      properties:
+        employeeId:
+          type: string
+        groupTags:
+          $ref: '#/components/schemas/ArrayOfGroups'
+    ArrayOfGroups:
+      type: array
+      items:
+        $ref: '#/components/schemas/GroupTags'
+    GroupTags:
+      type: object
+      properties:
+        groupTag:
+          $ref: '#/components/schemas/GroupId'
+    GroupId:
+      type: string
+    PostEmployeeRequest:
+      $ref: '#/components/schemas/EmployeeInfo'
+    PutEmployeeRequest:
+      $ref: '#/components/schemas/EmployeeInfo'
+    EmployeeIdRequest:
+      type: object
+      properties:
+        employeeId:
+          type: string
+  responses:
+    EmployeeInfo200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/EmployeeInfo'
+    EmployeeInfo201:
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/EmployeeInfo'

--- a/modules/swagger-parser-v3/src/test/resources/issue-2217/main.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2217/main.yaml
@@ -1,0 +1,59 @@
+openapi: "3.0.0"
+info:
+  title: Main test
+  version: 1.1.0
+paths:
+  /int/employees/extended:
+    responses:
+      "200":
+        description: OK
+        content:
+          application/json:
+            schema:
+              $ref: 'fragments.yaml#/components/schemas/EmployeesInfoPage'
+  /int/employees:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'fragments.yaml#/components/schemas/PostEmployeeRequest'
+        required: true
+      responses:
+        "201":
+          $ref: 'fragments.yaml#/components/responses/EmployeeInfo201'
+  /int/employees/id:
+    put:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'fragments.yaml#/components/schemas/PutEmployeeRequest'
+        required: true
+      responses:
+        "200":
+          $ref: 'fragments.yaml#/components/responses/EmployeeInfo200'
+        "201":
+          $ref: 'fragments.yaml#/components/responses/EmployeeInfo201'
+  /int/employees/id/request:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'fragments.yaml#/components/schemas/EmployeeIdRequest'
+        required: true
+      responses:
+        "200":
+          $ref: 'fragments.yaml#/components/responses/EmployeeInfo200'
+  /int/employees/id/remove:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: 'fragments.yaml#/components/schemas/EmployeeIdRequest'
+        required: true
+      responses:
+        "204":
+          description: No Content


### PR DESCRIPTION
# Pull Request

## Description

When creating references throughout the parser relative ones are sometimes generated as "./foo.yaml" and "foo.yaml". As the rename cache performs plain string equals checks these are considered to be different files, which isn't correct. This PR adds normalization for the external part of the references, this way we always ensure a consistent comparison regardless of how the references are defined.

Fixes: #2217 

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix

## Checklist

- [x] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)