### PR TITLE
fix: external schema resolution in OAS 3.1 files

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/reference/OpenAPI31Traverser.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/reference/OpenAPI31Traverser.java
@@ -23,7 +23,12 @@ import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.parser.util.DeserializationUtils;
 import io.swagger.v3.parser.util.OpenAPIDeserializer;
+import io.swagger.v3.parser.util.RefUtils;
+import io.swagger.v3.parser.models.RefFormat;
 import org.apache.commons.lang3.StringUtils;
+
+import static io.swagger.v3.parser.util.RefUtils.computeRefFormat;
+import static io.swagger.v3.parser.util.RefUtils.isAnExternalRefFormat;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -57,6 +62,7 @@ public class OpenAPI31Traverser implements Traverser {
 
     public Set<Object> visiting = new HashSet<>();
     protected HashMap<Object, Object> visitedMap = new HashMap<>();
+    protected Map<String, String> processedExternalSchemaRefs = new HashMap<>();
 
     public OpenAPI traverse(OpenAPI openAPI, Visitor visitor) throws Exception {
         if (!(visitor instanceof ReferenceVisitor)) {
@@ -920,6 +926,35 @@ public class OpenAPI31Traverser implements Traverser {
             visiting.remove(schema);
             return handleRootLocalRefs(schema.get$ref(), resolved, context.getOpenApi().getComponents().getSchemas());
         }
+        // handle external schema refs - add to components.schemas and return $ref
+        if (shouldHandleExternalSchemaRef(resolvedNotNull, schema.get$ref())) {
+            String externalRef = schema.get$ref();
+            String refName;
+            
+            // Check if this external ref was already processed
+            if (processedExternalSchemaRefs.containsKey(externalRef)) {
+                refName = processedExternalSchemaRefs.get(externalRef);
+            } else {
+                // Merge schema metadata (like $id) from original schema to resolved before adding to components
+                mergeSchemas(schema, resolved);
+                ensureComponents(context.getOpenApi());
+                if (context.getOpenApi().getComponents().getSchemas() == null) {
+                    context.getOpenApi().getComponents().schemas(new LinkedHashMap<>());
+                }
+                refName = handleExternalSchemaRef(externalRef, resolved, context.getOpenApi().getComponents().getSchemas());
+                processedExternalSchemaRefs.put(externalRef, refName);
+            }
+            
+            finalizeSchemaVisit(schema, resolved, inheritedIds);
+            
+            if (this.getContext().getParseOptions().isResolveFully()) {
+                return resolved;
+            } else {
+                Schema refSchema = new Schema();
+                refSchema.set$ref("#/components/schemas/" + refName);
+                return refSchema;
+            }
+        }
         // merge ALL STUFF
         mergeSchemas(schema, resolved);
         visitedMap.put(schema, deepcopy(resolved, Schema.class));
@@ -981,6 +1016,58 @@ public class OpenAPI31Traverser implements Traverser {
                 !this.getContext().getParseOptions().isResolveFully() &&
                 visitor.reference.getUri().equals(this.getContext().getRootUri()) &&
                 (ReferenceUtils.isLocalRefToComponents(ref) || ReferenceUtils.isAnchorRef(ref));
+    }
+
+    public boolean isExternalRef(String ref) {
+        if (StringUtils.isBlank(ref)) {
+            return false;
+        }
+        RefFormat refFormat = computeRefFormat(ref);
+        return isAnExternalRefFormat(refFormat);
+    }
+
+    public boolean shouldHandleExternalSchemaRef(boolean resolvedNotNull, String ref) {
+        return resolvedNotNull && isExternalRef(ref);
+    }
+
+    private void finalizeSchemaVisit(Schema schema, Schema resolved, List<String> inheritedIds) {
+        visitedMap.put(schema, deepcopy(resolved, Schema.class));
+        visiting.remove(schema);
+        if (StringUtils.isNotBlank(schema.get$id())) {
+            inheritedIds.remove(schema.get$id());
+        }
+    }
+
+    public String handleExternalSchemaRef(String ref, Schema resolved, Map<String, Schema> schemasMap) {
+        // Reuse RefUtils.computeDefinitionName from OpenAPI 3.0 processing
+        String name = RefUtils.computeDefinitionName(ref);
+        String uniqueName = getUniqueSchemaName(schemasMap, name, resolved);
+        schemasMap.put(uniqueName, resolved);
+        return uniqueName;
+    }
+
+    private String getUniqueSchemaName(Map<String, Schema> schemas, String name, Schema schema) {
+        String uniqueName = name;
+        int counter = 0;
+        while (schemas.containsKey(uniqueName)) {
+            Schema existingSchema = schemas.get(uniqueName);
+            if (schemasAreEqual(existingSchema, schema)) {
+                return uniqueName;
+            }
+            counter++;
+            uniqueName = name + "_" + counter;
+        }
+        return uniqueName;
+    }
+
+    private boolean schemasAreEqual(Schema s1, Schema s2) {
+        try {
+            String json1 = Json31.mapper().writeValueAsString(s1);
+            String json2 = Json31.mapper().writeValueAsString(s2);
+            return json1.equals(json2);
+        } catch (JsonProcessingException e) {
+            return false;
+        }
     }
 
     public void ensureComponents(OpenAPI openAPI) {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/reference/OpenAPI31Traverser.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/reference/OpenAPI31Traverser.java
@@ -926,34 +926,18 @@ public class OpenAPI31Traverser implements Traverser {
             visiting.remove(schema);
             return handleRootLocalRefs(schema.get$ref(), resolved, context.getOpenApi().getComponents().getSchemas());
         }
+        // handle local refs within external files - promote to components.schemas
+        // This mirrors ExternalRefProcessor.processRefSchema() from the 3.0 code path
+        if (shouldHandleLocalRefInExternalFile(resolvedNotNull, schema.get$ref(), visitor)) {
+            String cacheKey = visitor.reference.getUri() + schema.get$ref();
+            String baseName = ReferenceUtils.getRefName(schema.get$ref());
+            return promoteSchemaToComponents(schema, resolved, inheritedIds, cacheKey, baseName);
+        }
         // handle external schema refs - add to components.schemas and return $ref
         if (shouldHandleExternalSchemaRef(resolvedNotNull, schema.get$ref())) {
-            String externalRef = schema.get$ref();
-            String refName;
-            
-            // Check if this external ref was already processed
-            if (processedExternalSchemaRefs.containsKey(externalRef)) {
-                refName = processedExternalSchemaRefs.get(externalRef);
-            } else {
-                // Merge schema metadata (like $id) from original schema to resolved before adding to components
-                mergeSchemas(schema, resolved);
-                ensureComponents(context.getOpenApi());
-                if (context.getOpenApi().getComponents().getSchemas() == null) {
-                    context.getOpenApi().getComponents().schemas(new LinkedHashMap<>());
-                }
-                refName = handleExternalSchemaRef(externalRef, resolved, context.getOpenApi().getComponents().getSchemas());
-                processedExternalSchemaRefs.put(externalRef, refName);
-            }
-            
-            finalizeSchemaVisit(schema, resolved, inheritedIds);
-            
-            if (this.getContext().getParseOptions().isResolveFully()) {
-                return resolved;
-            } else {
-                Schema refSchema = new Schema();
-                refSchema.set$ref("#/components/schemas/" + refName);
-                return refSchema;
-            }
+            String cacheKey = schema.get$ref();
+            String baseName = RefUtils.computeDefinitionName(schema.get$ref());
+            return promoteSchemaToComponents(schema, resolved, inheritedIds, cacheKey, baseName);
         }
         // merge ALL STUFF
         mergeSchemas(schema, resolved);
@@ -1030,6 +1014,12 @@ public class OpenAPI31Traverser implements Traverser {
         return resolvedNotNull && isExternalRef(ref);
     }
 
+    public boolean shouldHandleLocalRefInExternalFile(boolean resolvedNotNull, String ref, ReferenceVisitor visitor) {
+        return resolvedNotNull &&
+                ReferenceUtils.isLocalRef(ref) &&
+                !visitor.reference.getUri().equals(this.getContext().getRootUri());
+    }
+
     private void finalizeSchemaVisit(Schema schema, Schema resolved, List<String> inheritedIds) {
         visitedMap.put(schema, deepcopy(resolved, Schema.class));
         visiting.remove(schema);
@@ -1038,12 +1028,36 @@ public class OpenAPI31Traverser implements Traverser {
         }
     }
 
-    public String handleExternalSchemaRef(String ref, Schema resolved, Map<String, Schema> schemasMap) {
-        // Reuse RefUtils.computeDefinitionName from OpenAPI 3.0 processing
-        String name = RefUtils.computeDefinitionName(ref);
-        String uniqueName = getUniqueSchemaName(schemasMap, name, resolved);
-        schemasMap.put(uniqueName, resolved);
-        return uniqueName;
+    /**
+     * Promotes a resolved schema to components.schemas and returns either the resolved schema
+     * (resolveFully) or a $ref pointing to the promoted component.
+     */
+    private Schema promoteSchemaToComponents(Schema schema, Schema resolved, List<String> inheritedIds,
+                                             String cacheKey, String baseName) {
+        String refName;
+        if (processedExternalSchemaRefs.containsKey(cacheKey)) {
+            refName = processedExternalSchemaRefs.get(cacheKey);
+        } else {
+            mergeSchemas(schema, resolved);
+            ensureComponents(context.getOpenApi());
+            if (context.getOpenApi().getComponents().getSchemas() == null) {
+                context.getOpenApi().getComponents().schemas(new LinkedHashMap<>());
+            }
+            Map<String, Schema> schemasMap = context.getOpenApi().getComponents().getSchemas();
+            refName = getUniqueSchemaName(schemasMap, baseName, resolved);
+            schemasMap.put(refName, resolved);
+            processedExternalSchemaRefs.put(cacheKey, refName);
+        }
+
+        finalizeSchemaVisit(schema, resolved, inheritedIds);
+
+        if (this.getContext().getParseOptions().isResolveFully()) {
+            return resolved;
+        } else {
+            Schema refSchema = new Schema();
+            refSchema.set$ref("#/components/schemas/" + refName);
+            return refSchema;
+        }
     }
 
     private String getUniqueSchemaName(Map<String, Schema> schemas, String name, Schema schema) {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/reference/OpenAPI31Traverser.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/reference/OpenAPI31Traverser.java
@@ -936,7 +936,7 @@ public class OpenAPI31Traverser implements Traverser {
         // handle external schema refs - add to components.schemas and return $ref
         if (shouldHandleExternalSchemaRef(resolvedNotNull, schema.get$ref())) {
             String cacheKey = schema.get$ref();
-            String baseName = RefUtils.computeDefinitionName(schema.get$ref());
+            String baseName = computeExternalSchemaName(schema.get$ref());
             return promoteSchemaToComponents(schema, resolved, inheritedIds, cacheKey, baseName);
         }
         // merge ALL STUFF
@@ -1026,6 +1026,24 @@ public class OpenAPI31Traverser implements Traverser {
         if (StringUtils.isNotBlank(schema.get$id())) {
             inheritedIds.remove(schema.get$id());
         }
+    }
+
+    /**
+     * Computes the component name for an external schema ref.
+     * For anchor-style refs (e.g., ./ex.json#user-profile), uses the anchor value as the name.
+     * This is 3.1-specific since $anchor is a JSON Schema 2020-12 feature.
+     * For JSON pointer refs (e.g., ./ex.json#/path/to/Schema), falls back to RefUtils.computeDefinitionName.
+     */
+    private String computeExternalSchemaName(String ref) {
+        int hashIndex = ref.indexOf('#');
+        if (hashIndex >= 0 && hashIndex < ref.length() - 1) {
+            String fragment = ref.substring(hashIndex + 1);
+            // Anchor refs don't start with '/' (JSON pointers do)
+            if (!fragment.startsWith("/")) {
+                return fragment;
+            }
+        }
+        return RefUtils.computeDefinitionName(ref);
     }
 
     /**

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV31ParserExternalSchemaRefTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV31ParserExternalSchemaRefTest.java
@@ -1,0 +1,74 @@
+package io.swagger.v3.parser.test;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test for GitHub issue #2266: External schema resolution broken in OpenAPI 3.1 (works in 3.0)
+ * 
+ * When parsing an OpenAPI 3.1 specification with external schema references (using $ref to separate YAML files),
+ * the getComponents().getSchemas() method should return the resolved schemas, not null.
+ */
+public class OpenAPIV31ParserExternalSchemaRefTest {
+
+    @Test
+    public void testExternalSchemaRefResolvedToComponents() throws Exception {
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(true);
+        
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation(
+            new File("src/test/resources/3.1.0/dereference/external-schema-ref/swagger.yaml").getAbsolutePath(), 
+            null, 
+            parseOptions
+        );
+        
+        OpenAPI openAPI = result.getOpenAPI();
+        
+        assertNotNull(openAPI, "OpenAPI should not be null");
+        assertNotNull(openAPI.getComponents(), "Components should not be null");
+        assertNotNull(openAPI.getComponents().getSchemas(), "Schemas should not be null");
+        
+        Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
+        assertTrue(schemas.size() > 0, "Schemas should contain at least one entry");
+        assertTrue(schemas.containsKey("ProbeInfo"), "Schemas should contain 'ProbeInfo'");
+        
+        Schema probeInfoSchema = schemas.get("ProbeInfo");
+        assertNotNull(probeInfoSchema, "ProbeInfo schema should not be null");
+        assertNotNull(probeInfoSchema.getProperties(), "ProbeInfo properties should not be null");
+        assertTrue(probeInfoSchema.getProperties().containsKey("status"), "ProbeInfo should have 'status' property");
+        assertTrue(probeInfoSchema.getProperties().containsKey("version"), "ProbeInfo should have 'version' property");
+    }
+    
+    @Test
+    public void testExternalSchemaRefResolvedFullyToComponents() throws Exception {
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(true);
+        parseOptions.setResolveFully(true);
+        
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation(
+            new File("src/test/resources/3.1.0/dereference/external-schema-ref/swagger.yaml").getAbsolutePath(), 
+            null, 
+            parseOptions
+        );
+        
+        OpenAPI openAPI = result.getOpenAPI();
+        
+        assertNotNull(openAPI, "OpenAPI should not be null");
+        assertNotNull(openAPI.getComponents(), "Components should not be null");
+        assertNotNull(openAPI.getComponents().getSchemas(), "Schemas should not be null with resolveFully");
+        
+        Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
+        assertTrue(schemas.size() > 0, "Schemas should contain at least one entry");
+        assertTrue(schemas.containsKey("ProbeInfo"), "Schemas should contain 'ProbeInfo'");
+    }
+}

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV31ParserNestedExternalRefTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV31ParserNestedExternalRefTest.java
@@ -1,0 +1,194 @@
+package io.swagger.v3.parser.test;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for promoting local $refs within external files to components.schemas in OpenAPI 3.1.
+ * This mirrors the behavior of ExternalRefProcessor.processRefSchema() from the 3.0 code path.
+ */
+public class OpenAPIV31ParserNestedExternalRefTest {
+
+    private static final String RESOURCE_DIR = "src/test/resources/3.1.0/dereference/external-schema-ref-nested/";
+
+    private OpenAPI parse(String file, boolean resolveFully) {
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(true);
+        if (resolveFully) {
+            parseOptions.setResolveFully(true);
+        }
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation(
+            new File(RESOURCE_DIR + file).getAbsolutePath(), null, parseOptions
+        );
+        assertNotNull(result.getOpenAPI(), "OpenAPI should not be null");
+        return result.getOpenAPI();
+    }
+
+    /**
+     * Basic test: external file has ListResponse with internal $ref to Item.
+     * Both should be promoted to components.schemas with resolve=true.
+     */
+    @Test
+    public void testNestedLocalRefPromotedToComponents() {
+        OpenAPI openAPI = parse("swagger.yaml", false);
+
+        Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
+        assertNotNull(schemas, "Schemas should not be null");
+        assertTrue(schemas.containsKey("ListResponse"), "Should contain ListResponse");
+        assertTrue(schemas.containsKey("Item"), "Should contain Item (promoted from internal ref in external file)");
+
+        // Verify Item has correct properties and types
+        Schema itemSchema = schemas.get("Item");
+        assertNotNull(itemSchema.getProperties(), "Item properties should not be null");
+        assertTrue(itemSchema.getProperties().containsKey("id"), "Item should have 'id' property");
+        assertTrue(itemSchema.getProperties().containsKey("name"), "Item should have 'name' property");
+
+        // Verify ListResponse.data.items is a $ref to Item, not inlined
+        Schema listResponse = schemas.get("ListResponse");
+        Schema dataProp = (Schema) listResponse.getProperties().get("data");
+        assertNotNull(dataProp.getItems(), "data.items should not be null");
+        assertEquals(dataProp.getItems().get$ref(), "#/components/schemas/Item",
+            "data.items should be a $ref to #/components/schemas/Item");
+    }
+
+    /**
+     * With resolveFully=true, schemas should still be in components but also inlined at usage sites.
+     */
+    @Test
+    public void testNestedLocalRefResolveFullyStillPopulatesComponents() {
+        OpenAPI openAPI = parse("swagger.yaml", true);
+
+        Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
+        assertNotNull(schemas, "Schemas should not be null");
+        assertTrue(schemas.containsKey("ListResponse"), "Should contain ListResponse");
+        assertTrue(schemas.containsKey("Item"), "Should contain Item");
+
+        // In resolveFully mode, the response schema should be inlined (no $ref)
+        Schema responseSchema = openAPI.getPaths().get("/items").getGet()
+            .getResponses().get("200").getContent().get("application/json").getSchema();
+        assertNull(responseSchema.get$ref(), "Response schema should be inlined (no $ref) in resolveFully mode");
+        assertNotNull(responseSchema.getProperties(), "Response schema should have inlined properties");
+    }
+
+    /**
+     * Type information must be preserved for all schemas: object, array, string, integer.
+     */
+    @Test
+    public void testTypeInformationPreserved() {
+        OpenAPI openAPI = parse("swagger.yaml", false);
+
+        Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
+
+        // ListResponse should be type: object (3.1 uses getTypes() returning a Set)
+        Schema listResponse = schemas.get("ListResponse");
+        assertTrue(listResponse.getTypes().contains("object"), "ListResponse should be type object");
+
+        // data property should be type: array
+        Schema dataProp = (Schema) listResponse.getProperties().get("data");
+        assertTrue(dataProp.getTypes().contains("array"), "data should be type array");
+
+        // total property should be type: integer
+        Schema totalProp = (Schema) listResponse.getProperties().get("total");
+        assertTrue(totalProp.getTypes().contains("integer"), "total should be type integer");
+
+        // Item should be type: object with string properties
+        Schema item = schemas.get("Item");
+        assertTrue(item.getTypes().contains("object"), "Item should be type object");
+        Schema idProp = (Schema) item.getProperties().get("id");
+        assertTrue(idProp.getTypes().contains("string"), "id should be type string");
+    }
+
+    /**
+     * Deep chain: Order -> Customer -> Address, Order -> OrderItem.
+     * All schemas in the chain should be promoted to components.
+     */
+    @Test
+    public void testDeepNestedRefChain() {
+        OpenAPI openAPI = parse("swagger-deep.yaml", false);
+
+        Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
+        assertNotNull(schemas, "Schemas should not be null");
+        assertTrue(schemas.containsKey("Order"), "Should contain Order");
+        assertTrue(schemas.containsKey("Customer"), "Should contain Customer");
+        assertTrue(schemas.containsKey("Address"), "Should contain Address (2 levels deep)");
+        assertTrue(schemas.containsKey("OrderItem"), "Should contain OrderItem");
+
+        // Verify Order.customer is a $ref to Customer
+        Schema order = schemas.get("Order");
+        Schema customerProp = (Schema) order.getProperties().get("customer");
+        assertEquals(customerProp.get$ref(), "#/components/schemas/Customer",
+            "Order.customer should ref Customer");
+
+        // Verify Customer.address is a $ref to Address
+        Schema customer = schemas.get("Customer");
+        Schema addressProp = (Schema) customer.getProperties().get("address");
+        assertEquals(addressProp.get$ref(), "#/components/schemas/Address",
+            "Customer.address should ref Address");
+
+        // Verify Order.items is array with $ref to OrderItem
+        Schema itemsProp = (Schema) order.getProperties().get("items");
+        assertTrue(itemsProp.getTypes().contains("array"), "items should be type array");
+        assertEquals(itemsProp.getItems().get$ref(), "#/components/schemas/OrderItem",
+            "Order.items should ref OrderItem");
+    }
+
+    /**
+     * Deep chain with resolveFully: all schemas in components, everything inlined at usage sites.
+     */
+    @Test
+    public void testDeepNestedRefChainResolveFully() {
+        OpenAPI openAPI = parse("swagger-deep.yaml", true);
+
+        Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
+        assertNotNull(schemas, "Schemas should not be null");
+        assertTrue(schemas.containsKey("Order"), "Should contain Order");
+        assertTrue(schemas.containsKey("Customer"), "Should contain Customer");
+        assertTrue(schemas.containsKey("Address"), "Should contain Address");
+        assertTrue(schemas.containsKey("OrderItem"), "Should contain OrderItem");
+
+        // Response schema should be fully inlined
+        Schema responseSchema = openAPI.getPaths().get("/orders").getGet()
+            .getResponses().get("200").getContent().get("application/json").getSchema();
+        assertNull(responseSchema.get$ref(), "Response should be inlined in resolveFully mode");
+        assertNotNull(responseSchema.getProperties().get("customer"),
+            "Inlined Order should have customer property");
+    }
+
+    /**
+     * When the same external file is referenced multiple times, schemas should not be duplicated.
+     * Item is referenced both indirectly (via ListResponse.data.items) and directly.
+     */
+    @Test
+    public void testDuplicateRefsNotDuplicated() {
+        OpenAPI openAPI = parse("swagger-duplicate-refs.yaml", false);
+
+        Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
+        assertNotNull(schemas, "Schemas should not be null");
+        assertTrue(schemas.containsKey("ListResponse"), "Should contain ListResponse");
+        assertTrue(schemas.containsKey("Item"), "Should contain Item");
+
+        // Item should appear exactly once (no Item_1 duplicate)
+        assertFalse(schemas.containsKey("Item_1"), "Item should not be duplicated as Item_1");
+
+        // Both refs should point to the same component
+        Schema listResponse = schemas.get("ListResponse");
+        Schema dataProp = (Schema) listResponse.getProperties().get("data");
+        assertEquals(dataProp.getItems().get$ref(), "#/components/schemas/Item",
+            "ListResponse.data.items should ref Item");
+
+        // Direct ref to Item should also point to #/components/schemas/Item
+        Schema directItemRef = openAPI.getPaths().get("/items/{id}").getGet()
+            .getResponses().get("200").getContent().get("application/json").getSchema();
+        assertEquals(directItemRef.get$ref(), "#/components/schemas/Item",
+            "Direct ref should also point to #/components/schemas/Item");
+    }
+}

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/external-schema-ref-nested/schemas/common.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/external-schema-ref-nested/schemas/common.yaml
@@ -1,0 +1,22 @@
+components:
+  schemas:
+    ListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Item'
+        total:
+          type: integer
+      required:
+        - data
+        - total
+
+    Item:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/external-schema-ref-nested/schemas/deep.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/external-schema-ref-nested/schemas/deep.yaml
@@ -1,0 +1,40 @@
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: string
+        customer:
+          $ref: '#/components/schemas/Customer'
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderItem'
+      required:
+        - id
+        - customer
+
+    Customer:
+      type: object
+      properties:
+        name:
+          type: string
+        address:
+          $ref: '#/components/schemas/Address'
+
+    Address:
+      type: object
+      properties:
+        street:
+          type: string
+        city:
+          type: string
+
+    OrderItem:
+      type: object
+      properties:
+        product:
+          type: string
+        quantity:
+          type: integer

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/external-schema-ref-nested/swagger-deep.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/external-schema-ref-nested/swagger-deep.yaml
@@ -1,0 +1,16 @@
+openapi: 3.1.0
+info:
+  title: Deep Nested Ref API
+  version: 1.0.0
+
+paths:
+  /orders:
+    get:
+      operationId: getOrders
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: schemas/deep.yaml#/components/schemas/Order

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/external-schema-ref-nested/swagger-duplicate-refs.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/external-schema-ref-nested/swagger-duplicate-refs.yaml
@@ -1,0 +1,26 @@
+openapi: 3.1.0
+info:
+  title: Duplicate Refs API
+  version: 1.0.0
+
+paths:
+  /items:
+    get:
+      operationId: getItems
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: schemas/common.yaml#/components/schemas/ListResponse
+  /items/{id}:
+    get:
+      operationId: getItem
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: schemas/common.yaml#/components/schemas/Item

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/external-schema-ref-nested/swagger.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/external-schema-ref-nested/swagger.yaml
@@ -1,0 +1,16 @@
+openapi: 3.1.0
+info:
+  title: Example API
+  version: 1.0.0
+
+paths:
+  /items:
+    get:
+      operationId: getItems
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: schemas/common.yaml#/components/schemas/ListResponse

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/external-schema-ref/schemas/health.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/external-schema-ref/schemas/health.yaml
@@ -1,0 +1,9 @@
+ProbeInfo:
+  type: object
+  properties:
+    status:
+      type: string
+    version:
+      type: string
+  required:
+    - status

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/external-schema-ref/swagger.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/external-schema-ref/swagger.yaml
@@ -1,0 +1,34 @@
+openapi: 3.1.0
+info:
+  title: Backend
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+servers:
+  - url: '{protocol}://{hostname}:{port}'
+    variables:
+      protocol:
+        enum:
+          - http
+          - https
+        default: http
+      hostname:
+        default: localhost
+      port:
+        default: '8080'
+paths:
+  /probe/info:
+    get:
+      tags:
+        - health
+      summary: info of the system
+      operationId: probe.info
+      security: []
+      responses:
+        200:
+          description: system is up and running
+          content:
+            application/json:
+              schema:
+                $ref: 'schemas/health.yaml#/ProbeInfo'

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/full/dereferenced.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/full/dereferenced.yaml
@@ -34,17 +34,25 @@ paths:
 components:
   schemas:
     Indirection:
+      $ref: "#/components/schemas/Indirection_2"
+    IndirectionSiblings:
+      $ref: "#/components/schemas/IndirectionSiblings_2"
+    ex3schema:
       type: object
       description: VALUE ex3schema
       properties:
         prop1:
           type: string
-    IndirectionSiblings:
-      type: object
+    Indirection_1:
+      $ref: "#/components/schemas/ex3schema"
+    Indirection_2:
+      $ref: "#/components/schemas/Indirection_1"
+    IndirectionSiblings_1:
+      $ref: "#/components/schemas/ex3schema"
+      description: IndirectionSiblings ex1schema
+    IndirectionSiblings_2:
+      $ref: "#/components/schemas/IndirectionSiblings_1"
       description: IndirectionSiblings root
-      properties:
-        prop1:
-          type: string
   parameters:
     userId:
       description: userId root

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/full/dereferencedfully.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/full/dereferencedfully.yaml
@@ -55,6 +55,24 @@ components:
       properties:
         prop1:
           type: string
+    ex3schema:
+      type: object
+      description: VALUE ex3schema
+      properties:
+        prop1:
+          type: string
+    Indirection_1:
+      type: object
+      description: VALUE ex3schema
+      properties:
+        prop1:
+          type: string
+    IndirectionSiblings_1:
+      type: object
+      description: IndirectionSiblings root
+      properties:
+        prop1:
+          type: string
   parameters:
     userId:
       name: userId

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/fullFS/dereferenced.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/fullFS/dereferenced.yaml
@@ -27,17 +27,25 @@ paths:
 components:
   schemas:
     Indirection:
+      $ref: "#/components/schemas/Indirection_2"
+    IndirectionSiblings:
+      $ref: "#/components/schemas/IndirectionSiblings_2"
+    ex3schema:
       type: object
       description: VALUE ex3schema
       properties:
         prop1:
           type: string
-    IndirectionSiblings:
-      type: object
+    Indirection_1:
+      $ref: "#/components/schemas/ex3schema"
+    Indirection_2:
+      $ref: "#/components/schemas/Indirection_1"
+    IndirectionSiblings_1:
+      $ref: "#/components/schemas/ex3schema"
+      description: IndirectionSiblings ex1schema
+    IndirectionSiblings_2:
+      $ref: "#/components/schemas/IndirectionSiblings_1"
       description: IndirectionSiblings root
-      properties:
-        prop1:
-          type: string
   parameters:
     userId:
       description: userId root

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/fullFS/dereferencedfully.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/fullFS/dereferencedfully.yaml
@@ -48,6 +48,24 @@ components:
       properties:
         prop1:
           type: string
+    ex3schema:
+      type: object
+      description: VALUE ex3schema
+      properties:
+        prop1:
+          type: string
+    Indirection_1:
+      type: object
+      description: VALUE ex3schema
+      properties:
+        prop1:
+          type: string
+    IndirectionSiblings_1:
+      type: object
+      description: IndirectionSiblings root
+      properties:
+        prop1:
+          type: string
   parameters:
     userId:
       name: userId

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/schema/$anchor-external/dereferenced.json
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/schema/$anchor-external/dereferenced.json
@@ -11,14 +11,17 @@
             "type" : "string"
           },
           "profile" : {
-            "properties" : {
-              "firstName" : {
-                "type" : "string"
-              },
-              "lastName" : {
-                "type" : "string"
-              }
-            }
+            "$ref" : "#/components/schemas/ex"
+          }
+        }
+      },
+      "ex" : {
+        "properties" : {
+          "firstName" : {
+            "type" : "string"
+          },
+          "lastName" : {
+            "type" : "string"
           }
         }
       }

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/schema/$anchor-external/dereferenced.json
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/schema/$anchor-external/dereferenced.json
@@ -11,11 +11,11 @@
             "type" : "string"
           },
           "profile" : {
-            "$ref" : "#/components/schemas/ex"
+            "$ref" : "#/components/schemas/user-profile"
           }
         }
       },
-      "ex" : {
+      "user-profile" : {
         "properties" : {
           "firstName" : {
             "type" : "string"

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/schema/$id-uri-direct/dereferenced.json
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/schema/$id-uri-direct/dereferenced.json
@@ -11,13 +11,16 @@
             "type" : "string"
           },
           "profile" : {
-            "type" : "object",
-            "$id" : "./nested/",
-            "properties" : {
-              "avatar" : {
-                "type" : "string"
-              }
-            }
+            "$ref" : "#/components/schemas/ex"
+          }
+        }
+      },
+      "ex" : {
+        "type" : "object",
+        "$id" : "./nested/",
+        "properties" : {
+          "avatar" : {
+            "type" : "string"
           }
         }
       }

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/schema/$id-uri-enclosing/dereferenced.json
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/schema/$id-uri-enclosing/dereferenced.json
@@ -12,12 +12,15 @@
             "type" : "string"
           },
           "profile" : {
-            "type" : "object",
-            "properties" : {
-              "avatar" : {
-                "type" : "string"
-              }
-            }
+            "$ref" : "#/components/schemas/ex"
+          }
+        }
+      },
+      "ex" : {
+        "type" : "object",
+        "properties" : {
+          "avatar" : {
+            "type" : "string"
           }
         }
       }

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/schema/$id-uri-external/dereferenced.json
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/schema/$id-uri-external/dereferenced.json
@@ -5,13 +5,19 @@
         "type" : "object",
         "properties" : {
           "profile" : {
-            "type" : "object",
-            "$id" : "./nested/",
-            "properties" : {
-              "avatar" : {
-                "type" : "string"
-              }
-            }
+            "$ref" : "#/components/schemas/UserProfile"
+          }
+        }
+      },
+      "UserProfile" : {
+        "$ref" : "#/components/schemas/ex"
+      },
+      "ex" : {
+        "type" : "object",
+        "$id" : "./nested/",
+        "properties" : {
+          "avatar" : {
+            "type" : "string"
           }
         }
       }

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/schemaindirect/dereferenced.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/dereference/schemaindirect/dereferenced.yaml
@@ -4,14 +4,12 @@ servers:
 components:
   schemas:
     Indirection:
+      $ref: "#/components/schemas/ex3schema"
+    IndirectionSiblings:
+      $ref: "#/components/schemas/ex3schema"
+    ex3schema:
       type: object
       description: desc ex3schema
-      properties:
-        prop1:
-          type: string
-    IndirectionSiblings:
-      type: object
-      description: overwritten desc IndirectionSiblings root
       properties:
         prop1:
           type: string


### PR DESCRIPTION
## Description

When parsing OpenAPI 3.1 specifications with external schema references (e.g., `$ref: "./schemas/health.yaml"`), the parser resolves the schemas correctly but does not add them to `components.schemas`. This causes `openAPI.getComponents().getSchemas()` to return null (as reported in https://github.com/swagger-api/swagger-parser/issues/2266), breaking downstream tooling like code generators that rely on component schemas being populated.

This works correctly for OpenAPI 3.0 specs (via `SchemaProcessor`/`ExternalRefProcessor`) but was missing in the OpenAPI 3.1 code path (`OpenAPI31Traverser`).

`OpenAPI31Traverser.traverseSchema()` handles local refs (starting with `#`) by adding them to `components.schemas`, but has no equivalent logic for external refs. External schemas are resolved and inlined during traversal, but never registered as components.

### Updated behavior for `setResolve(true)`

**Before**: External schemas were resolved and inlined directly at the usage site. `components.schemas` was not populated with external schemas.

**After**: External schemas are added to `components.schemas` and replaced with local $refs (e.g., `$ref: "#/components/schemas/ex"`). The schema content now lives in components instead of being inlined.

### Fixed behavior for `setResolveFully(true)`

**Before**: External schemas were resolved and inlined. components.schemas was not populated.

**After**: External schemas are added to components.schemas and still inlined at usage sites (because ResolverFully expands all remaining $refs afterward).

<!--
Describe what this PR changes:
- What problem does it solve?
- Is it a bug fix, new feature, or refactor?
- Link to any related issues.
-->

Fixes: #2266

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->