### PR TITLE
fix: Fix duplicate schemas from root document back-references (#1961)

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ResolverCache.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ResolverCache.java
@@ -69,6 +69,7 @@ public class ResolverCache {
     private final List<AuthorizationValue> auths;
     private final Path parentDirectory;
     private final String rootPath;
+    private final URI rootDocumentUri;
     private Map<String, Object> resolutionCache = new HashMap<>();
     private Map<String, String> externalFileCache = new HashMap<>();
     private Map<String, Object> canonicalResolutionCache = new HashMap<>();
@@ -99,13 +100,17 @@ public class ResolverCache {
         this.openApi = openApi;
         this.auths = auths;
         this.rootPath = parentFileLocation;
+        this.rootDocumentUri = PathUtils.rootDocumentUri(parentFileLocation);
         this.resolveValidationMessages = resolveValidationMessages;
         this.parseOptions = parseOptions;
         this.permittedUrlsChecker = new PermittedUrlsChecker(parseOptions.getRemoteRefAllowList(), parseOptions.getRemoteRefBlockList());
 
         if(parentFileLocation != null) {
-            if(parentFileLocation.startsWith("http") || parentFileLocation.startsWith("jar")) {
+            if(PathUtils.isHttpUri(rootDocumentUri) || parentFileLocation.startsWith("jar")) {
                 parentDirectory = null;
+            } else if (rootDocumentUri != null
+                    && "file".equalsIgnoreCase(rootDocumentUri.getScheme())) {
+                parentDirectory = PathUtils.parentDirectoryOfUri(rootDocumentUri);
             } else {
                 parentDirectory = PathUtils.getParentDirectoryOfFile(parentFileLocation);
             }
@@ -159,15 +164,20 @@ public class ResolverCache {
         //but we may have already loaded the file or url in question
         String contents = canonicalExternalFileCache.get(canonicalFile);
 
-        if (contents == null) {
-            if(parseOptions.isSafelyResolveURL()){
-                checkUrlIsPermitted(file);
-            }
+        if (contents == null && parseOptions.isSafelyResolveURL()) {
+            checkUrlIsPermitted(file);
+        }
 
+        T rootTarget = resolveRootReference(file, definitionPath, ref, canonicalRef, expectedType);
+        if (rootTarget != null) {
+            return rootTarget;
+        }
+
+        if (contents == null) {
             if(parentDirectory != null) {
                 contents = RefUtils.readExternalRef(file, refFormat, auths, parentDirectory, permittedUrlsChecker);
             }
-            else if(rootPath != null && rootPath.startsWith("http")) {
+            else if(rootPath != null && (PathUtils.isHttpUri(rootDocumentUri) || rootPath.startsWith("http"))) {
                 contents = RefUtils.readExternalUrlRef(file, refFormat, auths, rootPath, permittedUrlsChecker);
             }
             else if (rootPath != null) {
@@ -177,6 +187,7 @@ public class ResolverCache {
             canonicalExternalFileCache.put(canonicalFile, contents);
         }
         externalFileCache.putIfAbsent(file, contents);
+
         SwaggerParseResult deserializationUtilResult = new SwaggerParseResult();
         JsonNode tree = DeserializationUtils.deserializeIntoTree(contents, file, parseOptions, deserializationUtilResult);
 
@@ -235,6 +246,40 @@ public class ResolverCache {
             }
         }
         return result;
+    }
+
+    private <T> T resolveRootReference(String file, String definitionPath, String ref,
+                                       String canonicalRef, Class<T> expectedType) {
+        if (definitionPath == null || !isRootDocument(file)) {
+            return null;
+        }
+
+        Object rootTarget = loadInternalRef("#/" + definitionPath);
+        if (!expectedType.isInstance(rootTarget)) {
+            return null;
+        }
+
+        T result = expectedType.cast(rootTarget);
+        resolutionCache.put(ref, result);
+        canonicalResolutionCache.putIfAbsent(canonicalRef, result);
+        return result;
+    }
+
+    private boolean isRootDocument(String file) {
+        if (rootDocumentUri == null || file == null || file.isEmpty()) {
+            return false;
+        }
+
+        try {
+            URI target = rootDocumentUri.resolve(new URI(file)).normalize();
+            if (target.isOpaque()) {
+                return false;
+            }
+            target = PathUtils.withoutFragment(target);
+            return target != null && rootDocumentUri.equals(target);
+        } catch (IllegalArgumentException | URISyntaxException ignored) {
+            return false;
+        }
     }
 
     private <T> T deserializeFragment(JsonNode node, Class<T> expectedType, String file, String definitionPath) {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ResolverCache.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/ResolverCache.java
@@ -2,6 +2,7 @@ package io.swagger.v3.parser;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.callbacks.Callback;
@@ -36,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -70,6 +72,7 @@ public class ResolverCache {
     private final Path parentDirectory;
     private final String rootPath;
     private final URI rootDocumentUri;
+    private final Map<Pattern, Map<String, ?>> rootReferenceSnapshot;
     private Map<String, Object> resolutionCache = new HashMap<>();
     private Map<String, String> externalFileCache = new HashMap<>();
     private Map<String, Object> canonicalResolutionCache = new HashMap<>();
@@ -101,6 +104,7 @@ public class ResolverCache {
         this.auths = auths;
         this.rootPath = parentFileLocation;
         this.rootDocumentUri = PathUtils.rootDocumentUri(parentFileLocation);
+        this.rootReferenceSnapshot = snapshotRootReferences(openApi);
         this.resolveValidationMessages = resolveValidationMessages;
         this.parseOptions = parseOptions;
         this.permittedUrlsChecker = new PermittedUrlsChecker(parseOptions.getRemoteRefAllowList(), parseOptions.getRemoteRefBlockList());
@@ -254,7 +258,7 @@ public class ResolverCache {
             return null;
         }
 
-        Object rootTarget = loadInternalRef("#/" + definitionPath);
+        Object rootTarget = loadRootReference("#/" + definitionPath);
         if (!expectedType.isInstance(rootTarget)) {
             return null;
         }
@@ -280,6 +284,47 @@ public class ResolverCache {
         } catch (IllegalArgumentException | URISyntaxException ignored) {
             return false;
         }
+    }
+
+    private Map<Pattern, Map<String, ?>> snapshotRootReferences(OpenAPI rootOpenApi) {
+        Map<Pattern, Map<String, ?>> snapshot = new LinkedHashMap<>();
+        if (rootOpenApi == null) {
+            return Collections.emptyMap();
+        }
+
+        addRootReferences(snapshot, PATHS_PATTERN, rootOpenApi.getPaths());
+
+        Components components = rootOpenApi.getComponents();
+        if (components != null) {
+            addRootReferences(snapshot, SCHEMAS_PATTERN, components.getSchemas());
+            addRootReferences(snapshot, RESPONSES_PATTERN, components.getResponses());
+            addRootReferences(snapshot, PARAMETERS_PATTERN, components.getParameters());
+            addRootReferences(snapshot, REQUEST_BODIES_PATTERN, components.getRequestBodies());
+            addRootReferences(snapshot, EXAMPLES_PATTERN, components.getExamples());
+            addRootReferences(snapshot, LINKS_PATTERN, components.getLinks());
+            addRootReferences(snapshot, CALLBACKS_PATTERN, components.getCallbacks());
+            addRootReferences(snapshot, HEADERS_PATTERN, components.getHeaders());
+            addRootReferences(snapshot, SECURITY_SCHEMES, components.getSecuritySchemes());
+        }
+
+        return Collections.unmodifiableMap(snapshot);
+    }
+
+    private void addRootReferences(Map<Pattern, Map<String, ?>> snapshot, Pattern pattern,
+                                   Map<String, ?> references) {
+        if (references != null && !references.isEmpty()) {
+            snapshot.put(pattern, Collections.unmodifiableMap(new LinkedHashMap<>(references)));
+        }
+    }
+
+    private Object loadRootReference(String ref) {
+        for (Map.Entry<Pattern, Map<String, ?>> entry : rootReferenceSnapshot.entrySet()) {
+            Object result = getFromMap(ref, entry.getValue(), entry.getKey());
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
     }
 
     private <T> T deserializeFragment(JsonNode node, Class<T> expectedType, String file, String definitionPath) {
@@ -427,7 +472,7 @@ public class ResolverCache {
         return jsonPathElement.replaceAll("~0", "~");
     }
 
-    private Object getFromMap(String ref, Map map, Pattern pattern) {
+    private Object getFromMap(String ref, Map<?, ?> map, Pattern pattern) {
         final Matcher parameterMatcher = pattern.matcher(ref);
 
         if (parameterMatcher.matches()) {

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/PathUtils.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/PathUtils.java
@@ -1,14 +1,17 @@
 package io.swagger.v3.parser.util;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class PathUtils {
 
-    // TODO use properly java URL to idenfiy and get absolute URL
     final static String SCHEME_FILE = "file:";
     final static String SCHEME_HTTP = "http:";
     final static String SCHEME_HTTPS = "https:";
@@ -36,15 +39,7 @@ public class PathUtils {
 
     private static Path getParentDirectoryFromUrl(String location){
         try {
-            URL url = PathUtils.class.getResource(location);
-            if (url == null){
-                url = PathUtils.class.getClassLoader().getResource(location);
-            }
-            if(url == null) {
-                url = ClassLoader.getSystemResource(location);
-            }
-
-            Path file = Paths.get((URI.create(url.toExternalForm())));
+            Path file = getPathFromClasspath(location);
             return file.getParent();
 
         } catch (Exception e) {
@@ -79,19 +74,100 @@ public class PathUtils {
 
     private static String getClasspathUrl(String location){
         try {
-            URL url = PathUtils.class.getResource(location);
-            if (url == null){
-                url = PathUtils.class.getClassLoader().getResource(location);
-            }
-            if(url == null) {
-                url = ClassLoader.getSystemResource(location);
-            }
-
-            Path file = Paths.get((URI.create(url.toExternalForm())));
+            Path file = getPathFromClasspath(location);
             return file.toAbsolutePath().toUri().toString();
 
         } catch (Exception e) {
             return location;
+        }
+    }
+
+    private static Path getPathFromClasspath(String location) {
+        URL url = PathUtils.class.getResource(location);
+        if (url == null) {
+            url = PathUtils.class.getClassLoader().getResource(location);
+        }
+        if (url == null) {
+            url = ClassLoader.getSystemResource(location);
+        }
+        return Paths.get(URI.create(url.toExternalForm()));
+    }
+
+    public static URI rootDocumentUri(String rootPath) {
+        if (rootPath == null || rootPath.isEmpty()) {
+            return null;
+        }
+
+        // Windows absolute path: C:/... or C:\... — must be classified before URI parsing
+        // because new URI("C:/...") treats the drive letter as a URI scheme.
+        if (rootPath.length() >= 3
+                && Character.isLetter(rootPath.charAt(0))
+                && rootPath.charAt(1) == ':'
+                && (rootPath.charAt(2) == '/' || rootPath.charAt(2) == '\\')) {
+            return existingFileUri(rootPath);
+        }
+
+        try {
+            URI rootUri = new URI(rootPath);
+            if (rootUri.getScheme() != null) {
+                return normalizeRootDocumentUri(rootUri);
+            }
+        } catch (URISyntaxException ignored) {
+            // It can still be an ordinary filesystem path, for example one containing spaces.
+        }
+
+        return existingFileUri(rootPath);
+    }
+
+    private static URI normalizeRootDocumentUri(URI rootUri) {
+        boolean http = isHttpUri(rootUri);
+        boolean file = "file".equalsIgnoreCase(rootUri.getScheme());
+        if ((!http && !file)
+                || rootUri.isOpaque()
+                || (http && StringUtils.isBlank(rootUri.getRawAuthority()))) {
+            return null;
+        }
+        return withoutFragment(rootUri.normalize());
+    }
+
+    private static URI existingFileUri(String location) {
+        try {
+            Path file = Paths.get(location);
+            if (Files.isRegularFile(file)) {
+                return file.toAbsolutePath().normalize().toUri();
+            }
+        } catch (InvalidPathException | SecurityException ignored) {
+            // The root cannot be identified safely as a filesystem document.
+        }
+        return null;
+    }
+
+    public static Path parentDirectoryOfUri(URI fileUri) {
+        try {
+            URI pathOnly = new URI(fileUri.getScheme(), fileUri.getAuthority(),
+                    fileUri.getPath(), null, null);
+            return Paths.get(pathOnly).toAbsolutePath().getParent();
+        } catch (IllegalArgumentException | URISyntaxException ignored) {
+            return null;
+        }
+    }
+
+    public static boolean isHttpUri(URI uri) {
+        return uri != null && ("http".equalsIgnoreCase(uri.getScheme()) || "https".equalsIgnoreCase(uri.getScheme()));
+    }
+
+    public static URI withoutFragment(URI uri) {
+        if (uri == null || uri.isOpaque()) {
+            return null;
+        }
+        if (uri.getFragment() == null) {
+            return uri;
+        }
+        try {
+            String value = uri.toString();
+            return new URI(value.substring(0, value.indexOf('#')));
+        } catch (URISyntaxException | IllegalArgumentException ignored) {
+            return null;
         }
     }
 }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue1961PhantomBackRefTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue1961PhantomBackRefTest.java
@@ -1,0 +1,43 @@
+package io.swagger.v3.parser.test;
+
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class Issue1961PhantomBackRefTest {
+
+    private static final String ROOT_DOCUMENT =
+            "src/test/resources/issue-1961-phantom/root.yaml";
+
+    @Test(description = "A back-reference to a schema absent from the on-disk root document"
+            + " must surface an error, not bind to a schema promoted during resolution")
+    public void backRefToSchemaMissingFromRootDocumentIsReported() {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation(
+                ROOT_DOCUMENT, null, options);
+
+        assertNotNull(result.getOpenAPI());
+        assertTrue(result.getMessages().stream().anyMatch(
+                        m -> m.contains("Could not find components/schemas/Payload")),
+                "The invalid back-reference must be reported; got: " + result.getMessages());
+
+        Map<String, Schema> schemas = result.getOpenAPI().getComponents().getSchemas();
+        Schema payload = schemas.get("Payload");
+        assertNotNull(payload, "The promoted external Payload schema itself is expected");
+
+        Schema x = (Schema) payload.getProperties().get("x");
+        assertNotEquals(x.get$ref(), "#/components/schemas/Payload",
+                "The phantom back-reference must not be silently rewritten into a"
+                        + " self-reference to the promoted copy");
+    }
+}

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue1961Test.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue1961Test.java
@@ -1,0 +1,106 @@
+package io.swagger.v3.parser.test;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class Issue1961Test {
+
+    private static final String ROOT_DOCUMENT =
+            "src/test/resources/issue-1961/TestCase.yaml";
+
+    @Test(description = "Issue #1961: a reference cycle back to the root file must not duplicate schemas")
+    public void externalSchemaReferencingRootSchemaDoesNotCreateDuplicate() {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation(
+                ROOT_DOCUMENT, null, options);
+
+        assertNotNull(result.getOpenAPI());
+        assertTrue(result.getMessages().isEmpty(), "Unexpected parser messages: " + result.getMessages());
+
+        OpenAPI openAPI = result.getOpenAPI();
+        assertNotNull(openAPI.getComponents());
+        Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
+        assertNotNull(schemas);
+
+        assertTrue(schemas.containsKey("TestCase_TestCase"));
+        assertTrue(schemas.containsKey("TestCase_v1_TestCase"));
+        assertTrue(schemas.containsKey("TestCase_Foo"));
+        assertTrue(schemas.containsKey("TestCase_FooType"));
+        assertFalse(schemas.containsKey("TestCase_Foo_1"),
+                "The back-reference to the root file must reuse TestCase_Foo");
+        assertEquals(schemas.size(), 4);
+
+        ComposedSchema root = (ComposedSchema) schemas.get("TestCase_TestCase");
+        assertEquals(root.getAnyOf().get(0).get$ref(),
+                "#/components/schemas/TestCase_v1_TestCase");
+
+        Schema versioned = schemas.get("TestCase_v1_TestCase");
+        assertEquals(((Schema) versioned.getProperties().get("Foo")).get$ref(),
+                "#/components/schemas/TestCase_Foo");
+
+        Schema foo = schemas.get("TestCase_Foo");
+        ArraySchema fooTypes = (ArraySchema) foo.getProperties().get("FooTypes");
+        assertEquals(fooTypes.getItems().get$ref(),
+                "#/components/schemas/TestCase_FooType");
+    }
+
+    @Test(description = "Issue #1961 control: duplicate promotion only occurs during resolution")
+    public void unresolvedDocumentKeepsOriginalSchemasAndReferences() {
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation(
+                ROOT_DOCUMENT, null, new ParseOptions());
+
+        assertNotNull(result.getOpenAPI());
+        assertTrue(result.getMessages().isEmpty(), "Unexpected parser messages: " + result.getMessages());
+
+        Map<String, Schema> schemas = result.getOpenAPI().getComponents().getSchemas();
+        assertEquals(schemas.size(), 3);
+        assertFalse(schemas.containsKey("TestCase_v1_TestCase"));
+        assertFalse(schemas.containsKey("TestCase_Foo_1"));
+
+        ComposedSchema root = (ComposedSchema) schemas.get("TestCase_TestCase");
+        assertEquals(root.getAnyOf().get(0).get$ref(),
+                "./TestCase.v1.yaml#/components/schemas/TestCase_v1_TestCase");
+
+        Schema foo = schemas.get("TestCase_Foo");
+        ArraySchema fooTypes = (ArraySchema) foo.getProperties().get("FooTypes");
+        assertEquals(fooTypes.getItems().get$ref(),
+                "./TestCase.yaml#/components/schemas/TestCase_FooType");
+    }
+
+    @Test(description = "Issue #1961: file: URI as root document resolves parent directory and deduplicates schemas")
+    public void fileUriRootResolvesExternalRefsAndDeduplicatesSchemas() {
+        Path rootFile = Paths.get(ROOT_DOCUMENT).toAbsolutePath().normalize();
+        String fileUri = rootFile.toUri().toString();
+
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation(fileUri, null, options);
+
+        assertNotNull(result.getOpenAPI());
+        assertTrue(result.getMessages().isEmpty(), "Unexpected parser messages: " + result.getMessages());
+
+        Map<String, Schema> schemas = result.getOpenAPI().getComponents().getSchemas();
+        assertNotNull(schemas);
+        assertFalse(schemas.containsKey("TestCase_Foo_1"),
+                "file: URI root must not duplicate schemas from back-references");
+        assertEquals(schemas.size(), 4);
+    }
+}

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/ResolverCacheTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/ResolverCacheTest.java
@@ -347,6 +347,21 @@ public class ResolverCacheTest {
     }
 
     @Test
+    public void testRootReferenceUsesObjectPresentAtCacheConstruction() {
+        Schema originalRootSchema = new Schema().type("object");
+        openAPI.components(new Components().addSchemas("Foo", originalRootSchema));
+        final String root = "https://example.com/api/root.yaml";
+        ResolverCache cache = new ResolverCache(openAPI, auths, root);
+
+        openAPI.getComponents().getSchemas().put("Foo", new Schema().type("string"));
+
+        Schema result = cache.loadRef(
+                root + "#/components/schemas/Foo", RefFormat.URL, Schema.class);
+
+        assertSame(result, originalRootSchema);
+    }
+
+    @Test
     public void testSameFilenameInDifferentDirectoryDoesNotReuseRoot() {
         Schema rootSchema = new Schema().type("object");
         openAPI.components(new Components().addSchemas("Foo", rootSchema));

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/ResolverCacheTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/ResolverCacheTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
@@ -22,13 +23,19 @@ import mockit.Mocked;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
@@ -254,12 +261,211 @@ public class ResolverCacheTest {
     }
 
     @Test
+    public void testRootDocumentUriIsEstablishedOnceForSupportedRoots() throws Exception {
+        Path rootFile = Files.createTempFile("resolver-cache-root", ".yaml");
+        ResolverCache filesystemCache = new ResolverCache(openAPI, auths, rootFile.toString());
+        URI filesystemUri = getRootDocumentUri(filesystemCache);
+        Files.delete(rootFile);
+
+        assertEquals(filesystemUri, rootFile.toAbsolutePath().normalize().toUri());
+        assertEquals(getRootDocumentUri(filesystemCache), filesystemUri);
+
+        ResolverCache fileCache = new ResolverCache(
+                openAPI, auths, "file:///tmp/schemas/../root.yaml?v=1#section");
+        assertEquals(getRootDocumentUri(fileCache), new URI("file:/tmp/root.yaml?v=1"));
+
+        ResolverCache httpCache = new ResolverCache(
+                openAPI, auths, "https://example.com/api/../root.yaml?v=1#section");
+        assertEquals(getRootDocumentUri(httpCache),
+                new URI("https://example.com/root.yaml?v=1"));
+    }
+
+    @Test
+    public void testUnsupportedAndAmbiguousRootsDisableRootIdentity() throws Exception {
+        String[] roots = {
+                "classpath:/root.yaml",
+                "jar:file:/tmp/specs.jar!/root.yaml",
+                "urn:swagger:root",
+                "http://example.com/%zz",
+                "missing-relative-root.yaml"
+        };
+
+        for (String root : roots) {
+            assertNull(getRootDocumentUri(new ResolverCache(openAPI, auths, root)), root);
+        }
+    }
+
+    @Test
+    public void testClasspathRootKeepsExistingExternalLoadingPath() {
+        Schema rootSchema = new Schema().type("object");
+        openAPI.components(new Components().addSchemas("Foo", rootSchema));
+        final String root = "classpath:/root.yaml";
+        final String file = "external.yaml";
+        final String contents = "components:\n  schemas:\n    Foo:\n      type: string\n";
+
+        new Expectations() {{
+            RefUtils.readExternalClasspathRef(file, RefFormat.RELATIVE, auths, root,
+                    (PermittedUrlsChecker) any);
+            times = 1;
+            result = contents;
+        }};
+
+        Schema result = new ResolverCache(openAPI, auths, root).loadRef(
+                file + "#/components/schemas/Foo", RefFormat.RELATIVE, Schema.class);
+
+        assertNotSame(result, rootSchema);
+        assertEquals(result.getType(), "string");
+    }
+
+    @Test
+    public void testDotSegmentHttpReferenceReusesRootWithoutLoading() {
+        Schema rootSchema = new Schema().type("object");
+        openAPI.components(new Components().addSchemas("Foo", rootSchema));
+        final String root = "https://example.com/api/root.yaml";
+        final String file = "https://example.com/api/nested/../root.yaml";
+        final String ref = file + "#/components/schemas/Foo";
+        final List<AuthorizationValue> rootAuths = new ArrayList<>();
+        rootAuths.add(new AuthorizationValue("Authorization", "token", "header"));
+        ParseOptions options = new ParseOptions();
+        options.setSafelyResolveURL(true);
+
+        final int[] permissionChecks = {0};
+        ResolverCache cache = new ResolverCache(openAPI, rootAuths, root, new HashSet<>(), options) {
+            @Override
+            protected void checkUrlIsPermitted(String refSet) {
+                permissionChecks[0]++;
+                super.checkUrlIsPermitted(refSet);
+            }
+        };
+
+        Schema result = cache.loadRef(ref, RefFormat.URL, Schema.class);
+
+        assertSame(result, rootSchema);
+        assertEquals(permissionChecks[0], 1);
+        assertFalse(cache.getExternalFileCache().containsKey(file));
+        assertSame(cache.getResolutionCache().get(ref), rootSchema);
+    }
+
+    @Test
+    public void testSameFilenameInDifferentDirectoryDoesNotReuseRoot() {
+        Schema rootSchema = new Schema().type("object");
+        openAPI.components(new Components().addSchemas("Foo", rootSchema));
+        final String root = "https://example.com/api/root.yaml";
+        final String file = "https://example.com/api/sub/root.yaml";
+        final String contents = "components:\n  schemas:\n    Foo:\n      type: string\n";
+
+        new Expectations() {{
+            RefUtils.readExternalUrlRef(file, RefFormat.URL, auths, root,
+                    (PermittedUrlsChecker) any);
+            times = 1;
+            result = contents;
+        }};
+
+        Schema result = new ResolverCache(openAPI, auths, root).loadRef(
+                file + "#/components/schemas/Foo", RefFormat.URL, Schema.class);
+
+        assertNotSame(result, rootSchema);
+        assertEquals(result.getType(), "string");
+    }
+
+    @Test
+    public void testHttpQueryIsPartOfRootIdentity() {
+        Schema rootSchema = new Schema().type("object");
+        openAPI.components(new Components().addSchemas("Foo", rootSchema));
+        final String root = "https://example.com/api/root.yaml?v=1";
+        final String file = "https://example.com/api/root.yaml?v=2";
+        final String contents = "components:\n  schemas:\n    Foo:\n      type: integer\n";
+
+        new Expectations() {{
+            RefUtils.readExternalUrlRef(file, RefFormat.URL, auths, root,
+                    (PermittedUrlsChecker) any);
+            times = 1;
+            result = contents;
+        }};
+
+        Schema result = new ResolverCache(openAPI, auths, root).loadRef(
+                file + "#/components/schemas/Foo", RefFormat.URL, Schema.class);
+
+        assertNotSame(result, rootSchema);
+        assertEquals(result.getType(), "integer");
+    }
+
+    @Test
+    public void testUnsupportedAbsentAndWrongTypePointersUseExternalDocument() {
+        Schema rootSchema = new Schema().type("object");
+        openAPI.components(new Components().addSchemas("Foo", rootSchema));
+        final String root = "https://example.com/api/root.yaml";
+        final String contents =
+                "components:\n" +
+                "  schemas:\n" +
+                "    External:\n" +
+                "      type: string\n" +
+                "    Foo:\n" +
+                "      name: id\n" +
+                "      in: query\n" +
+                "      properties:\n" +
+                "        value:\n" +
+                "          type: integer\n";
+
+        new Expectations() {{
+            RefUtils.readExternalUrlRef(root, RefFormat.URL, auths, root,
+                    (PermittedUrlsChecker) any);
+            times = 1;
+            result = contents;
+        }};
+
+        ResolverCache cache = new ResolverCache(openAPI, auths, root);
+        Schema absent = cache.loadRef(
+                root + "#/components/schemas/External", RefFormat.URL, Schema.class);
+        Schema deeper = cache.loadRef(
+                root + "#/components/schemas/Foo/properties/value", RefFormat.URL, Schema.class);
+        Parameter wrongType = cache.loadRef(
+                root + "#/components/schemas/Foo", RefFormat.URL, Parameter.class);
+
+        assertEquals(absent.getType(), "string");
+        assertEquals(deeper.getType(), "integer");
+        assertNotNull(wrongType);
+        assertEquals(wrongType.getName(), "id");
+    }
+
+    @Test
+    public void testRootReuseDoesNotReplaceExistingCanonicalEntry() throws Exception {
+        Header rootHeader = new Header().description("root");
+        openAPI.components(new Components().addHeaders("Root", rootHeader));
+        final String root = "https://example.com/api/root.yaml";
+        final String ref = root + "#/components/headers/Root";
+        ResolverCache cache = new ResolverCache(openAPI, auths, root);
+        Schema existingCanonicalObject = new Schema().type("string");
+        Map<String, Object> canonicalCache = getCanonicalResolutionCache(cache);
+        canonicalCache.put(ref, existingCanonicalObject);
+
+        Header result = cache.loadRef(ref, RefFormat.URL, Header.class);
+
+        assertSame(result, rootHeader);
+        assertSame(cache.getResolutionCache().get(ref), rootHeader);
+        assertSame(canonicalCache.get(ref), existingCanonicalObject);
+    }
+
+    @Test
     public void testRenameCache() {
         ResolverCache cache = new ResolverCache(openAPI, auths, null);
 
         assertNull(cache.getRenamedRef("foo"));
         cache.putRenamedRef("foo", "bar");
         assertEquals(cache.getRenamedRef("foo"), "bar");
+    }
+
+    private URI getRootDocumentUri(ResolverCache cache) throws Exception {
+        Field field = ResolverCache.class.getDeclaredField("rootDocumentUri");
+        field.setAccessible(true);
+        return (URI) field.get(cache);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getCanonicalResolutionCache(ResolverCache cache) throws Exception {
+        Field field = ResolverCache.class.getDeclaredField("canonicalResolutionCache");
+        field.setAccessible(true);
+        return (Map<String, Object>) field.get(cache);
     }
 
     @Test

--- a/modules/swagger-parser-v3/src/test/resources/issue-1961-phantom/ext.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1961-phantom/ext.yaml
@@ -1,0 +1,10 @@
+# "Payload" exists only in this file. The nested $ref points back to the root
+# document at a name the root does not define on disk. The parser must report
+# the invalid reference even though resolution promotes a schema named Payload.
+components:
+  schemas:
+    Payload:
+      type: object
+      properties:
+        x:
+          $ref: ./root.yaml#/components/schemas/Payload

--- a/modules/swagger-parser-v3/src/test/resources/issue-1961-phantom/root.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1961-phantom/root.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.1
+info:
+  title: phantom-back-ref
+  version: 1.0.0
+paths:
+  /a:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: ./ext.yaml#/components/schemas/Payload
+components:
+  schemas:
+    Local:
+      type: object

--- a/modules/swagger-parser-v3/src/test/resources/issue-1961/TestCase.v1.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1961/TestCase.v1.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.1
+info:
+  title: '#TestCase.v1.TestCase'
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    TestCase_v1_TestCase:
+      type: object
+      properties:
+        Foo:
+          $ref: ./TestCase.yaml#/components/schemas/TestCase_Foo

--- a/modules/swagger-parser-v3/src/test/resources/issue-1961/TestCase.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-1961/TestCase.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.1
+info:
+  title: '#TestCase.TestCase'
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    TestCase_TestCase:
+      anyOf:
+        - $ref: ./TestCase.v1.yaml#/components/schemas/TestCase_v1_TestCase
+    TestCase_Foo:
+      type: object
+      properties:
+        FooTypes:
+          type: array
+          items:
+            $ref: ./TestCase.yaml#/components/schemas/TestCase_FooType
+    TestCase_FooType:
+      type: string
+      enum:
+        - All
+        - OEM


### PR DESCRIPTION
# Pull Request

## Description

When an OpenAPI file has external `$ref`s that point back to the root document, the parser produces duplicate schemas.

**Example:**
```
TestCase.yaml
  └─ $ref: ./TestCase.v1.yaml#/components/schemas/TestCase_v1_TestCase

TestCase.v1.yaml
  └─ $ref: ./TestCase.yaml#/components/schemas/TestCase_Foo   ← back to root
```

The parser treated `./TestCase.yaml` as a new external file, loaded it from disk again, and when it found `TestCase_Foo` already in components, renamed the imported copy `TestCase_Foo_1`.

**Root cause:** path comparison used plain string matching. `./TestCase.yaml` and `src/test/resources/TestCase.yaml` look different as strings even though they point to the same file.

---

## Solution: root document identity

`ResolverCache` now stores a `rootDocumentUri` — a normalized URI computed once at construction time. Every external `$ref` is checked against it before loading.

`PathUtils.rootDocumentUri(String)` handles three input forms:

| Input | Example | Result |
|---|---|---|
| HTTP/HTTPS URL | `https://example.com/api/../root.yaml#section` | `https://example.com/root.yaml` |
| `file:` URI | `file:///home/user/specs/../root.yaml` | `file:///home/user/root.yaml` |
| Filesystem path | `src/test/resources/root.yaml` | `file:///abs/path/to/root.yaml` |

Unsupported formats (`classpath:`, `jar:file:`) return `null`, which disables the check and preserves the original behavior.

---

## How the check works

`isRootDocument(file)` runs three steps on every external file load:

1. Resolve the external path against `rootDocumentUri` to get an absolute URI
2. Strip the `#fragment` (the file is the same regardless of which part is referenced)
3. Compare to `rootDocumentUri` — equal means it's a back-reference to root

When a back-reference is detected, the parser calls `loadInternalRef("#/" + definitionPath)` — the same lookup used for internal `#/components/...` references — and returns the already-loaded object from memory. No file re-read, no deserialization, no duplicate.

If the object is not found or has the wrong type, it falls back to deserializing from the cached file content.

---

## Other changes

**`PathUtils` helpers** (moved out of `ResolverCache` for reusability):
- `rootDocumentUri(String)` — normalize any supported path to a URI
- `parentDirectoryOfUri(URI)` — get the parent folder of a `file:` URI
- `isHttpUri(URI)` — check for `http`/`https` scheme
- `withoutFragment(URI)` — strip the `#fragment` from a URI

This also clears a long-standing `TODO` in `PathUtils`: _"TODO use properly java URL to identify absolute URL."_

**Parent directory resolution** for `file:` URIs now uses `PathUtils.parentDirectoryOfUri(URI)`, which strips the query string and fragment before returning the parent folder. Behavior for HTTP/HTTPS and other path types is unchanged.
Fixes: https://github.com/swagger-api/swagger-parser/issues/1961

## Why the root snapshot is needed                                                                                                                                                                                

Resolution copies external components into the root OpenAPI model, so the live component map ends up containing both original and imported entries. `ResolverCache` saves the original root components before resolution starts. A back-reference to the root can only reuse entries from that snapshot. 

For example, if the root originally contains only Local, an imported Payload cannot make this reference valid: 
`./root.yaml#/components/schemas/Payload `
                                                                                                                                                                                                                The parser reads the root file and reports the missing schema. This keeps valid root back-references deduplicated and prevents resolution order from affecting results.

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->