### PR TITLE
fix(parser): honor inferSchemaType for OAS 3.1 enum schemas

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/OpenAPIDeserializer.java
@@ -4020,7 +4020,7 @@ public class OpenAPIDeserializer {
 				}
 			}
 
-		} else {
+		} else if (result.isInferSchemaType()) {
 			// may have an enum where type can be inferred
 			JsonNode enumNode = node.get("enum");
 			if (enumNode != null && enumNode.isArray()) {

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OAI31DeserializationTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OAI31DeserializationTest.java
@@ -1035,6 +1035,59 @@ public class OAI31DeserializationTest {
         assertEquals(id.getTypes().iterator().next(), "string");
     }
 
+    @Test(description = "Test Issue 1964 with inferSchemaType disabled")
+    public void test31Issue1964InferSchemaTypeDisabled() {
+        ParseOptions options = new ParseOptions();
+        options.setInferSchemaType(false);
+
+        String yaml = "openapi: 3.1.0\n" +
+                "info:\n" +
+                "  version: 1.0.0\n" +
+                "  title: Example\n" +
+                "paths:\n" +
+                "  /somePath:\n" +
+                "    get:\n" +
+                "      operationId: getSomePath\n" +
+                "      responses:\n" +
+                "        '200':\n" +
+                "          description: OK\n" +
+                "          content:\n" +
+                "            application/json:\n" +
+                "              schema: {}\n" +
+                "components:\n" +
+                "  schemas:\n" +
+                "    ArrayContainsValue:\n" +
+                "      type: array\n" +
+                "      contains:\n" +
+                "        enum:\n" +
+                "          - 1\n" +
+                "    AdditionalpropertiesBeingFalseDoesNotAllowOtherProperties:\n" +
+                "      $schema: https://json-schema.org/draft/2020-12/schema\n" +
+                "      properties:\n" +
+                "        foo: {}\n" +
+                "        bar: {}\n" +
+                "      patternProperties:\n" +
+                "        ^v: {}\n" +
+                "      additionalProperties: false\n";
+
+        SwaggerParseResult result = new OpenAPIV3Parser().readContents(yaml, null, options);
+        OpenAPI openAPI = result.getOpenAPI();
+        assertNotNull(openAPI);
+        assertTrue(result.getMessages().isEmpty(), String.valueOf(result.getMessages()));
+
+        Schema arrayContainsValue = openAPI.getComponents().getSchemas().get("ArrayContainsValue");
+        assertNotNull(arrayContainsValue.getContains());
+        assertNull(arrayContainsValue.getContains().getType());
+        assertNull(arrayContainsValue.getContains().getTypes());
+
+        Schema objectWithoutExplicitType = openAPI.getComponents().getSchemas()
+                .get("AdditionalpropertiesBeingFalseDoesNotAllowOtherProperties");
+        assertTrue(objectWithoutExplicitType.getAdditionalProperties() instanceof Schema);
+        assertFalse(((Schema) objectWithoutExplicitType.getAdditionalProperties()).getBooleanSchemaValue());
+        assertNull(objectWithoutExplicitType.getType());
+        assertNull(objectWithoutExplicitType.getTypes());
+    }
+
     @Test(description = "Test safe resolving")
     public void test31SafeURLResolving() {
         ParseOptions parseOptions = new ParseOptions();


### PR DESCRIPTION
# Pull Request
  ---

  ## Description

  This PR fixes an OpenAPI 3.1 parser inconsistency when `ParseOptions.setInferSchemaType(false)` is used.

  In the OAS 3.1 `getJsonSchema(...)` path, enum-based type inference was still applied even when schema type inference was explicitly disabled. As a result, schemas like:

  ```yaml
  contains:
    enum:
      - 1

  were parsed with an invented type instead of preserving an unset type.

  This PR updates that path to honor inferSchemaType(false) and adds a regression test covering the issue.

  Fixes [#1964](https://github.com/swagger-api/swagger-parser/pull/2299)

  ## Type of Change

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] ♻️ Refactor (non-breaking change)
  - [x] 🧪 Tests
  - [ ] 📝 Documentation
  - [ ] 🧹 Chore (build or tooling)

  ## Checklist

  - [x] I have added/updated tests as needed
  - [ ] I have added/updated documentation where applicable
  - [x] The PR title is descriptive
  - [x] The code builds and passes tests locally
  - [x] I have linked related issues (if any)

  ## Screenshots / Additional Context

  Locally verified with:

  mvn -pl modules/swagger-parser-v3 -am -Dsurefire.failIfNoSpecifiedTests=false -Dtest=OAI31DeserializationTest#test31Issue1964InferSchemaTypeDisabled test
  mvn -pl modules/swagger-parser-v3 -am -Dsurefire.failIfNoSpecifiedTests=false -Dtest=OAI31DeserializationTest#testSchemaKeysOAS31 test

  The regression test confirms that with inferSchemaType(false):

  - contains: { enum: [1] } does not get an inferred type
  - additionalProperties: false does not force an object type