### PR TITLE
fix: hangling default int64 values for integer components of type int64

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -1903,6 +1903,29 @@ public class OpenAPIDeserializer {
 		return value;
 	}
 
+	private Number getInteger32or64(String key, ObjectNode node, boolean required, String location, ParseResult result) {
+		Number value = null;
+		JsonNode v = node.get(key);
+		if (node == null || v == null) {
+			if (required) {
+				result.missing(location, key);
+				result.invalid();
+			}
+		} else if (v.getNodeType().equals(JsonNodeType.NUMBER)) {
+			if (v.isInt()) {
+				value = v.intValue();
+			}
+			JsonNode format = node.get("format");
+			if (format != null && format.asText().equals("int64") && v.isLong()) {
+				value = v.longValue();
+			}
+		} else if (!v.isValueNode()) {
+			result.invalidType(location, key, "integer", node);
+		}
+		return value;
+	}
+
+
 	public Map<String, Parameter> getParameters(ObjectNode obj, String location, ParseResult result,
 												boolean underComponents) {
 		if (obj == null) {
@@ -2312,7 +2335,7 @@ public class OpenAPIDeserializer {
 				return getString(nodeKey, node, false, location, result);
 			}
 			if (example.getNodeType().equals(JsonNodeType.NUMBER)) {
-				Integer integerExample = getInteger(nodeKey, node, false, location, result);
+				Number integerExample = getInteger32or64(nodeKey, node, false, location, result);
 				if (integerExample != null) {
 					return integerExample;
 				} else {
@@ -2973,7 +2996,7 @@ public class OpenAPIDeserializer {
                         schema.setDefault(object);
                     }
                 } else if (schema.getType().equals("integer")) {
-                    Integer number = getInteger("default", node, false, location, result);
+                    Number number = getInteger32or64("default", node, false, location, result);
                     if (number != null) {
                         schema.setDefault(number);
                     }
@@ -3043,7 +3066,7 @@ public class OpenAPIDeserializer {
             schema.setMinimum(bigDecimal);
         }
 
-        Integer integer = getInteger("minLength", node, false, location, result);
+		Integer integer = getInteger("minLength", node, false, location, result);
         if (integer != null) {
             schema.setMinLength(integer);
         }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -1413,10 +1413,21 @@ public class OpenAPIV3ParserTest {
     }
 
     @Test
-    public void int64ExampleWithoutOverflow()  {
+    public void int64WithoutOverflow()  {
         OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/resources/int64example.yaml");
-        IntegerSchema date = ((IntegerSchema) openAPI.getPaths().get("/foo").getGet().getResponses().get("200").getContent().get("application/json").getSchema().getProperties().get("date"));
-        Assert.assertEquals(date.getExample().toString(), "1516042231144");
+        Operation get = openAPI.getPaths().get("/foo").getGet();
+        IntegerSchema exampleProperty = ((IntegerSchema) get.getResponses().get("200").getContent().get("application/json").getSchema().getProperties().get("exampleProperty"));
+        Assert.assertEquals(exampleProperty.getExample().toString(), "1516042231144");
+
+        Parameter parameter = get.getParameters().get(0);
+        String maxLong = "9223372036854775807";
+        Assert.assertEquals(parameter.getExample().toString(), maxLong);
+
+        IntegerSchema parameterInt64 = ((IntegerSchema) parameter.getSchema());
+        Assert.assertEquals(parameterInt64.getExample().toString(), maxLong);
+        Assert.assertEquals(parameterInt64.getMinimum().toString(), maxLong);
+        Assert.assertEquals(parameterInt64.getMaximum().toString(), maxLong);
+        Assert.assertEquals(parameterInt64.getDefault().toString(), maxLong);
     }
 
     @Test

--- a/modules/swagger-parser-v3/src/test/resources/int64example.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/int64example.yaml
@@ -5,6 +5,17 @@ info:
 paths:
   /foo:
     get:
+      parameters:
+        - in: query
+          name: int64
+          example: 9223372036854775807
+          schema:
+            type: integer
+            format: int64
+            default: 9223372036854775807
+            example: 9223372036854775807
+            minimum: 9223372036854775807
+            maximum: 9223372036854775807
       responses:
         '200':
           description: OK
@@ -13,9 +24,9 @@ paths:
               schema:
                 type: object
                 properties:
-                  date:
+                  exampleProperty:
                     type: integer
                     format: int64
                     example: 1516042231144
                 required:
-                  - date
+                  - exampleProperty


### PR DESCRIPTION

# Pull Request

Thank you for contributing to **swagger-parser**!

Please fill out the following checklist to help us review your PR efficiently.

---

## Description


Bug fix:
When deserializing a default value that is bigger than a int32, the value is returned as null.
This change allows to have default values up to int64 size when the type of the integer is specified as int64.

The change is mostly for the field default, but I took care to cover other fields that could accept int64 values (which were working fine) . See test for details.


## Type of Change

<!-- Check all that apply: -->

- [X ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [ X] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [X ] The PR title is descriptive
- [ X] The code builds and passes tests locally
- [ ] I have linked related issues (if any)

## Screenshots / Additional Context

