### PR TITLE
Fix remaining ResolverFully recursion edge case

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/ResolverFully.java
@@ -529,7 +529,11 @@ public class ResolverFully {
             for (String key : updated.keySet()) {
                 Schema property = updated.get(key);
 
-                if (property.getProperties() != model.getProperties()) {
+                if (schemasInProgress.contains(property) || property.getProperties() == model.getProperties()) {
+                    LOGGER.debug("not adding recursive properties, using generic object");
+                    ObjectSchema newSchema = new ObjectSchema();
+                    model.addProperties(key, newSchema);
+                } else {
                     if (!hasSchemaType(property) && parseOptions.isExplicitObjectSchema()) {
                         if (SpecVersion.V30.equals(property.getSpecVersion())) {
                             property.setType("object");
@@ -538,10 +542,6 @@ public class ResolverFully {
                         }
                     }
                     model.addProperties(key, property);
-                } else {
-                    LOGGER.debug("not adding recursive properties, using generic object");
-                    ObjectSchema newSchema = new ObjectSchema();
-                    model.addProperties(key, newSchema);
                 }
 
             }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIResolverTest.java
@@ -1493,6 +1493,28 @@ public class OpenAPIResolverTest {
     }
 
     @Test
+    public void recursiveResolvingAllOfSelfRecursionOas31() {
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(true);
+        parseOptions.setResolveFully(true);
+        OpenAPI openAPI = new OpenAPIV3Parser().read("issue_2297_allof_self_recursion.yaml", null, parseOptions);
+        assertNotNull(openAPI, "OpenAPI should be parsed successfully");
+        assertNotNull(openAPI.getComponents(), "Components should not be null");
+        Schema node = openAPI.getComponents().getSchemas().get("Node");
+        assertNotNull(node, "Node schema should be present");
+        assertNotNull(node.getProperties(), "Node should have properties");
+        assertNotNull(node.getProperties().get("child"),
+                "Node should contain the self-referencing property");
+        try {
+            String serialized = Json.mapper().writeValueAsString(openAPI);
+            assertNotNull(serialized, "Serialized output should not be null");
+        }
+        catch (Exception e) {
+            fail("Recursive loop found for self-reference combined with allOf: " + e.getMessage());
+        }
+    }
+
+    @Test
     public void recursiveIssue984() {
         ParseOptions parseOptions = new ParseOptions();
         parseOptions.setResolve(true);

--- a/modules/swagger-parser-v3/src/test/resources/issue_2297_allof_self_recursion.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue_2297_allof_self_recursion.yaml
@@ -1,0 +1,26 @@
+openapi: 3.1.0
+info:
+  title: allOf self recursion regression
+  version: 1.0.0
+paths:
+  /node:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+components:
+  schemas:
+    Node:
+      type: object
+      allOf:
+        - type: object
+          properties:
+            value:
+              type: number
+      properties:
+        child:
+          $ref: '#/components/schemas/Node'


### PR DESCRIPTION
## Description

This PR fixes the issue described in #2374.

It addresses a remaining `ResolverFully` recursion edge case for an OpenAPI 3.1 self-referencing schema combined with `allOf` when parsing with `resolve = true` and `resolveFully = true`.

In this scenario, `ResolverFully` may re-attach a schema that is still present in `schemasInProgress` back into a newly aggregated schema, which can create a cyclic Java object graph.

This PR updates the recursive property re-attachment logic to treat in-progress schemas as recursive placeholders in this path, and adds a regression test covering the `OAS 3.1 + allOf + self-reference` case.

Fixes: #2374

## Type of Change

- [x] 🐛 Bug fix
- [x] 🧪 Tests

## Checklist

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

Regression test added for a minimal OpenAPI 3.1 reproducer with:

- a self-referencing schema
- `allOf`
- `resolveFully = true`

The new fixture uses this minimal shape:

```yaml
components:
  schemas:
    Node:
      type: object
      allOf:
        - type: object
          properties:
            value:
              type: number
      properties:
        child:
          $ref: '#/components/schemas/Node'