### PR TITLE
Validate empty Swagger property names

### DIFF
--- a/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
+++ b/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
@@ -153,6 +153,7 @@ public class SwaggerConverter implements SwaggerParserExtension {
         SwaggerInventory inventory = new SwaggerInventory().process(parse.getSwagger());
 
         Swagger swagger = parse.getSwagger();
+        addEmptyPropertyNameMessages(swagger, output);
 
         if (swagger.getVendorExtensions() != null) {
             openAPI.setExtensions(convert(swagger.getVendorExtensions()));
@@ -663,6 +664,135 @@ public class SwaggerConverter implements SwaggerParserExtension {
             }
         }
         return result;
+    }
+
+    private void addEmptyPropertyNameMessages(Swagger swagger, SwaggerParseResult output) {
+        if (swagger.getDefinitions() != null) {
+            swagger.getDefinitions().forEach((name, model) ->
+                    addEmptyPropertyNameMessages("definitions." + name, model, output));
+        }
+
+        if (swagger.getPaths() != null) {
+            swagger.getPaths().forEach((pathname, path) -> {
+                if (path == null) {
+                    return;
+                }
+                addEmptyPropertyNameMessages("paths.'" + pathname + "'.parameters", path.getParameters(), output);
+                addEmptyPropertyNameMessages("paths.'" + pathname + "'(get)", path.getGet(), output);
+                addEmptyPropertyNameMessages("paths.'" + pathname + "'(put)", path.getPut(), output);
+                addEmptyPropertyNameMessages("paths.'" + pathname + "'(post)", path.getPost(), output);
+                addEmptyPropertyNameMessages("paths.'" + pathname + "'(delete)", path.getDelete(), output);
+                addEmptyPropertyNameMessages("paths.'" + pathname + "'(options)", path.getOptions(), output);
+                addEmptyPropertyNameMessages("paths.'" + pathname + "'(head)", path.getHead(), output);
+                addEmptyPropertyNameMessages("paths.'" + pathname + "'(patch)", path.getPatch(), output);
+            });
+        }
+    }
+
+    private void addEmptyPropertyNameMessages(String location, io.swagger.models.Operation operation,
+                                              SwaggerParseResult output) {
+        if (operation == null) {
+            return;
+        }
+        addEmptyPropertyNameMessages(location + ".parameters", operation.getParameters(), output);
+
+        if (operation.getResponses() != null) {
+            operation.getResponses().forEach((code, response) -> {
+                if (response != null) {
+                    addEmptyPropertyNameMessages(location + ".responses." + code + ".schema",
+                            response.getResponseSchema(), output);
+                }
+            });
+        }
+    }
+
+    private void addEmptyPropertyNameMessages(String location, List<io.swagger.models.parameters.Parameter> parameters,
+                                              SwaggerParseResult output) {
+        if (parameters == null) {
+            return;
+        }
+
+        parameters.forEach(parameter -> {
+            if (parameter == null) {
+                return;
+            }
+            if (parameter instanceof BodyParameter) {
+                BodyParameter bodyParameter = (BodyParameter) parameter;
+                addEmptyPropertyNameMessages(location + ".[" + bodyParameter.getName() + "].schema",
+                        bodyParameter.getSchema(), output);
+            }
+        });
+    }
+
+    private void addEmptyPropertyNameMessages(String location, Model model, SwaggerParseResult output) {
+        if (model == null) {
+            return;
+        }
+
+        if (model instanceof ArrayModel) {
+            addEmptyPropertyNameMessages(location + ".items", ((ArrayModel) model).getItems(), output);
+        } else if (model instanceof ComposedModel) {
+            ComposedModel composedModel = (ComposedModel) model;
+            if (composedModel.getAllOf() != null) {
+                for (int i = 0; i < composedModel.getAllOf().size(); i++) {
+                    addEmptyPropertyNameMessages(location + ".allOf." + i, composedModel.getAllOf().get(i), output);
+                }
+            }
+        }
+
+        addEmptyPropertyNameMessages(location + ".properties", model.getProperties(), output);
+
+        if (model instanceof ModelImpl) {
+            addEmptyPropertyNameMessages(location + ".additionalProperties",
+                    ((ModelImpl) model).getAdditionalProperties(), output);
+        }
+    }
+
+    private void addEmptyPropertyNameMessages(String location, Property property, SwaggerParseResult output) {
+        if (property == null) {
+            return;
+        }
+
+        if (property instanceof ArrayProperty) {
+            addEmptyPropertyNameMessages(location + ".items", ((ArrayProperty) property).getItems(), output);
+        } else if (property instanceof ObjectProperty) {
+            addEmptyPropertyNameMessages(location + ".properties", ((ObjectProperty) property).getProperties(), output);
+        } else if (property instanceof MapProperty) {
+            addEmptyPropertyNameMessages(location + ".additionalProperties",
+                    ((MapProperty) property).getAdditionalProperties(), output);
+        } else if (property instanceof ComposedProperty) {
+            ComposedProperty composedProperty = (ComposedProperty) property;
+            if (composedProperty.getAllOf() != null) {
+                for (int i = 0; i < composedProperty.getAllOf().size(); i++) {
+                    addEmptyPropertyNameMessages(location + ".allOf." + i, composedProperty.getAllOf().get(i), output);
+                }
+            }
+        }
+    }
+
+    private void addEmptyPropertyNameMessages(String location, Map<String, Property> properties,
+                                              SwaggerParseResult output) {
+        if (properties == null) {
+            return;
+        }
+
+        properties.forEach((name, property) -> {
+            if (StringUtils.isEmpty(name)) {
+                addMessage(output, "attribute " + location + " contains an empty property name");
+            }
+            addEmptyPropertyNameMessages(location + "." + name, property, output);
+        });
+    }
+
+    private void addMessage(SwaggerParseResult output, String message) {
+        List<String> messages = output.getMessages();
+        if (messages == null) {
+            messages = new ArrayList<>();
+            output.messages(messages);
+        }
+        if (!messages.contains(message)) {
+            messages.add(message);
+        }
     }
 
     private Schema convertFormDataToSchema(io.swagger.models.parameters.Parameter formParam) {
@@ -1276,4 +1406,3 @@ public class SwaggerConverter implements SwaggerParserExtension {
         }
     }
 }
-

--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -737,6 +737,45 @@ public class V2ConverterTest {
         assertNotNull(result.getMessages());
     }
 
+    @Test(description = "OpenAPI v2 converter - empty property names report validation messages")
+    public void testEmptyPropertyNameHasMessage() {
+        String swaggerAsString = "{\n" +
+                "  \"swagger\": \"2.0\",\n" +
+                "  \"info\": {\n" +
+                "    \"title\": \"info_title\",\n" +
+                "    \"version\": \"0/0\"\n" +
+                "  },\n" +
+                "  \"paths\": {\n" +
+                "    \"/path\": {\n" +
+                "      \"get\": {\n" +
+                "        \"responses\": {\n" +
+                "          \"200\": {\n" +
+                "            \"description\": \"..\",\n" +
+                "            \"schema\": {\n" +
+                "              \"type\": \"object\",\n" +
+                "              \"properties\": {\n" +
+                "                \"AA\": {\n" +
+                "                  \"type\": \"string\"\n" +
+                "                },\n" +
+                "                \"\": {\n" +
+                "                  \"type\": \"number\"\n" +
+                "                }\n" +
+                "              }\n" +
+                "            }\n" +
+                "          }\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        SwaggerParseResult result = new SwaggerConverter().readContents(swaggerAsString, null, null);
+
+        assertNotNull(result.getMessages());
+        assertTrue(result.getMessages().contains(
+                "attribute paths.'/path'(get).responses.200.schema.properties contains an empty property name"));
+    }
+
 
     @Test(description = "OpenAPI v2 converter - Migrate minLength, maxLength and pattern of String property")
     public void testIssue786() throws Exception {


### PR DESCRIPTION
Fixes #2339.

## What changed

This adds validation for Swagger 2.0 schemas that contain an empty property name under `properties`.

Previously, a schema like this was parsed without reporting a validation message:

```json
"properties": {
  "AA": { "type": "string" },
  "": { "type": "number" }
}
```

The converter now adds a validation message for the empty property name while continuing to parse the document.

## Testing

Ran the focused regression test and the full `V2ConverterTest` class:

```bash
mvn -pl modules/swagger-parser-v2-converter -am -Dtest=V2ConverterTest#testEmptyPropertyNameHasMessage -Dsurefire.failIfNoSpecifiedTests=false test
mvn -pl modules/swagger-parser-v2-converter -am -Dtest=V2ConverterTest -Dsurefire.failIfNoSpecifiedTests=false test
```