### PR TITLE
Prevent `StackOverflowError` in `ResolverFully`

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
@@ -66,7 +66,7 @@ public class ResolverFully {
     private Map<String, RequestBody> requestBodies;
     private Map<String, Header> headers;
     private Map<String, Link> links;
-    private Map<String, Schema> resolvedProperties = new IdentityHashMap<>();
+    private Map<Schema, Schema> resolvedSchemas = new IdentityHashMap<>();
     private Map<String, Callback> callbacks;
 
     public void resolveFully(OpenAPI openAPI) {
@@ -337,6 +337,18 @@ public class ResolverFully {
             return null;
         }
 
+        Schema resolved = resolvedSchemas.get(schema);
+        if (resolved != null) {
+            return resolved;
+        }
+
+        resolved = resolveSchemaImpl(schema);
+        resolvedSchemas.put(schema, resolved);
+        return resolved;
+    }
+
+    private Schema resolveSchemaImpl(Schema schema) {
+
         if(schema.get$ref() != null) {
             String ref= schema.get$ref();
             Schema resolved;
@@ -394,7 +406,7 @@ public class ResolverFully {
                     Schema innerProperty = obj.getProperties().get(propertyName);
                     // reference check
                     if(schema != innerProperty) {
-                        updated.put(propertyName, resolveSchemaProperty(propertyName, innerProperty));
+                        updated.put(propertyName, resolveSchema(innerProperty));
                     }
                 }
                 obj.setProperties(updated);
@@ -499,7 +511,7 @@ public class ResolverFully {
             Map<String, Schema> properties = model.getProperties();
             for (String propertyName : properties.keySet()) {
                 Schema property = (Schema) model.getProperties().get(propertyName);
-                updated.put(propertyName, resolveSchemaProperty(propertyName, property));
+                updated.put(propertyName, resolveSchema(property));
             }
 
             for (String key : updated.keySet()) {
@@ -573,7 +585,7 @@ public class ResolverFully {
             if (resolved.getProperties() != null) {
                 for (String key : properties.keySet()) {
                     Schema prop = (Schema) resolved.getProperties().get(key);
-                    targetSchema.addProperties(key, resolveSchemaProperty(key, prop));
+                    targetSchema.addProperties(key, resolveSchema(prop));
                 }
 
                 if (resolved.getRequired() != null) {
@@ -696,17 +708,6 @@ public class ResolverFully {
             }
             required.addAll(requiredProperties);
             targetSchema.setRequired(required);
-        }
-    }
-
-    private Schema resolveSchemaProperty(String propertyName, Schema innerProperty) {
-        if (resolvedProperties.get(propertyName) == null || resolvedProperties.get(propertyName) != innerProperty) {
-            LOGGER.debug("avoiding infinite loop");
-            Schema resolved = resolveSchema(innerProperty);
-            resolvedProperties.put(propertyName, resolved);
-            return resolved;
-        } else {
-            return resolvedProperties.get(propertyName);
         }
     }
 }

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -67,6 +68,7 @@ public class ResolverFully {
     private Map<String, Header> headers;
     private Map<String, Link> links;
     private Map<Schema, Schema> resolvedSchemas = new IdentityHashMap<>();
+    private Set<Schema> schemasInProgress = Collections.newSetFromMap(new IdentityHashMap<>());
     private Map<String, Callback> callbacks;
 
     public void resolveFully(OpenAPI openAPI) {
@@ -336,15 +338,25 @@ public class ResolverFully {
         if (schema == null) {
             return null;
         }
-
-        Schema resolved = resolvedSchemas.get(schema);
-        if (resolved != null) {
-            return resolved;
+        Schema cached = resolvedSchemas.get(schema);
+        if (cached != null) {
+            return cached;
         }
+        if (schemasInProgress.contains(schema)) {
+            return schema;
+        }
+        return resolveAndCache(schema);
+    }
 
-        resolved = resolveSchemaImpl(schema);
-        resolvedSchemas.put(schema, resolved);
-        return resolved;
+    private Schema resolveAndCache(Schema schema) {
+        schemasInProgress.add(schema);
+        try {
+            Schema resolved = resolveSchemaImpl(schema);
+            resolvedSchemas.put(schema, resolved);
+            return resolved;
+        } finally {
+            schemasInProgress.remove(schema);
+        }
     }
 
     private Schema resolveSchemaImpl(Schema schema) {

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
@@ -1433,6 +1433,20 @@ public class OpenAPIResolverTest {
     }
 
     @Test
+    public void recursiveResolvingIssue1751() {
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(true);
+        parseOptions.setResolveFully(true);
+        OpenAPI openAPI = new OpenAPIV3Parser().read("issue_1751.yaml", null, parseOptions);
+        try {
+            Json.mapper().writeValueAsString(openAPI);
+        }
+        catch (Exception e) {
+            fail("Recursive loop found");
+        }
+    }
+
+    @Test
     public void recursiveIssue984() {
         ParseOptions parseOptions = new ParseOptions();
         parseOptions.setResolve(true);

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
@@ -1438,11 +1438,57 @@ public class OpenAPIResolverTest {
         parseOptions.setResolve(true);
         parseOptions.setResolveFully(true);
         OpenAPI openAPI = new OpenAPIV3Parser().read("issue_1751.yaml", null, parseOptions);
+        assertNotNull(openAPI, "OpenAPI should be parsed successfully");
+        assertNotNull(openAPI.getComponents().getSchemas().get("NestedObject"), "NestedObject schema should be present");
         try {
-            Json.mapper().writeValueAsString(openAPI);
+            String serialized = Json.mapper().writeValueAsString(openAPI);
+            assertNotNull(serialized, "Serialized output should not be null");
         }
         catch (Exception e) {
-            fail("Recursive loop found");
+            fail("Recursive loop found: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void recursiveResolvingIssue1751MutualRecursion() {
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(true);
+        parseOptions.setResolveFully(true);
+        OpenAPI openAPI = new OpenAPIV3Parser().read("issue_1751_mutual_recursion.yaml", null, parseOptions);
+        assertNotNull(openAPI, "OpenAPI should be parsed successfully");
+        assertNotNull(openAPI.getComponents(), "Components should not be null");
+        assertNotNull(openAPI.getComponents().getSchemas().get("SchemaA"), "SchemaA should be present");
+        assertNotNull(openAPI.getComponents().getSchemas().get("SchemaB"), "SchemaB should be present");
+        assertEquals(openAPI.getComponents().getSchemas().get("SchemaA").getType(), "object", "SchemaA should be object type");
+        assertEquals(openAPI.getComponents().getSchemas().get("SchemaB").getType(), "object", "SchemaB should be object type");
+        try {
+            String serialized = Json.mapper().writeValueAsString(openAPI);
+            assertNotNull(serialized, "Serialized output should not be null");
+        }
+        catch (Exception e) {
+            fail("Recursive loop found: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void recursiveResolvingIssue1751RecursiveArrayItems() {
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(true);
+        parseOptions.setResolveFully(true);
+        OpenAPI openAPI = new OpenAPIV3Parser().read("issue_1751_recursive_array.yaml", null, parseOptions);
+        assertNotNull(openAPI, "OpenAPI should be parsed successfully");
+        Schema treeNode = openAPI.getComponents().getSchemas().get("TreeNode");
+        assertNotNull(treeNode, "TreeNode schema should be present");
+        assertEquals(treeNode.getType(), "object", "TreeNode should be object type");
+        Schema valueProperty = (Schema) treeNode.getProperties().get("value");
+        assertNotNull(valueProperty, "TreeNode should have a value property");
+        assertEquals(valueProperty.getType(), "integer", "value property should be integer type");
+        try {
+            String serialized = Json.mapper().writeValueAsString(openAPI);
+            assertNotNull(serialized, "Serialized output should not be null");
+        }
+        catch (Exception e) {
+            fail("Recursive loop found: " + e.getMessage());
         }
     }
 

--- a/modules/swagger-parser-v3/src/test/resources/issue_1751.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue_1751.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+paths:
+  /first:
+    get:
+      parameters:
+      - "$ref": "#/components/parameters/p_one"
+      - "$ref": "#/components/parameters/p_one"
+      - "$ref": "#/components/parameters/p_one"
+      responses:
+        200:
+          description: ok
+components:
+  parameters:
+    p_one:
+      in: query
+      schema:
+        "$ref": "#/components/schemas/NestedObject"
+      style: deepObject
+  schemas:
+    NestedObject:
+      additionalProperties:
+        oneOf:
+        - "$ref": "#/components/schemas/NestedObject"
+        - not:
+            type: object
+      type: object

--- a/modules/swagger-parser-v3/src/test/resources/issue_1751_mutual_recursion.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue_1751_mutual_recursion.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.0
+info:
+  title: Mutual Recursion Test
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchemaA'
+components:
+  schemas:
+    SchemaA:
+      type: object
+      properties:
+        name:
+          type: string
+        b:
+          $ref: '#/components/schemas/SchemaB'
+    SchemaB:
+      type: object
+      properties:
+        value:
+          type: integer
+        a:
+          $ref: '#/components/schemas/SchemaA'

--- a/modules/swagger-parser-v3/src/test/resources/issue_1751_recursive_array.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue_1751_recursive_array.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Recursive Array Items Test
+  version: 1.0.0
+paths:
+  /tree:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TreeNode'
+components:
+  schemas:
+    TreeNode:
+      type: object
+      properties:
+        value:
+          type: integer
+        left:
+          $ref: '#/components/schemas/TreeNode'
+        right:
+          $ref: '#/components/schemas/TreeNode'
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/TreeNode'


### PR DESCRIPTION
## Description

Add guard to resolve schemas just once to prevent loops/stack overflows.

`ResolverFully.resolveSchema()` threw `java.lang.StackOverflowError` when parsing
OpenAPI documents that contain recursive schema definitions. For example: a schema
whose `additionalProperties.oneOf` references itself, or a tree-shaped model whose
`items` points back to the parent type.

Two-phase guard:

| Phase | Mechanism | Keyed by | Catches |
|---|---|---|---|
| In-progress | `schemasInProgress` | object identity | cycles found *during* descent |
| Completed | `resolvedSchemas` | object identity | repeated resolution of already-resolved schemas |

Fix #1751.

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)
