### PR TITLE
fix: resolve relative refs correctly from spring boot jars (#2080, #2298)

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/RefUtils.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/RefUtils.java
@@ -6,7 +6,6 @@ import io.swagger.v3.parser.processors.ExternalRefProcessor;
 import io.swagger.v3.parser.urlresolver.PermittedUrlsChecker;
 import org.apache.commons.io.IOUtils;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -235,7 +234,7 @@ public class RefUtils {
     }
 
     private static String readAll(Path path) throws IOException {
-        try (InputStream inputStream = new FileInputStream(path.toFile())) {
+        try (InputStream inputStream = Files.newInputStream(path)) {
             return IOUtils.toString(inputStream, UTF_8);
         }
     }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/RefUtilsTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/RefUtilsTest.java
@@ -195,10 +195,6 @@ public class RefUtilsTest {
             times = 1;
             result = true;
 
-            pathToUse.toFile();
-            times = 1;
-            result = file;
-
         }};
     }
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/RefUtilsZipFileSystemTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/RefUtilsZipFileSystemTest.java
@@ -1,0 +1,50 @@
+package io.swagger.v3.parser.util;
+
+import io.swagger.v3.parser.models.RefFormat;
+import io.swagger.v3.parser.urlresolver.PermittedUrlsChecker;
+import org.junit.Test;
+
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+public class RefUtilsZipFileSystemTest {
+
+    @Test
+    public void testReadExternalRefFromZipFileSystem() throws Exception {
+        Path archive = Files.createTempFile("ref-utils", ".zip");
+        Files.delete(archive);
+
+        Map<String, String> environment = Collections.singletonMap("create", "true");
+        URI archiveUri = URI.create("jar:" + archive.toUri());
+        String expectedContent = "openapi: 3.0.0\n";
+
+        try (FileSystem zipFileSystem = FileSystems.newFileSystem(archiveUri, environment)) {
+            Path parentDirectory = zipFileSystem.getPath("/specs");
+            Path referencedFile = parentDirectory.resolve("error.openapi.yaml");
+            Files.createDirectories(parentDirectory);
+            Files.write(referencedFile, expectedContent.getBytes(UTF_8));
+
+            assertNotSame(FileSystems.getDefault(), referencedFile.getFileSystem());
+
+            String actualContent = RefUtils.readExternalRef(
+                    "./error.openapi.yaml",
+                    RefFormat.RELATIVE,
+                    Collections.emptyList(),
+                    parentDirectory,
+                    new PermittedUrlsChecker());
+
+            assertEquals(expectedContent, actualContent);
+        } finally {
+            Files.deleteIfExists(archive);
+        }
+    }
+}


### PR DESCRIPTION
Parsing schemas with refs to other files fails did fail when using running a spring boot jar and using the default loader.

# Pull Request

Thank you for contributing to **swagger-parser**!

Please fill out the following checklist to help us review your PR efficiently.

---

## Description

Fixes loading schemas with refs when running a spring boot jar

Fixes: #2080 and #2298 (is a duplicate)

## Type of Change

<!-- Check all that apply: -->

- [x ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

Kudos to @sjsachinrj for his suggested fix