### PR TITLE
fix: add content example resolving for request bodies and parameters

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
@@ -147,17 +147,7 @@ public class ResolverFully {
                             parameter.setSchema(resolved);
                         }
                     }
-                    if(parameter.getContent() != null){
-                        Map<String,MediaType> content = parameter.getContent();
-                        for (String key: content.keySet()){
-                            if (content.get(key) != null && content.get(key).getSchema() != null ){
-                                Schema resolvedSchema = resolveSchema(content.get(key).getSchema());
-                                if (resolvedSchema != null) {
-                                    content.get(key).setSchema(resolvedSchema);
-                                }
-                            }
-                        }
-                    }
+                    resolveContent(parameter.getContent());
                 }
             }
 
@@ -183,17 +173,7 @@ public class ResolverFully {
             if (refRequestBody != null){
                 RequestBody requestBody = refRequestBody.get$ref() != null ? resolveRequestBody(refRequestBody) : refRequestBody;
                 op.setRequestBody(requestBody);
-                if (requestBody.getContent() != null) {
-                    Map<String, MediaType> content = requestBody.getContent();
-                    for (String key : content.keySet()) {
-                        if (content.get(key) != null && content.get(key).getSchema() != null) {
-                            Schema resolved = resolveSchema(content.get(key).getSchema());
-                            if (resolved != null) {
-                                content.get(key).setSchema(resolved);
-                            }
-                        }
-                    }
-                }
+                resolveContent(requestBody.getContent());
             }
             // responses
             ApiResponses responses = op.getResponses();
@@ -202,20 +182,7 @@ public class ResolverFully {
                 for(String code : responses.keySet()) {
                     ApiResponse response = responses.get(code);
                     response = response.get$ref() != null ? resolveResponse(response) : response;
-                    if (response.getContent() != null) {
-                        Map<String, MediaType> content = response.getContent();
-                        for(String mediaType: content.keySet()){
-                            if(content.get(mediaType).getSchema() != null) {
-                                Schema resolved = resolveSchema(content.get(mediaType).getSchema());
-                                response.getContent().get(mediaType).setSchema(resolved);
-                            }
-                            if(content.get(mediaType).getExamples() != null) {
-                                Map<String,Example> resolved = resolveExample(content.get(mediaType).getExamples());
-                                response.getContent().get(mediaType).setExamples(resolved);
-
-                            }
-                        }
-                    }
+                    resolveContent(response.getContent());
 
                     resolveHeaders(response.getHeaders());
 
@@ -230,6 +197,28 @@ public class ResolverFully {
                     resolvedResponses.addApiResponse(code, response);
                 }
                 op.setResponses(resolvedResponses);
+            }
+        }
+    }
+
+    private void resolveContent(Map<String, MediaType> content) {
+        if (content == null) {
+            return;
+        }
+        for (String key : content.keySet()) {
+            MediaType mediaType = content.get(key);
+            if (mediaType != null) {
+                Schema mediaTypeSchema = mediaType.getSchema();
+                if (mediaTypeSchema != null) {
+                    Schema resolved = resolveSchema(mediaTypeSchema);
+                    if (resolved != null) {
+                        mediaType.setSchema(resolved);
+                    }
+                }
+                Map<String, Example> examples = mediaType.getExamples();
+                if (examples != null) {
+                    mediaType.setExamples(resolveExample(examples));
+                }
             }
         }
     }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
@@ -1560,5 +1560,39 @@ public class OpenAPIResolverTest {
                 { false }
         };
     }
-    
+
+    @Test
+    public void testIssue2292() {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        options.setResolveFully(true);
+
+        OpenAPI openAPI = new OpenAPIV3Parser().readLocation("/issue-2292.yaml", auths, options).getOpenAPI();
+
+        // Verify parameter content examples are resolved
+        Parameter filterParam = openAPI.getPaths().get("/users").getPost().getParameters().get(0);
+        Map<String, Example> paramExamples = filterParam.getContent().get("application/json").getExamples();
+        Example resolvedFilterExample = paramExamples.get("simpleFilter");
+        assertNotNull(resolvedFilterExample);
+        assertNull(resolvedFilterExample.get$ref());
+        assertEquals("A sample filter", resolvedFilterExample.getSummary());
+
+        // Verify requestBody content examples are resolved
+        RequestBody requestBody = openAPI.getPaths().get("/users").getPost().getRequestBody();
+        Map<String, Example> requestBodyExamples = requestBody.getContent().get("application/json").getExamples();
+        Example resolvedUserExample = requestBodyExamples.get("defaultUser");
+        assertNotNull(resolvedUserExample);
+        assertNull(resolvedUserExample.get$ref());
+        assertEquals("A sample user", resolvedUserExample.getSummary());
+
+        // Verify response content examples are resolved
+        ApiResponse response = openAPI.getPaths().get("/users").getPost().getResponses().get("200");
+        Map<String, Example> responseExamples = response.getContent().get("application/json").getExamples();
+        Example resolvedResponseExample = responseExamples.get("successResponse");
+        assertNotNull(resolvedResponseExample);
+        assertNull(resolvedResponseExample.get$ref());
+        assertEquals("A sample user", resolvedResponseExample.getSummary());
+    }
+
+
 }

--- a/modules/swagger-parser-v3/src/test/resources/issue-2292.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2292.yaml
@@ -1,0 +1,56 @@
+openapi: "3.0.3"
+info:
+  title: Example Reference Demo API
+  version: "1.0"
+paths:
+  /users:
+    post:
+      summary: Create a user
+      parameters:
+        - name: filter
+          in: query
+          content:
+            application/json:
+              schema:
+                type: object
+              examples:
+                simpleFilter:
+                  $ref: "#/components/examples/FilterExample"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+            examples:
+              defaultUser:
+                $ref: "#/components/examples/UserExample"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+              examples:
+                successResponse:
+                  $ref: "#/components/examples/UserExample"
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+  examples:
+    UserExample:
+      summary: A sample user
+      value:
+        id: "12345"
+        name: John Doe
+    FilterExample:
+      summary: A sample filter
+      value:
+        status: active


### PR DESCRIPTION
## Description

- Fixes content example resolving for request bodies and parameters.
- Refactors duplicate content resolution logic (schema + examples) into a shared resolveContent() helper method.

Fixes: [#2292](https://github.com/swagger-api/swagger-parser/issues/2292)

## Type of Change

<!-- Check all that apply: -->

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [X] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)
