### PR TITLE
fix: Replace the unsafe Yaml instantiation in ReferenceVisitor.getYam…

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/reference/ReferenceVisitor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/reference/ReferenceVisitor.java
@@ -19,8 +19,11 @@ import io.swagger.v3.parser.util.DeserializationUtils;
 import io.swagger.v3.parser.util.RemoteUrl;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.representer.Representer;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -319,15 +322,13 @@ public class ReferenceVisitor extends AbstractVisitor {
     }
 
     private Yaml getYaml() {
-        Yaml yaml;
         String yamlCodePoints = System.getProperty("maxYamlCodePoints");
         if (yamlCodePoints != null && !yamlCodePoints.isEmpty() && StringUtils.isNumeric(yamlCodePoints)) {
-            loaderOptions.setCodePointLimit(Integer.parseInt(yamlCodePoints));
-            yaml = new Yaml(loaderOptions);
-        } else {
-            yaml = new Yaml();
+            LoaderOptions opts = new LoaderOptions();
+            opts.setCodePointLimit(Integer.parseInt(yamlCodePoints));
+            return new Yaml(new SafeConstructor(opts), new Representer(new DumperOptions()), new DumperOptions(), opts);
         }
-        return yaml;
+        return new Yaml(new SafeConstructor(new LoaderOptions()));
     }
 
     public JsonNode parse(String absoluteUri, List<AuthorizationValue> auths) throws Exception {

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/reference/ReferenceVisitorTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/reference/ReferenceVisitorTest.java
@@ -28,6 +28,12 @@ public class ReferenceVisitorTest {
         System.clearProperty("maxYamlCodePoints");
     }
 
+    @Test(expectedExceptions = YAMLException.class)
+    public void unsafeYamlTagShouldBeRejected() throws Exception {
+        ReferenceVisitor visitor = new ReferenceVisitor(null, null, null, null);
+        visitor.deserializeIntoTree("!!javax.script.ScriptEngineManager [!!java.net.URLClassLoader [[]]]");
+    }
+
     @Test
     public void largeFileShouldNotBeParsedByJacksonLibraryWhenCodeLimitIsNotSet() throws Exception {
         ReferenceVisitor visitor = new ReferenceVisitor(null, null, null, null);


### PR DESCRIPTION
This pull request strengthens YAML parsing security in the `ReferenceVisitor` class by ensuring only safe YAML tags are allowed, and adds a test to verify that unsafe tags are rejected. 

* Updated the `getYaml()` method in `ReferenceVisitor` to always use `SafeConstructor` and `LoaderOptions`, ensuring that only safe YAML tags are processed and preventing deserialization of potentially unsafe Java objects.
* Added imports for `SafeConstructor`, `Representer`, and `DumperOptions` to support the new YAML instantiation approach