### PR TITLE
Fix #1518 Duplicate External Schema Components

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -130,17 +130,8 @@ public final class ExternalRefProcessor {
                 if (isAnExternalRefFormat(ref)) {
                     if (!ref.equals(RefFormat.URL)) {
                         String schemaFullRef = schema.get$ref();
-                        String parent = (file.contains("/")) ? file.substring(0, file.lastIndexOf('/')) : "";
-                        if (!parent.isEmpty() && !schemaFullRef.startsWith("/")) {
-                            if (schemaFullRef.contains("#/")) {
-                                String[] parts = schemaFullRef.split("#/");
-                                String schemaFullRefFilePart = parts[0];
-                                String schemaFullRefInternalRefPart = parts[1];
-                                schemaFullRef = Paths.get(parent, schemaFullRefFilePart).normalize() + "#/" + schemaFullRefInternalRefPart;
-                            } else {
-                                schemaFullRef = Paths.get(parent, schemaFullRef).normalize().toString();
-                            }
-                            schemaFullRef = FilenameUtils.separatorsToUnix(schemaFullRef);
+                        if (!schemaFullRef.startsWith("/")) {
+                            schemaFullRef = join(file, schemaFullRef);
                         }
                         schema.set$ref(processRefToExternalSchema(schemaFullRef, ref));
                     }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -35,6 +35,7 @@ import java.util.*;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.testng.Assert.*;
+import static org.testng.Assert.assertEqualsNoOrder;
 
 
 public class OpenAPIV3ParserTest {
@@ -560,6 +561,16 @@ public class OpenAPIV3ParserTest {
         }catch (StackOverflowError stackOverflowError){
             fail();
         }
+    }
+
+    @Test
+    public void testIssue1518NestedExternalRefs() {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation("issue-1518-nested-ref/api.yaml", null, options);
+        OpenAPI openAPI = result.getOpenAPI();
+        Set<String> schemaKeys = openAPI.getComponents().getSchemas().keySet();
+        assertEqualsNoOrder(schemaKeys, Arrays.asList("SharedModel", "shared-model", "Wrapper", "Leaf"));
     }
 
     @Test
@@ -3292,7 +3303,7 @@ public class OpenAPIV3ParserTest {
         OpenAPI openAPI = parseResult.getOpenAPI();
         assertEqualsNoOrder(
             openAPI.getComponents().getSchemas().keySet(),
-            Arrays.asList("ArrayPojo", "Enum1", "Enum1_1", "Enum2", "Enum3", "MapPojo", "SetPojo", "SimplePojo",
+            Arrays.asList("ArrayPojo", "Enum1", "Enum2", "Enum3", "MapPojo", "SetPojo", "SimplePojo",
                 "TransactionsPatchRequestBody", "additional-properties", "array-pojo", "locale-translation-item",
                 "map-pojo", "set-pojo", "simple-pojo", "translation-item")
         );

--- a/modules/swagger-parser-v3/src/test/resources/issue-1518-nested-ref/api.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1518-nested-ref/api.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.3
+info:
+  title: Duplicate Schema Repro
+  version: 1.0.0
+
+paths:
+  /shared-directly:
+    $ref: "./paths/direct.yaml"
+  /shared-nested:
+    $ref: "./paths/nested.yaml"
+
+components:
+  schemas:
+    SharedModel:
+      $ref: "./schemas/shared-model.yaml"
+    Wrapper:
+      $ref: "./schemas/wrapper.yaml"
+    Leaf:
+      $ref: "./schemas/leaf.yaml"

--- a/modules/swagger-parser-v3/src/test/resources/issue-1518-nested-ref/paths/direct.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1518-nested-ref/paths/direct.yaml
@@ -1,0 +1,10 @@
+get:
+  tags: [Repro]
+  operationId: getSharedDirectly
+  responses:
+    '200':
+      description: Path that returns the shared model directly.
+      content:
+        application/json:
+          schema:
+            $ref: "../api.yaml#/components/schemas/SharedModel"

--- a/modules/swagger-parser-v3/src/test/resources/issue-1518-nested-ref/paths/nested.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1518-nested-ref/paths/nested.yaml
@@ -1,0 +1,10 @@
+get:
+  tags: [Repro]
+  operationId: getSharedNested
+  responses:
+    '200':
+      description: Path that returns a wrapper whose items are the shared model.
+      content:
+        application/json:
+          schema:
+            $ref: "../api.yaml#/components/schemas/Wrapper"

--- a/modules/swagger-parser-v3/src/test/resources/issue-1518-nested-ref/schemas/leaf.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1518-nested-ref/schemas/leaf.yaml
@@ -1,0 +1,7 @@
+type: object
+required:
+  - id
+properties:
+  id:
+    type: string
+    format: uuid

--- a/modules/swagger-parser-v3/src/test/resources/issue-1518-nested-ref/schemas/shared-model.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1518-nested-ref/schemas/shared-model.yaml
@@ -1,0 +1,9 @@
+type: object
+required:
+  - name
+  - leaf
+properties:
+  name:
+    type: string
+  leaf:
+    $ref: "../api.yaml#/components/schemas/Leaf"

--- a/modules/swagger-parser-v3/src/test/resources/issue-1518-nested-ref/schemas/wrapper.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1518-nested-ref/schemas/wrapper.yaml
@@ -1,0 +1,8 @@
+type: object
+required:
+  - items
+properties:
+  items:
+    type: array
+    items:
+      $ref: "../api.yaml#/components/schemas/SharedModel"


### PR DESCRIPTION
# Pull Request

Thank you for contributing to **swagger-parser**!

Please fill out the following checklist to help us review your PR efficiently.

---

## Description

Fixes #1518

Resolving nested external schema refs could treat the same target schema as different refs depending on the relative path spelling, which led to duplicate generated models with suffixed names (see added test case).

This change normalizes nested external schema refs through the existing `join(...)` path resolution logic in `ExternalRefProcessor` instead of rebuilding the ref manually.

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)