### PR TITLE
Resolve same-named schemas from different files as distinct components (fixes #2333)

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ResolverCache.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ResolverCache.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -420,6 +421,10 @@ public class ResolverCache {
     public void putRenamedRef(String originalRef, String newRef) {
         renameCache.put(originalRef, newRef);
         canonicalRenameCache.put(canonicalize(originalRef), newRef);
+    }
+
+    public boolean refsAreEquivalent(String first, String second) {
+        return Objects.equals(canonicalize(first), canonicalize(second));
     }
 
     private static String canonicalize(String ref) {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -57,11 +57,24 @@ public final class ExternalRefProcessor {
 
     private String finalNameRec(Map<String, Schema> schemas, String possiblyConflictingDefinitionName, Schema newSchema,
         int iteration) {
+        return finalNameRec(schemas, possiblyConflictingDefinitionName, newSchema, iteration, null);
+    }
+
+    private String finalNameRec(Map<String, Schema> schemas, String possiblyConflictingDefinitionName, Schema newSchema,
+        int iteration, String incomingRef) {
         String tryName =
             iteration == 0 ? possiblyConflictingDefinitionName : possiblyConflictingDefinitionName + "_" + iteration;
         Schema existingModel = schemas.get(tryName);
         if (existingModel != null) {
             if (existingModel.get$ref() != null) {
+                // The name is currently held by a not-yet-resolved external $ref placeholder. It is only safe to
+                // reuse the name when that placeholder targets the same reference we are resolving; otherwise the
+                // placeholder is a distinct schema that would be silently overwritten (see issue #2333).
+                if (incomingRef != null && existingModel.get$ref() != null
+                        && !existingModel.get$ref().equals(incomingRef)) {
+                    LOGGER.debug("A different external $ref already claims the name " + tryName);
+                    return finalNameRec(schemas, possiblyConflictingDefinitionName, newSchema, ++iteration, incomingRef);
+                }
                 // use the new model
                 existingModel = null;
             } else if (!newSchema.equals(existingModel)) {
@@ -69,7 +82,7 @@ public final class ExternalRefProcessor {
                     return tryName;
                 }
                 LOGGER.debug("A model for " + existingModel + " already exists");
-                return finalNameRec(schemas, possiblyConflictingDefinitionName, newSchema, ++iteration);
+                return finalNameRec(schemas, possiblyConflictingDefinitionName, newSchema, ++iteration, incomingRef);
             }
         }else{
             // validate the name
@@ -111,7 +124,7 @@ public final class ExternalRefProcessor {
         }
 
         final String possiblyConflictingDefinitionName = computeDefinitionName($ref);
-        newRef = finalNameRec(schemas, possiblyConflictingDefinitionName, schema, 0);
+        newRef = finalNameRec(schemas, possiblyConflictingDefinitionName, schema, 0, $ref);
         cache.putRenamedRef($ref, newRef);
         Schema existingModel = schemas.get(newRef);
        if(existingModel != null && existingModel.get$ref() != null) {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -56,11 +56,24 @@ public final class ExternalRefProcessor {
 
     private String finalNameRec(Map<String, Schema> schemas, String possiblyConflictingDefinitionName, Schema newSchema,
         int iteration) {
+        return finalNameRec(schemas, possiblyConflictingDefinitionName, newSchema, iteration, null);
+    }
+
+    private String finalNameRec(Map<String, Schema> schemas, String possiblyConflictingDefinitionName, Schema newSchema,
+        int iteration, String incomingRef) {
         String tryName =
             iteration == 0 ? possiblyConflictingDefinitionName : possiblyConflictingDefinitionName + "_" + iteration;
         Schema existingModel = schemas.get(tryName);
         if (existingModel != null) {
             if (existingModel.get$ref() != null) {
+                // The name is currently held by a not-yet-resolved external $ref placeholder. It is only safe to
+                // reuse the name when that placeholder targets the same reference we are resolving; otherwise the
+                // placeholder is a distinct schema that would be silently overwritten (see issue #2333).
+                if (incomingRef != null && existingModel.get$ref() != null
+                        && !existingModel.get$ref().equals(incomingRef)) {
+                    LOGGER.debug("A different external $ref already claims the name " + tryName);
+                    return finalNameRec(schemas, possiblyConflictingDefinitionName, newSchema, ++iteration, incomingRef);
+                }
                 // use the new model
                 existingModel = null;
             } else if (!newSchema.equals(existingModel)) {
@@ -68,7 +81,7 @@ public final class ExternalRefProcessor {
                     return tryName;
                 }
                 LOGGER.debug("A model for " + existingModel + " already exists");
-                return finalNameRec(schemas, possiblyConflictingDefinitionName, newSchema, ++iteration);
+                return finalNameRec(schemas, possiblyConflictingDefinitionName, newSchema, ++iteration, incomingRef);
             }
         }else{
             // validate the name
@@ -110,7 +123,7 @@ public final class ExternalRefProcessor {
         }
 
         final String possiblyConflictingDefinitionName = computeDefinitionName($ref);
-        newRef = finalNameRec(schemas, possiblyConflictingDefinitionName, schema, 0);
+        newRef = finalNameRec(schemas, possiblyConflictingDefinitionName, schema, 0, $ref);
         cache.putRenamedRef($ref, newRef);
         Schema existingModel = schemas.get(newRef);
        if(existingModel != null && existingModel.get$ref() != null) {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -59,6 +59,15 @@ public final class ExternalRefProcessor {
         String tryName =
             iteration == 0 ? possiblyConflictingDefinitionName : possiblyConflictingDefinitionName + "_" + iteration;
         Schema existingModel = schemas.get(tryName);
+        if (existingModel == null) {
+            for (String name : schemas.keySet()) {
+                if (name.equalsIgnoreCase(tryName)) {
+                    existingModel = schemas.get(name);
+                    tryName = name;
+                    break;
+                }
+            }
+        }
         if (existingModel != null) {
             if (existingModel.get$ref() != null) {
                 if (incomingRef != null && !cache.refsAreEquivalent(existingModel.get$ref(), incomingRef)) {
@@ -73,17 +82,6 @@ public final class ExternalRefProcessor {
                 }
                 LOGGER.debug("A model for " + existingModel + " already exists");
                 return finalNameRec(schemas, possiblyConflictingDefinitionName, newSchema, ++iteration, incomingRef);
-            }
-        }else{
-            // validate the name
-            if(existingModel == null){
-                for(String name: schemas.keySet()){
-                    if(name.toLowerCase().equals(tryName.toLowerCase())){
-                        existingModel = schemas.get(name);
-                        tryName = name;
-                        break;
-                    }
-                }
             }
         }
         return tryName;

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -55,22 +55,13 @@ public final class ExternalRefProcessor {
     }
 
     private String finalNameRec(Map<String, Schema> schemas, String possiblyConflictingDefinitionName, Schema newSchema,
-        int iteration) {
-        return finalNameRec(schemas, possiblyConflictingDefinitionName, newSchema, iteration, null);
-    }
-
-    private String finalNameRec(Map<String, Schema> schemas, String possiblyConflictingDefinitionName, Schema newSchema,
         int iteration, String incomingRef) {
         String tryName =
             iteration == 0 ? possiblyConflictingDefinitionName : possiblyConflictingDefinitionName + "_" + iteration;
         Schema existingModel = schemas.get(tryName);
         if (existingModel != null) {
             if (existingModel.get$ref() != null) {
-                // The name is currently held by a not-yet-resolved external $ref placeholder. It is only safe to
-                // reuse the name when that placeholder targets the same reference we are resolving; otherwise the
-                // placeholder is a distinct schema that would be silently overwritten (see issue #2333).
-                if (incomingRef != null && existingModel.get$ref() != null
-                        && !existingModel.get$ref().equals(incomingRef)) {
+                if (incomingRef != null && !cache.refsAreEquivalent(existingModel.get$ref(), incomingRef)) {
                     LOGGER.debug("A different external $ref already claims the name " + tryName);
                     return finalNameRec(schemas, possiblyConflictingDefinitionName, newSchema, ++iteration, incomingRef);
                 }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue2333Test.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue2333Test.java
@@ -1,0 +1,57 @@
+package io.swagger.v3.parser.test;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class Issue2333Test {
+
+    /**
+     * Two schemas defined in different files but sharing the same name (both {@code Pet}) must be resolved as
+     * distinct components. Previously the resolver reused the first model for both references, so a schema that
+     * was still an unresolved external {@code $ref} placeholder was silently overwritten by an unrelated one.
+     */
+    @Test
+    public void referencedModelsWithSameNameFromDifferentFilesAreNotMerged() {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        options.setResolveResponses(true);
+
+        SwaggerParseResult result = new OpenAPIV3Parser()
+                .readLocation("./src/test/resources/issue-2333/main.yaml", null, options);
+
+        assertNotNull(result.getOpenAPI());
+        Map<String, Schema> schemas = result.getOpenAPI().getComponents().getSchemas();
+
+        // SomeItem points at inventory.yaml's Pet (the "name" property)
+        Schema someItem = resolve(schemas, schemas.get("SomeItem"));
+        assertNotNull(someItem.getProperties());
+        assertTrue(someItem.getProperties().containsKey("name"),
+                "SomeItem should resolve to inventory.yaml's Pet (name), but was " + someItem.getProperties().keySet());
+        assertEquals(someItem.getProperties().size(), 1);
+
+        // Pet points at pets.yaml's Pet (the "id" property) and must not be overwritten by inventory.yaml's Pet
+        Schema pet = resolve(schemas, schemas.get("Pet"));
+        assertNotNull(pet.getProperties());
+        assertTrue(pet.getProperties().containsKey("id"),
+                "Pet should resolve to pets.yaml's Pet (id), but was " + pet.getProperties().keySet());
+        assertEquals(pet.getProperties().size(), 1);
+    }
+
+    private Schema resolve(Map<String, Schema> schemas, Schema schema) {
+        if (schema != null && schema.get$ref() != null) {
+            String name = schema.get$ref().substring(schema.get$ref().lastIndexOf('/') + 1);
+            return schemas.get(name);
+        }
+        return schema;
+    }
+}

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue2333Test.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue2333Test.java
@@ -35,6 +35,19 @@ public class Issue2333Test {
     }
 
     @Test
+    public void identicalModelsWithSameNameFromDifferentFilesReuseSingleComponent() {
+        Map<String, Schema> schemas = parse("identical-models-different-files.yaml");
+
+        assertEquals(schemas.size(), 3);
+        assertTrue(schemas.keySet().containsAll(Arrays.asList("FirstPet", "SecondPet", "Pet")));
+        assertFalse(schemas.containsKey("Pet_1"));
+        assertSame(schemas.get("FirstPet"), schemas.get("Pet"));
+        assertSame(schemas.get("SecondPet"), schemas.get("Pet"));
+        assertSchemaHasOnlyProperty(resolve(schemas, schemas.get("FirstPet")), "id");
+        assertSchemaHasOnlyProperty(resolve(schemas, schemas.get("SecondPet")), "id");
+    }
+
+    @Test
     public void equivalentRefsWithDifferentSpellingReuseThePlaceholderName() {
         Map<String, Schema> schemas = parse("equivalent-refs.yaml");
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue2333Test.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue2333Test.java
@@ -1,16 +1,18 @@
 package io.swagger.v3.parser.test;
 
-import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 public class Issue2333Test {
@@ -22,29 +24,62 @@ public class Issue2333Test {
      */
     @Test
     public void referencedModelsWithSameNameFromDifferentFilesAreNotMerged() {
+        Map<String, Schema> schemas = parse("main.yaml");
+
+        assertEquals(schemas.size(), 3);
+        assertTrue(schemas.keySet().containsAll(Arrays.asList("SomeItem", "Pet", "Pet_1")));
+        assertSchemaHasOnlyProperty(resolve(schemas, schemas.get("Pet")), "id");
+        assertSchemaHasOnlyProperty(schemas.get("Pet_1"), "name");
+        assertSame(schemas.get("SomeItem"), schemas.get("Pet_1"));
+        assertSchemaHasOnlyProperty(resolve(schemas, schemas.get("SomeItem")), "name");
+    }
+
+    @Test
+    public void equivalentRefsWithDifferentSpellingReuseThePlaceholderName() {
+        Map<String, Schema> schemas = parse("equivalent-refs.yaml");
+
+        assertEquals(schemas.size(), 2);
+        assertTrue(schemas.containsKey("Thing"));
+        assertFalse(schemas.containsKey("Thing_1"));
+        assertSame(schemas.get("ThingAlias"), schemas.get("Thing"));
+        assertSchemaHasOnlyProperty(resolve(schemas, schemas.get("ThingAlias")), "value");
+    }
+
+    @Test
+    public void reversedTraversalPreservesDistinctTargetsAndCollapsesEquivalentRefs() {
+        Map<String, Schema> schemas = parse("reversed.yaml");
+
+        assertEquals(schemas.size(), 4);
+        assertTrue(schemas.keySet().containsAll(Arrays.asList("Pet", "SomeItem", "PetAlias", "Pet_1")));
+        assertFalse(schemas.containsKey("Pet_2"));
+        assertSchemaHasOnlyProperty(resolve(schemas, schemas.get("Pet")), "id");
+        assertSchemaHasOnlyProperty(schemas.get("Pet_1"), "name");
+        assertSame(schemas.get("SomeItem"), schemas.get("Pet_1"));
+        assertSame(schemas.get("PetAlias"), schemas.get("Pet"));
+        assertSchemaHasOnlyProperty(resolve(schemas, schemas.get("SomeItem")), "name");
+        assertSchemaHasOnlyProperty(resolve(schemas, schemas.get("PetAlias")), "id");
+    }
+
+    private Map<String, Schema> parse(String fixture) {
         ParseOptions options = new ParseOptions();
         options.setResolve(true);
         options.setResolveResponses(true);
 
         SwaggerParseResult result = new OpenAPIV3Parser()
-                .readLocation("./src/test/resources/issue-2333/main.yaml", null, options);
+                .readLocation("./src/test/resources/issue-2333/" + fixture, null, options);
 
         assertNotNull(result.getOpenAPI());
-        Map<String, Schema> schemas = result.getOpenAPI().getComponents().getSchemas();
+        assertNotNull(result.getOpenAPI().getComponents());
+        assertNotNull(result.getOpenAPI().getComponents().getSchemas());
+        return result.getOpenAPI().getComponents().getSchemas();
+    }
 
-        // SomeItem points at inventory.yaml's Pet (the "name" property)
-        Schema someItem = resolve(schemas, schemas.get("SomeItem"));
-        assertNotNull(someItem.getProperties());
-        assertTrue(someItem.getProperties().containsKey("name"),
-                "SomeItem should resolve to inventory.yaml's Pet (name), but was " + someItem.getProperties().keySet());
-        assertEquals(someItem.getProperties().size(), 1);
-
-        // Pet points at pets.yaml's Pet (the "id" property) and must not be overwritten by inventory.yaml's Pet
-        Schema pet = resolve(schemas, schemas.get("Pet"));
-        assertNotNull(pet.getProperties());
-        assertTrue(pet.getProperties().containsKey("id"),
-                "Pet should resolve to pets.yaml's Pet (id), but was " + pet.getProperties().keySet());
-        assertEquals(pet.getProperties().size(), 1);
+    private void assertSchemaHasOnlyProperty(Schema schema, String property) {
+        assertNotNull(schema);
+        assertNotNull(schema.getProperties());
+        assertEquals(schema.getProperties().size(), 1);
+        assertTrue(schema.getProperties().containsKey(property),
+                "Expected property " + property + ", but was " + schema.getProperties().keySet());
     }
 
     private Schema resolve(Map<String, Schema> schemas, Schema schema) {

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue2333Test.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue2333Test.java
@@ -60,6 +60,19 @@ public class Issue2333Test {
         assertSchemaHasOnlyProperty(resolve(schemas, schemas.get("PetAlias")), "id");
     }
 
+    @Test
+    public void caseInsensitiveNameCollisionPreservesDistinctTargets() {
+        Map<String, Schema> schemas = parse("case-insensitive.yaml");
+
+        assertEquals(schemas.size(), 3);
+        assertTrue(schemas.keySet().containsAll(Arrays.asList("SomeItem", "pet", "Pet_1")));
+        assertFalse(schemas.containsKey("Pet"));
+        assertSchemaHasOnlyProperty(resolve(schemas, schemas.get("pet")), "id");
+        assertSchemaHasOnlyProperty(schemas.get("Pet_1"), "name");
+        assertSame(schemas.get("SomeItem"), schemas.get("Pet_1"));
+        assertSchemaHasOnlyProperty(resolve(schemas, schemas.get("SomeItem")), "name");
+    }
+
     private Map<String, Schema> parse(String fixture) {
         ParseOptions options = new ParseOptions();
         options.setResolve(true);
@@ -69,6 +82,7 @@ public class Issue2333Test {
                 .readLocation("./src/test/resources/issue-2333/" + fixture, null, options);
 
         assertNotNull(result.getOpenAPI());
+        assertTrue(result.getMessages().isEmpty(), "Unexpected parser messages: " + result.getMessages());
         assertNotNull(result.getOpenAPI().getComponents());
         assertNotNull(result.getOpenAPI().getComponents().getSchemas());
         return result.getOpenAPI().getComponents().getSchemas();

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/ResolverCacheTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/ResolverCacheTest.java
@@ -27,9 +27,11 @@ import java.util.HashSet;
 import java.util.List;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 public class ResolverCacheTest {
 
@@ -345,6 +347,18 @@ public class ResolverCacheTest {
         assertEquals(cache.getRenameCache().size(), 1);
         assertEquals(cache.getRenameCache().get(refWithRedundantDotSegment), "A");
         assertNull(cache.getRenameCache().get(equivalentRef));
+    }
+
+    @Test
+    public void testRefEquivalenceUsesNormalizedCacheIdentity() {
+        ResolverCache cache = new ResolverCache(openAPI, auths, null);
+
+        assertTrue(cache.refsAreEquivalent(
+                "./components/schemas/Thing.yaml#/components/schemas/Thing",
+                "components/foo/../schemas/Thing.yaml#/components/schemas/Thing"));
+        assertFalse(cache.refsAreEquivalent(
+                "inventory.yaml#/components/schemas/Pet",
+                "pets.yaml#/components/schemas/Pet"));
     }
 
     @Test

--- a/modules/swagger-parser-v3/src/test/resources/issue-2333/case-insensitive.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2333/case-insensitive.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Case-insensitive collision
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    SomeItem:
+      $ref: "inventory.yaml#/components/schemas/Pet"
+    pet:
+      $ref: "pets.yaml#/components/schemas/Pet"

--- a/modules/swagger-parser-v3/src/test/resources/issue-2333/components/schemas/Thing.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2333/components/schemas/Thing.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.3
+info:
+  title: Thing API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        value:
+          type: string

--- a/modules/swagger-parser-v3/src/test/resources/issue-2333/equivalent-refs.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2333/equivalent-refs.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Equivalent refs
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    ThingAlias:
+      $ref: "./components/schemas/Thing.yaml#/components/schemas/Thing"
+    Thing:
+      $ref: "components/schemas/../schemas/Thing.yaml#/components/schemas/Thing"

--- a/modules/swagger-parser-v3/src/test/resources/issue-2333/identical-models-different-files.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2333/identical-models-different-files.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Identical models in different files
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    FirstPet:
+      $ref: "identical-pet-a.yaml#/components/schemas/Pet"
+    SecondPet:
+      $ref: "identical-pet-b.yaml#/components/schemas/Pet"

--- a/modules/swagger-parser-v3/src/test/resources/issue-2333/identical-pet-a.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2333/identical-pet-a.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.3
+info:
+  title: Identical Pet A
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer

--- a/modules/swagger-parser-v3/src/test/resources/issue-2333/identical-pet-b.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2333/identical-pet-b.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.3
+info:
+  title: Identical Pet B
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer

--- a/modules/swagger-parser-v3/src/test/resources/issue-2333/inventory.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2333/inventory.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.3
+info:
+  title: Inventory API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string

--- a/modules/swagger-parser-v3/src/test/resources/issue-2333/main.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2333/main.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.3
+info:
+  title: Pet Store API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    SomeItem:
+      $ref: "inventory.yaml#/components/schemas/Pet"
+    Pet:
+      $ref: "pets.yaml#/components/schemas/Pet"

--- a/modules/swagger-parser-v3/src/test/resources/issue-2333/pets.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2333/pets.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.3
+info:
+  title: Pets API
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer

--- a/modules/swagger-parser-v3/src/test/resources/issue-2333/reversed.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2333/reversed.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.3
+info:
+  title: Reversed collision order
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Pet:
+      $ref: "pets.yaml#/components/schemas/Pet"
+    SomeItem:
+      $ref: "inventory.yaml#/components/schemas/Pet"
+    PetAlias:
+      $ref: "./components/../pets.yaml#/components/schemas/Pet"


### PR DESCRIPTION
## Fixes #2333

### Problem
When parsing a spec with `resolve: true` where two schemas in **different files share the same name**, both references collapse into the first model. In the issue's reproducer, `SomeItem` (→ `inventory.yaml#/components/schemas/Pet`, has `name`) and `Pet` (→ `pets.yaml#/components/schemas/Pet`, has `id`) both end up pointing at inventory's `Pet`.

### Root cause
`ExternalRefProcessor.finalNameRec` decides which name a freshly resolved external schema gets. When the candidate name is already taken by an entry that still carries a `$ref` (an unresolved external placeholder, e.g. the sibling `Pet` component pointing at `pets.yaml`), the code unconditionally treated that slot as free and reused the name — then `addSchemas(newRef, schema)` overwrote the placeholder. The distinct second schema was lost.

### Fix
A `$ref` placeholder slot is only safe to reuse when it targets **the same reference** currently being resolved. The incoming `$ref` is now threaded into `finalNameRec`; if the existing placeholder points to a different target, resolution falls through to the next suffixed name (`Pet_1`) instead of clobbering it. This is the conservative direction — a mismatch only ever produces an extra suffixed name, never data loss.

### Result on the reproducer
```
SomeItem -> { name }     (inventory.yaml Pet)
Pet      -> { id }       (pets.yaml Pet)
Pet_1    -> { name }
```
`SomeItem` correctly carries `name` and `Pet` correctly carries `id`.

### Test evidence
- Added `Issue2333Test` with the issue's three-file reproducer asserting the two `Pet` schemas resolve distinctly. Passes.
- Full `swagger-parser-v3` module suite: **609 tests, 0 failures, 0 errors** (run with `-Dmaven.javadoc.skip=true`; the offline javadoc fetch and the unrelated `swagger-parser-safe-url-resolver` `PermittedUrlsCheckerTest` failures are pre-existing JDK 25 environment issues, not related to this change).

### Verification done
1. No in-flight PR (`gh pr list` search for the issue/keywords — none open); 2. no self-claim in the thread; 3. code-focused (`.java`); 4. reproduced the bug on `master`, confirmed the fix flips the behavior; 5. confirmed root symbol `finalNameRec`/`processRefToExternalSchema` still present on `master`; 6. n/a (no parent epic).
