### PR TITLE
Failing test: OAS 3.1 internal $ref inlined when spec loaded by file:// URL (resolveFully=false) — #1922

### DIFF
--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue1922InternalRefFileUrlTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue1922InternalRefFileUrlTest.java
@@ -1,0 +1,65 @@
+package io.swagger.v3.parser.test;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Regression test for https://github.com/swagger-api/swagger-parser/issues/1922
+ *
+ * For an OAS 3.1 document that contains only internal ("#/components/...") references, parsing with
+ * {@code resolve=true} and {@code resolveFully=false} must leave the internal {@code $ref}s intact —
+ * regardless of whether the root document is loaded by a filesystem path or by a {@code file://} URL.
+ *
+ * Today the result diverges: loaded by PATH the {@code $ref} is preserved (correct); loaded by
+ * {@code file://} URL the OAS 3.1 dereferencer inlines the referenced schema and the {@code $ref} is
+ * lost. Downstream code generators (openapi-generator, quarkus-openapi-generator) that pass the spec
+ * as a URL therefore see every reused component duplicated per use-site, with the canonical component
+ * left generated-but-orphaned.
+ */
+public class Issue1922InternalRefFileUrlTest {
+
+    private static final String SPEC = "src/test/resources/3.1.0/issue-1922-internal-ref-reuse.yaml";
+
+    private static ParseOptions resolveButNotFully() {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);        // resolve references...
+        options.setResolveFully(false);  // ...but do NOT inline them
+        options.setFlatten(false);
+        return options;
+    }
+
+    /** The internal $ref at FeeListResponse.fees.items, or null if it was inlined. */
+    private static String feesItemsRef(String location) {
+        OpenAPI api = new OpenAPIV3Parser().readLocation(location, null, resolveButNotFully()).getOpenAPI();
+        Schema<?> fees = (Schema<?>) api.getComponents().getSchemas().get("FeeListResponse").getProperties().get("fees");
+        return fees.getItems() == null ? null : fees.getItems().get$ref();
+    }
+
+    @Test(description = "internal $ref is preserved when loaded by filesystem path (baseline)")
+    public void internalRefPreservedWhenLoadedByPath() {
+        String path = new File(SPEC).getAbsolutePath();
+        assertEquals(feesItemsRef(path), "#/components/schemas/FeeValues");
+    }
+
+    @Test(description = "internal $ref must also be preserved when loaded by file:// URL (issue #1922)")
+    public void internalRefPreservedWhenLoadedByFileUrl() {
+        String fileUrl = Paths.get(SPEC).toAbsolutePath().toUri().toString();
+        // FAILS today: the OAS 3.1 dereferencer inlines the internal $ref on file:// load, so this is null.
+        assertEquals(feesItemsRef(fileUrl), "#/components/schemas/FeeValues");
+    }
+
+    @Test(description = "path and file:// URL must produce identical handling of internal $refs")
+    public void pathAndFileUrlAgree() {
+        String path = new File(SPEC).getAbsolutePath();
+        String fileUrl = Paths.get(SPEC).toAbsolutePath().toUri().toString();
+        assertEquals(feesItemsRef(fileUrl), feesItemsRef(path));
+    }
+}

--- a/modules/swagger-parser-v3/src/test/resources/3.1.0/issue-1922-internal-ref-reuse.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/3.1.0/issue-1922-internal-ref-reuse.yaml
@@ -1,0 +1,42 @@
+openapi: 3.1.0
+info:
+  title: internal-ref-reuse
+  version: "1.0.0"
+paths:
+  /fees:
+    get:
+      operationId: listFees
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeeListResponse"
+  /fees/group/{groupId}:
+    put:
+      operationId: putGroupFees
+      parameters:
+        - { name: groupId, in: path, required: true, schema: { type: string } }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FeeValues"
+      responses:
+        "204": { description: ok }
+components:
+  schemas:
+    FeeValues:
+      type: object
+      required: [amount]
+      properties:
+        amount: { type: integer, format: int32 }
+        label: { type: string }
+    FeeListResponse:
+      type: object
+      properties:
+        fees:
+          type: array
+          items:
+            $ref: "#/components/schemas/FeeValues"


### PR DESCRIPTION
## What / why

Adds a **failing regression test** for #1922 in the parser's own harness.

For an OAS **3.1** document that contains only *internal* (`#/components/...`) references, parsing with `resolve=true` and **`resolveFully=false`** should leave those `$ref`s intact. Today the result depends on *how the root document was loaded*:

| load by | `FeeListResponse.fees.items.$ref` |
|---|---|
| filesystem **path** | `#/components/schemas/FeeValues` (preserved ✅) |
| **`file://` URL** | `null` — schema inlined, `$ref` lost ❌ |

`reproduce` (also dependency-free, runnable against any `openapi-generator-cli` jar which bundles this parser):
```java
ParseOptions o = new ParseOptions();
o.setResolve(true);
o.setResolveFully(false);            // explicitly: do NOT inline
new OpenAPIV3Parser().readLocation(PATH, null, o);      // $ref preserved
new OpenAPIV3Parser().readLocation(FILE_URI, null, o);  // $ref inlined (bug)
```

This is **OAS 3.1-only** (the equivalent 3.0 spec preserves the `$ref` under both path and URL load) and reproduces on every release from **2.1.22 through 2.1.43** (latest).

## Test results (this PR)

```
internalRefPreservedWhenLoadedByPath     PASS   (baseline)
internalRefPreservedWhenLoadedByFileUrl  FAIL   expected [#/components/schemas/FeeValues] but found [null]
pathAndFileUrlAgree                      FAIL   expected [#/components/schemas/FeeValues] but found [null]
```

The two failing assertions are the bug. **Draft** because the test is intended to fail until the parser is fixed.

## Why it matters downstream

`openapi-generator`'s `CodegenConfigurator` calls `readLocation(...)` with `resolve=true, resolveFully=false` and relies on internal `$ref`s being preserved (it runs its own `InlineModelResolver`). Callers that pass the spec as a **URL** — the Maven/Gradle plugins, and `quarkus-openapi-generator` (`configurator.setInputSpec(specFilePath.toUri().toString())`) — get the refs back **inlined**, so every reused component is duplicated **per use-site** (`<Parent><Prop>Inner`, `<Parent><Prop>` for nullable `anyOf`, `<Operation>Request` for request bodies) and the canonical component is emitted but **orphaned**.

## Root-cause localization (for a fix)

For OAS 3.1, `OpenAPIV3Parser.resolve(...)` runs the dereferencer whenever `isResolve() || isResolveFully()`. In `OpenAPIDereferencer31.dereference(...)` the root document is registered in the in-memory reference set as `"local"` **only when `rootUri` is blank**; with a non-blank `file://` `rootUri` it is not, so in `ReferenceVisitor.resolveSchemaRef(...)` an internal `#/...` pointer is resolved against the `file://` base URI and the document is re-read/dereferenced (inlined). A fix likely lives here: internal (`ReferenceUtils.isLocalRef`) pointers into the root document should be handled consistently regardless of whether the root was loaded by path or by `file://` URL (i.e. not inlined under `resolveFully=false`). Related: #2201, #1166.

I'm happy to iterate on the actual fix with maintainer guidance on the intended `resolve` vs `resolveFully` contract for internal refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
