### PR TITLE
fix: resolve $ref inside allOf of unreferenced component schemas

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
@@ -133,6 +133,19 @@ public class ResolverFully {
                 resolvePath(pathItem);
             }
         }
+
+        // Resolve component schemas that are not reachable through any path, so that
+        // e.g. a $ref inside an allOf of an otherwise-unreferenced component schema is
+        // still fully resolved. resolveSchema caches its results, so component schemas
+        // already resolved while walking the paths are returned as-is (no double resolution).
+        if (schemas != null) {
+            for (String schemaName : new ArrayList<>(schemas.keySet())) {
+                Schema resolved = resolveSchema(schemas.get(schemaName));
+                if (resolved != null) {
+                    schemas.put(schemaName, resolved);
+                }
+            }
+        }
     }
 
     public void resolvePath(PathItem pathItem){

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue2270Test.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue2270Test.java
@@ -1,0 +1,42 @@
+package io.swagger.v3.parser.test;
+
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class Issue2270Test {
+
+    @Test
+    public void shouldResolveRefInsideAllOfOfUnreferencedComponentSchema() {
+        ParseOptions options = new ParseOptions();
+        options.setResolveFully(true);
+        // Keep the allOf structure so we can assert the inner $ref itself was resolved.
+        options.setResolveCombinators(false);
+
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation("issue-2270/openapi.yaml", null, options);
+
+        assertNotNull(result.getOpenAPI());
+        Schema<?> contact = result.getOpenAPI().getComponents().getSchemas().get("Contact");
+        assertNotNull(contact);
+
+        List<Schema> allOf = contact.getAllOf();
+        assertNotNull(allOf);
+
+        // The first allOf member is a $ref to SObject and, although Contact is not reachable
+        // through any path, resolveFully(true) must still resolve it: the $ref must be gone
+        // and the referenced schema's properties must be inlined.
+        Schema<?> firstMember = allOf.get(0);
+        assertNull("$ref inside allOf of an unreferenced component schema was not resolved",
+                firstMember.get$ref());
+        assertNotNull(firstMember.getProperties());
+        assertTrue(firstMember.getProperties().containsKey("id"));
+    }
+}

--- a/modules/swagger-parser-v3/src/test/resources/issue-2270/openapi.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2270/openapi.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.1
+info:
+  title: issue-2270
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    SObject:
+      type: object
+      properties:
+        id:
+          type: string
+    Contact:
+      allOf:
+        - $ref: '#/components/schemas/SObject'
+        - type: object
+          properties:
+            name:
+              type: string


### PR DESCRIPTION
Fixes #2270

### Root cause
`ResolverFully.resolveFully(OpenAPI)` copies the component maps into its internal fields but then only iterates `openAPI.getPaths()` to drive resolution. Any component schema that is **not reachable through a path** is therefore never resolved — so a `$ref` nested inside the `allOf` of such a component schema stays unresolved even when `resolveFully(true)` is set (as reported, and confirmed by a second user).

### Change
After walking the paths, also resolve the captured component schemas. `resolveSchema(...)` is backed by an `IdentityHashMap` cache and an in-progress guard, so component schemas already resolved while walking the paths are returned as-is — no double resolution, and recursive/self-referential schemas are safe.

### Tests
Added `Issue2270Test` + `issue-2270/openapi.yaml`: a spec with empty `paths` and a component `Contact = allOf: [ $ref SObject, {inline} ]`. The test asserts that after `resolveFully(true)` the inner `$ref` is resolved (gone, with `SObject`'s properties inlined). It **fails before** this change (`expected null, but was: #/components/schemas/SObject`) and **passes after**.

### Verification done
- Reproduced the bug on master with the new test (fails before the fix, passes after).
- Ran the full `swagger-parser-v3` module test suite: **610 tests, 0 failures, 0 errors** (`mvn -pl modules/swagger-parser-v3 test`).

### Note for reviewers
Previously-unreferenced component schemas now get resolved by `resolveFully`, which is the intended meaning of the option, but it is a visible output change for any consumer that relied on such components staying in raw `$ref`/`allOf` form. Not covered by any prior test, so flagging it explicitly.