### PR TITLE
fix: Inlining of references with dot (#2109)

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/InlineModelResolver.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/InlineModelResolver.java
@@ -5,9 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -27,7 +24,6 @@ import io.swagger.v3.parser.models.RefType;
 @SuppressWarnings("rawtypes")
 public class InlineModelResolver {
     private OpenAPI openAPI;
-    static final Logger LOGGER = LoggerFactory.getLogger(InlineModelResolver.class);
 
     Map<String, Schema> addedModels = new HashMap<>();
     Map<String, String> generatedSignature = new HashMap<>();
@@ -103,14 +99,14 @@ public class InlineModelResolver {
                   if (model.getProperties() != null && model.getProperties().size() > 0) {
                       flattenProperties(model.getProperties(), pathname);
                       String modelName = resolveModelName(model.getTitle(), genericName);
-                      mediaType.setSchema(new Schema().$ref(modelName));
+                      mediaType.setSchema(new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + modelName));
                       addGenerated(modelName, model);
                       openAPI.getComponents().addSchemas(modelName, model);
                   } else if (model instanceof ComposedSchema) {
                       flattenComposedSchema(model, pathname);
                       if (model.get$ref() == null) {
                           String modelName = resolveModelName(model.getTitle(), genericName);
-                          mediaType.setSchema(this.makeRefProperty(modelName, model));
+                          mediaType.setSchema(this.makeRefProperty(Components.COMPONENTS_SCHEMAS_REF + modelName, model));
                           addGenerated(modelName, model);
                           openAPI.getComponents().addSchemas(modelName, model);
                       }
@@ -123,9 +119,9 @@ public class InlineModelResolver {
                               String modelName = resolveModelName(inner.getTitle(), genericName);
                               String existing = matchGenerated(inner);
                               if (existing != null) {
-                                  am.setItems(new Schema().$ref(existing));
+                                  am.setItems(new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + existing));
                               } else {
-                                  am.setItems(new Schema().$ref(modelName));
+                                  am.setItems(new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + modelName));
                                   addGenerated(modelName, inner);
                                   openAPI.getComponents().addSchemas(modelName, inner);
                               }
@@ -133,7 +129,7 @@ public class InlineModelResolver {
                               flattenComposedSchema(inner,key);
                               if (inner.get$ref() == null) {
                                   String modelName = resolveModelName(inner.getTitle(), "inline_body_items_" + key + "_" + pathname);
-                                  am.setItems(this.makeRefProperty(modelName, inner));
+                                  am.setItems(this.makeRefProperty(Components.COMPONENTS_SCHEMAS_REF + modelName, inner));
                                   addGenerated(modelName, inner);
                                   openAPI.getComponents().addSchemas(modelName, inner);
                               }
@@ -158,14 +154,14 @@ public class InlineModelResolver {
                       if (model.getProperties() != null && model.getProperties().size() > 0) {
                           flattenProperties(model.getProperties(), pathname);
                           String modelName = resolveModelName(model.getTitle(), parameter.getName());
-                          parameter.setSchema(new Schema().$ref(modelName));
+                          parameter.setSchema(new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + modelName));
                           addGenerated(modelName, model);
                           openAPI.getComponents().addSchemas(modelName, model);
                       }
                   }
               }else if (model instanceof ComposedSchema) {
                   String modelName = resolveModelName(model.getTitle(), parameter.getName());
-                  parameter.setSchema(new Schema().$ref(modelName));
+                  parameter.setSchema(new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + modelName));
                   addGenerated(modelName, model);
                   openAPI.getComponents().addSchemas(modelName, model);
               }else if (model instanceof ArraySchema) {
@@ -177,9 +173,9 @@ public class InlineModelResolver {
                           String modelName = resolveModelName(inner.getTitle(), parameter.getName());
                           String existing = matchGenerated(inner);
                           if (existing != null) {
-                              am.setItems(new Schema().$ref(existing));
+                              am.setItems(new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + existing));
                           } else {
-                              am.setItems(new Schema().$ref(modelName));
+                              am.setItems(new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + modelName));
                               addGenerated(modelName, am);
                               openAPI.getComponents().addSchemas(modelName, am);
                           }
@@ -187,7 +183,7 @@ public class InlineModelResolver {
                           flattenComposedSchema(inner, parameter.getName());
                           if (inner.get$ref() == null) {
                               String modelName = resolveModelName(inner.getTitle(), "inline_parameter_items_" + parameter.getName());
-                              am.setItems(this.makeRefProperty(modelName, inner));
+                              am.setItems(this.makeRefProperty(Components.COMPONENTS_SCHEMAS_REF + modelName, inner));
                               addGenerated(modelName, inner);
                               openAPI.getComponents().addSchemas(modelName, inner);
                           }
@@ -217,9 +213,9 @@ public class InlineModelResolver {
                                   String modelName = resolveModelName(mediaSchema.getTitle(), "inline_response_" + key);
                                   String existing = matchGenerated(mediaSchema);
                                   if (existing != null) {
-                                      media.setSchema(this.makeRefProperty(existing, mediaSchema));
+                                      media.setSchema(this.makeRefProperty(Components.COMPONENTS_SCHEMAS_REF + existing, mediaSchema));
                                   } else {
-                                      media.setSchema(this.makeRefProperty(modelName, mediaSchema));
+                                      media.setSchema(this.makeRefProperty(Components.COMPONENTS_SCHEMAS_REF + modelName, mediaSchema));
                                       addGenerated(modelName, mediaSchema);
                                       openAPI.getComponents().addSchemas(modelName, mediaSchema);
                                   }
@@ -279,15 +275,15 @@ public class InlineModelResolver {
                       if (existing == null) {
                           openAPI.getComponents().addSchemas(innerModelName, inner);
                           addGenerated(innerModelName, inner);
-                          m.setItems(new Schema().$ref(innerModelName));
+                          m.setItems(new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + innerModelName));
                       } else {
-                          m.setItems(new Schema().$ref(existing));
+                          m.setItems(new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + existing));
                       }
                   }else if (inner instanceof ComposedSchema && this.flattenComposedSchemas){
                       flattenComposedSchema(inner,modelName);
                       if (inner.get$ref() == null) {
                           modelName = resolveModelName(inner.getTitle(), "inline_array_items_" + modelName);
-                          m.setItems(this.makeRefProperty(modelName, inner));
+                          m.setItems(this.makeRefProperty(Components.COMPONENTS_SCHEMAS_REF + modelName, inner));
                           addGenerated(modelName, inner);
                           openAPI.getComponents().addSchemas(modelName, inner);
                       }
@@ -317,7 +313,7 @@ public class InlineModelResolver {
                       if (this.flattenComposedSchemas) {
                           int position = i+1;
                           inlineModelName = resolveModelName(inline.getTitle(),  modelName + inlineModelName + "_" + position);
-                          list.set(i,new Schema().$ref(inlineModelName));
+                          list.set(i,new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + inlineModelName));
                           addGenerated(inlineModelName, inline);
                           openAPI.getComponents().addSchemas(inlineModelName, inline);
                       }
@@ -334,9 +330,9 @@ public class InlineModelResolver {
             String modelName = resolveModelName(inner.getTitle(), key);
             String existing = matchGenerated(inner);
             if (existing != null) {
-                ap.setItems(this.makeRefProperty(existing, inner));
+                ap.setItems(this.makeRefProperty(Components.COMPONENTS_SCHEMAS_REF + existing, inner));
             } else {
-                ap.setItems(this.makeRefProperty(modelName, inner));
+                ap.setItems(this.makeRefProperty(Components.COMPONENTS_SCHEMAS_REF + modelName, inner));
                 addGenerated(modelName, inner);
                 openAPI.getComponents().addSchemas(modelName, inner);
             }
@@ -345,7 +341,7 @@ public class InlineModelResolver {
             if (inner.get$ref() == null) {
                 key = "inline_response_items" + key;
                 String modelName = resolveModelName(inner.getTitle(), key );
-                ap.setItems(this.makeRefProperty(modelName, inner));
+                ap.setItems(this.makeRefProperty(Components.COMPONENTS_SCHEMAS_REF + modelName, inner));
                 addGenerated(modelName, inner);
                 openAPI.getComponents().addSchemas(modelName, inner);
             }
@@ -359,9 +355,9 @@ public class InlineModelResolver {
             String modelName = resolveModelName(innerProperty.getTitle(), key);
             String existing = matchGenerated(innerProperty);
             if (existing != null) {
-                mediaSchema.setAdditionalProperties(new Schema().$ref(existing));
+                mediaSchema.setAdditionalProperties(new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + existing));
             } else {
-                mediaSchema.setAdditionalProperties(new Schema().$ref(modelName));
+                mediaSchema.setAdditionalProperties(new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + modelName));
                 addGenerated(modelName, innerProperty);
                 openAPI.getComponents().addSchemas(modelName, innerProperty);
             }
@@ -369,7 +365,7 @@ public class InlineModelResolver {
             flattenComposedSchema(innerProperty,key);
             if (innerProperty.get$ref() == null) {
                 String modelName = resolveModelName(innerProperty.getTitle(), key);
-                mediaSchema.setAdditionalProperties(new Schema().$ref(modelName));
+                mediaSchema.setAdditionalProperties(new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + modelName));
                 addGenerated(modelName, innerProperty);
                 openAPI.getComponents().addSchemas(modelName, innerProperty);
             }
@@ -579,7 +575,7 @@ public class InlineModelResolver {
                 if (this.flattenComposedSchemas) {
                     int position = i+1;
                     inlineModelName = resolveModelName(inline.getTitle(),  key + inlineModelName + "_" + position);
-                    list.set(i,new Schema().$ref(inlineModelName));
+                    list.set(i,new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + inlineModelName));
                     addGenerated(inlineModelName, inline);
                     openAPI.getComponents().addSchemas(inlineModelName, inline);
                 }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/InlineModelResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/InlineModelResolverTest.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.MediaType;
@@ -35,7 +36,7 @@ import static org.testng.AssertJUnit.*;
 public class InlineModelResolverTest {
 
     @Test
-    public void testIssueUnexpectedNullValues() throws Exception {
+    public void testIssueUnexpectedNullValues() {
         ParseOptions options = new ParseOptions();
         options.setResolve(true);
         options.setFlatten(true);
@@ -49,7 +50,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void testIssue1018() throws Exception {
+    public void testIssue1018()  {
         ParseOptions options = new ParseOptions();
         options.setFlatten(true);
         OpenAPI openAPI = new OpenAPIV3Parser().read("flatten.json",null, options);
@@ -60,7 +61,7 @@ public class InlineModelResolverTest {
 
 
     @Test
-    public void testIssue705() throws Exception {
+    public void testIssue705() {
         ParseOptions options = new ParseOptions();
         options.setFlatten(true);
         OpenAPI openAPI = new OpenAPIV3Parser().read("issue-705.yaml",null, options);
@@ -71,7 +72,7 @@ public class InlineModelResolverTest {
 
 
     @Test
-    public void resolveInlineModelTestWithoutTitle() throws Exception {
+    public void resolveInlineModelTestWithoutTitle() {
         OpenAPI openAPI = new OpenAPI();
         openAPI.setComponents(new Components());
 
@@ -110,7 +111,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void resolveInlineModelTestWithTitle() throws Exception {
+    public void resolveInlineModelTestWithTitle() {
         OpenAPI openAPI = new OpenAPI();
         openAPI.setComponents(new Components());
 
@@ -151,7 +152,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void resolveInlineModel2EqualInnerModels() throws Exception {
+    public void resolveInlineModel2EqualInnerModels() {
         OpenAPI openAPI = new OpenAPI();
         openAPI.setComponents(new Components());
 
@@ -215,7 +216,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void resolveInlineModel2DifferentInnerModelsWIthSameTitle() throws Exception {
+    public void resolveInlineModel2DifferentInnerModelsWIthSameTitle() {
         OpenAPI openAPI = new OpenAPI();
         openAPI.setComponents(new Components());
 
@@ -285,7 +286,7 @@ public class InlineModelResolverTest {
 
 
     @Test
-    public void testInlineResponseModel() throws Exception {
+    public void testInlineResponseModel() {
         OpenAPI openAPI = new OpenAPI();
 
 
@@ -364,7 +365,7 @@ public class InlineModelResolverTest {
 
 
     @Test
-    public void testInlineResponseModelWithTitle() throws Exception {
+    public void testInlineResponseModelWithTitle() {
         OpenAPI openAPI = new OpenAPI();
 
         String responseTitle = "GetBarResponse";
@@ -439,6 +440,276 @@ public class InlineModelResolverTest {
         assertTrue(model.getProperties().size() == 1);
         assertNotNull(model.getProperties().get("name"));
         assertTrue(model.getProperties().get("name") instanceof StringSchema);
+    }
+
+    @Test
+    public void testFlattenSchemaTitleWithDot() {
+        String title = "admin.user";
+        OpenAPI openAPI = openAPIWithInlineResponseSchema(title);
+
+        new InlineModelResolver().flatten(openAPI);
+
+        // A dot is valid in a component key and must not make the generated $ref path-like or external.
+        assertFlattenedResponseSchema(openAPI, title, "#/components/schemas/admin.user");
+    }
+
+    @Test
+    public void testFlattenSchemaTitleWithSimpleName() {
+        String title = "User";
+        OpenAPI openAPI = openAPIWithInlineResponseSchema(title);
+
+        new InlineModelResolver().flatten(openAPI);
+
+        assertFlattenedResponseSchema(openAPI, title, "#/components/schemas/User");
+    }
+
+    private OpenAPI openAPIWithInlineResponseSchema(String title) {
+        Schema inlineSchema = new ObjectSchema()
+                .title(title)
+                .addProperty("name", new StringSchema());
+        ApiResponse response = new ApiResponse()
+                .description("OK")
+                .content(new Content().addMediaType("application/json", new MediaType().schema(inlineSchema)));
+        Operation operation = new Operation()
+                .responses(new ApiResponses().addApiResponse("200", response));
+
+        return new OpenAPI().path("/admin.user", new PathItem().get(operation));
+    }
+
+    private void assertFlattenedResponseSchema(OpenAPI openAPI, String expectedName, String expectedRef) {
+        assertNotNull(openAPI.getComponents());
+        assertNotNull(openAPI.getComponents().getSchemas());
+        assertTrue(openAPI.getComponents().getSchemas().containsKey(expectedName));
+
+        Schema resolvedSchema = openAPI.getPaths().get("/admin.user").getGet().getResponses().get("200")
+                .getContent().get("application/json").getSchema();
+        assertEquals(expectedRef, resolvedSchema.get$ref());
+        assertTrue(expectedRef.startsWith("#/components/schemas/"));
+        assertTrue(openAPI.getComponents().getSchemas()
+                .containsKey(expectedRef.substring("#/components/schemas/".length())));
+    }
+
+    @Test
+    public void testDottedRequestBodyObjectUsesLocalSchemaRef() {
+        ObjectSchema schema = dottedObjectSchema("admin.request");
+        OpenAPI openAPI = new OpenAPI().path("/request", new PathItem().post(new Operation()
+                .requestBody(requestBody(schema))));
+
+        new InlineModelResolver().flatten(openAPI);
+
+        assertLocalSchemaRef(openAPI, "admin.request", openAPI.getPaths().get("/request").getPost()
+                .getRequestBody().getContent().get("application/json").getSchema());
+    }
+
+    @Test
+    public void testDottedRequestBodyArrayItemUsesLocalSchemaRefWhenReused() {
+        ObjectSchema item = dottedObjectSchema("admin.item");
+        OpenAPI openAPI = new OpenAPI()
+                .path("/first", new PathItem().post(new Operation().requestBody(requestBody(new ArraySchema().items(item)))))
+                .path("/second", new PathItem().post(new Operation().requestBody(requestBody(new ArraySchema().items(item)))));
+
+        new InlineModelResolver().flatten(openAPI);
+
+        assertLocalSchemaRef(openAPI, "admin.item", ((ArraySchema) openAPI.getPaths().get("/first").getPost()
+                .getRequestBody().getContent().get("application/json").getSchema()).getItems());
+        assertLocalSchemaRef(openAPI, "admin.item", ((ArraySchema) openAPI.getPaths().get("/second").getPost()
+                .getRequestBody().getContent().get("application/json").getSchema()).getItems());
+    }
+
+    @Test
+    public void testDottedParameterObjectUsesLocalSchemaRef() {
+        Parameter parameter = new Parameter().name("filter").schema(dottedObjectSchema("admin.parameter"));
+        OpenAPI openAPI = openAPIWithParameter(parameter);
+
+        new InlineModelResolver().flatten(openAPI);
+
+        assertLocalSchemaRef(openAPI, "admin.parameter", openAPI.getPaths().get("/parameter").getGet()
+                .getParameters().get(0).getSchema());
+    }
+
+    @Test
+    public void testDottedParameterComposedSchemaUsesLocalSchemaRef() {
+        ComposedSchema schema = new ComposedSchema();
+        schema.setTitle("admin.parameter.composed");
+        schema.addOneOfItem(new StringSchema());
+        OpenAPI openAPI = openAPIWithParameter(new Parameter().name("filter").schema(schema));
+
+        new InlineModelResolver().flatten(openAPI);
+
+        assertLocalSchemaRef(openAPI, "admin.parameter.composed", openAPI.getPaths().get("/parameter").getGet()
+                .getParameters().get(0).getSchema());
+    }
+
+    @Test
+    public void testDottedParameterArrayItemUsesLocalSchemaRef() {
+        Parameter parameter = new Parameter().name("filter")
+                .schema(new ArraySchema().items(dottedObjectSchema("admin.parameter.item")));
+        OpenAPI openAPI = openAPIWithParameter(parameter);
+
+        new InlineModelResolver().flatten(openAPI);
+
+        assertLocalSchemaRef(openAPI, "admin.parameter.item", ((ArraySchema) openAPI.getPaths().get("/parameter")
+                .getGet().getParameters().get(0).getSchema()).getItems());
+    }
+
+    @Test
+    public void testDottedParameterArrayItemUsesExistingLocalSchemaRef() {
+        ObjectSchema item = dottedObjectSchema("admin.parameter.item");
+        Parameter parameter = new Parameter().name("filter").schema(new ArraySchema().items(item));
+        Operation operation = new Operation()
+                .requestBody(requestBody(new ArraySchema().items(item)))
+                .addParametersItem(parameter);
+        OpenAPI openAPI = new OpenAPI().path("/parameter-array", new PathItem().post(operation));
+
+        new InlineModelResolver().flatten(openAPI);
+
+        assertLocalSchemaRef(openAPI, "admin.parameter.item", ((ArraySchema) operation.getRequestBody()
+                .getContent().get("application/json").getSchema()).getItems());
+        assertLocalSchemaRef(openAPI, "admin.parameter.item", ((ArraySchema) parameter.getSchema()).getItems());
+    }
+
+    @Test
+    public void testDottedResponseArrayItemUsesLocalSchemaRef() {
+        ObjectSchema item = dottedObjectSchema("admin.response.item");
+        ApiResponses responses = new ApiResponses()
+                .addApiResponse("200", response(new ArraySchema().items(item)))
+                .addApiResponse("201", response(new ArraySchema().items(item)));
+        OpenAPI openAPI = new OpenAPI().path("/response", new PathItem().get(new Operation().responses(responses)));
+
+        new InlineModelResolver().flatten(openAPI);
+
+        assertLocalSchemaRef(openAPI, "admin.response.item", ((ArraySchema) responses.get("200")
+                .getContent().get("application/json").getSchema()).getItems());
+        assertLocalSchemaRef(openAPI, "admin.response.item", ((ArraySchema) responses.get("201")
+                .getContent().get("application/json").getSchema()).getItems());
+    }
+
+    @Test
+    public void testDottedResponseObjectUsesExistingLocalSchemaRef() {
+        ObjectSchema schema = dottedObjectSchema("admin.response");
+        ApiResponses responses = new ApiResponses()
+                .addApiResponse("200", response(schema))
+                .addApiResponse("201", response(schema));
+        OpenAPI openAPI = new OpenAPI().path("/response", new PathItem().get(new Operation().responses(responses)));
+
+        new InlineModelResolver().flatten(openAPI);
+
+        assertLocalSchemaRef(openAPI, "admin.response",
+                responses.get("200").getContent().get("application/json").getSchema());
+        assertLocalSchemaRef(openAPI, "admin.response",
+                responses.get("201").getContent().get("application/json").getSchema());
+    }
+
+    @Test
+    public void testDottedResponseMapUsesLocalSchemaRef() {
+        ObjectSchema map = new ObjectSchema();
+        map.setAdditionalProperties(dottedObjectSchema("admin.value"));
+        OpenAPI openAPI = openAPIWithResponseSchema(map);
+
+        new InlineModelResolver().flatten(openAPI);
+
+        Schema flattenedMap = openAPI.getPaths().get("/response").getGet().getResponses().get("200")
+                .getContent().get("application/json").getSchema();
+        assertLocalSchemaRef(openAPI, "admin.value", (Schema) flattenedMap.getAdditionalProperties());
+    }
+
+    @Test
+    public void testDottedResponseMapUsesExistingLocalSchemaRef() {
+        ObjectSchema value = dottedObjectSchema("admin.value");
+        ObjectSchema map = new ObjectSchema();
+        map.setAdditionalProperties(value);
+        Operation operation = new Operation()
+                .requestBody(requestBody(value))
+                .responses(new ApiResponses().addApiResponse("200", response(map)));
+        OpenAPI openAPI = new OpenAPI().path("/response-map", new PathItem().post(operation));
+
+        new InlineModelResolver().flatten(openAPI);
+
+        Schema flattenedMap = operation.getResponses().get("200").getContent().get("application/json").getSchema();
+        assertLocalSchemaRef(openAPI, "admin.value", (Schema) flattenedMap.getAdditionalProperties());
+    }
+
+    @Test
+    public void testDottedComponentArrayItemUsesLocalSchemaRefWhenReused() {
+        ObjectSchema item = dottedObjectSchema("admin.component.item");
+        Components components = new Components()
+                .addSchemas("FirstArray", new ArraySchema().items(item))
+                .addSchemas("SecondArray", new ArraySchema().items(item));
+        OpenAPI openAPI = new OpenAPI().components(components);
+
+        new InlineModelResolver().flatten(openAPI);
+
+        assertLocalSchemaRef(openAPI, "admin.component.item",
+                ((ArraySchema) components.getSchemas().get("FirstArray")).getItems());
+        assertLocalSchemaRef(openAPI, "admin.component.item",
+                ((ArraySchema) components.getSchemas().get("SecondArray")).getItems());
+    }
+
+    @Test
+    public void testDottedComponentComposedChildUsesLocalSchemaRef() {
+        ObjectSchema child = dottedObjectSchema("admin.composed");
+        ComposedSchema composed = new ComposedSchema();
+        composed.addAllOfItem(child);
+        OpenAPI openAPI = new OpenAPI().components(new Components().addSchemas("Wrapper", composed));
+
+        new InlineModelResolver(true, false).flatten(openAPI);
+
+        assertLocalSchemaRef(openAPI, "admin.composed", composed.getAllOf().get(0));
+    }
+
+    @Test
+    public void testDottedRequestComposedChildUsesLocalSchemaRef() {
+        ObjectSchema child = dottedObjectSchema("admin.request.composed");
+        ComposedSchema composed = new ComposedSchema();
+        composed.setTitle("RequestWrapper");
+        composed.addAnyOfItem(child);
+        OpenAPI openAPI = new OpenAPI().path("/request-composed", new PathItem().post(new Operation()
+                .requestBody(requestBody(composed))));
+
+        new InlineModelResolver(true, false).flatten(openAPI);
+
+        assertLocalSchemaRef(openAPI, "admin.request.composed", composed.getAnyOf().get(0));
+    }
+
+    @Test
+    public void testExternalRequestBodyRefIsNotRewritten() {
+        Schema external = new Schema().$ref("./models/Product.yaml");
+        OpenAPI openAPI = new OpenAPI().path("/external", new PathItem().post(new Operation()
+                .requestBody(requestBody(external))));
+
+        new InlineModelResolver().flatten(openAPI);
+
+        assertEquals("./models/Product.yaml", openAPI.getPaths().get("/external").getPost().getRequestBody()
+                .getContent().get("application/json").getSchema().get$ref());
+    }
+
+    private ObjectSchema dottedObjectSchema(String title) {
+        return (ObjectSchema) new ObjectSchema().title(title).addProperty("name", new StringSchema());
+    }
+
+    private RequestBody requestBody(Schema schema) {
+        return new RequestBody().content(new Content().addMediaType("application/json", new MediaType().schema(schema)));
+    }
+
+    private ApiResponse response(Schema schema) {
+        return new ApiResponse().description("OK")
+                .content(new Content().addMediaType("application/json", new MediaType().schema(schema)));
+    }
+
+    private OpenAPI openAPIWithResponseSchema(Schema schema) {
+        return new OpenAPI().path("/response", new PathItem().get(new Operation()
+                .responses(new ApiResponses().addApiResponse("200", response(schema)))));
+    }
+
+    private OpenAPI openAPIWithParameter(Parameter parameter) {
+        return new OpenAPI().path("/parameter", new PathItem().get(new Operation().addParametersItem(parameter)));
+    }
+
+    private void assertLocalSchemaRef(OpenAPI openAPI, String modelName, Schema reference) {
+        assertNotNull(openAPI.getComponents());
+        assertNotNull(openAPI.getComponents().getSchemas());
+        assertTrue(openAPI.getComponents().getSchemas().containsKey(modelName));
+        assertEquals("#/components/schemas/" + modelName, reference.get$ref());
     }
 
     @Test
@@ -546,7 +817,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void resolveInlineArrayModelWithTitle() throws Exception {
+    public void resolveInlineArrayModelWithTitle() {
         OpenAPI openAPI = new OpenAPI();
         openAPI.setComponents(new Components());
 
@@ -580,7 +851,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void resolveInlineArrayModelWithoutTitle() throws Exception {
+    public void resolveInlineArrayModelWithoutTitle() {
         OpenAPI openAPI = new OpenAPI();
         openAPI.setComponents(new Components());
 
@@ -615,7 +886,7 @@ public class InlineModelResolverTest {
 
 
     @Test
-    public void resolveInlineRequestBody() throws Exception {
+    public void resolveInlineRequestBody() {
         OpenAPI openAPI = new OpenAPI();
 
 
@@ -655,7 +926,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void resolveInlineRequestBody_maxTwoPathParts() throws Exception {
+    public void resolveInlineRequestBody_maxTwoPathParts() {
         OpenAPI openAPI = new OpenAPI();
 
         ObjectSchema objectSchema = new ObjectSchema();
@@ -694,7 +965,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void resolveInlineRequestBody_stripsDotsFromPath() throws Exception {
+    public void resolveInlineRequestBody_stripsDotsFromPath() {
         OpenAPI openAPI = new OpenAPI();
 
         ObjectSchema objectSchema = new ObjectSchema();
@@ -735,7 +1006,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void resolveInlineParameter() throws Exception {
+    public void resolveInlineParameter() {
         OpenAPI openAPI = new OpenAPI();
 
 
@@ -776,7 +1047,7 @@ public class InlineModelResolverTest {
     }
 
    @Test
-    public void resolveInlineRequestBodyWithTitle() throws Exception {
+    public void resolveInlineRequestBodyWithTitle() {
         OpenAPI openAPI = new OpenAPI();
 
         ObjectSchema objectSchema = new ObjectSchema();
@@ -806,7 +1077,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void notResolveNonModelRequestBody() throws Exception {
+    public void notResolveNonModelRequestBody() {
         OpenAPI openAPI = new OpenAPI();
 
         openAPI.path("/hello", new PathItem()
@@ -827,7 +1098,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void resolveInlineArrayRequestBody() throws Exception {
+    public void resolveInlineArrayRequestBody() {
         OpenAPI openAPI = new OpenAPI();
 
         ObjectSchema addressSchema = new ObjectSchema();
@@ -878,7 +1149,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void resolveInlineArrayResponse() throws Exception {
+    public void resolveInlineArrayResponse() {
         OpenAPI openAPI = new OpenAPI();
 
         ObjectSchema items = new ObjectSchema();
@@ -932,7 +1203,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void resolveInlineArrayResponseWithTitle() throws Exception {
+    public void resolveInlineArrayResponseWithTitle() {
         OpenAPI openAPI = new OpenAPI();
 
         ApiResponse apiResponse  = new ApiResponse();
@@ -978,7 +1249,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void testInlineMapResponse() throws Exception {
+    public void testInlineMapResponse() {
         OpenAPI openAPI = new OpenAPI();
 
         Schema schema = new Schema();
@@ -1017,7 +1288,7 @@ public class InlineModelResolverTest {
     }
 
     @Test
-    public void testInlineMapResponseWithObjectSchema() throws Exception {
+    public void testInlineMapResponseWithObjectSchema() {
         OpenAPI openAPI = new OpenAPI();
 
         Schema schema = new Schema();
@@ -1429,7 +1700,7 @@ public class InlineModelResolverTest {
 
 
     @Test(description = "https://github.com/swagger-api/swagger-parser/issues/1527")
-    public void testInlineItemsSchema() throws Exception {
+    public void testInlineItemsSchema() {
         ParseOptions options = new ParseOptions();
         options.setFlatten(true);
         OpenAPI openAPI = new OpenAPIV3Parser().read("flatten.json",null, options);


### PR DESCRIPTION
# Pull Request

## Description

`InlineModelResolver.flatten()` generated bare schema names (e.g. `admin.user`) instead of fully-qualified local references (`#/components/schemas/admin.user`) in every `$ref` it produced. For simple names this was harmless, but when a model title contained a dot the bare name `admin.user` was parsed as a relative file reference rather than a local component reference, breaking resolution.

The array-item case for request/response bodies was previously fixed in https://github.com/swagger-api/swagger-parser/pull/2330. This PR applies the same prefix to all remaining paths.

## Fix

Every call-site in `InlineModelResolver` that sets a `$ref` to an extracted schema now prepends `Components.COMPONENTS_SCHEMAS_REF` (`#/components/schemas/`) instead of a bare name. 

Swagger Core's `$ref` setter skips the auto-prefix when the name contains a `.`, treating it as a potential relative file path. That's correct for resolve, where `admin.user` could legitimately refer to `./admin.user`. In flatten, every schema being referenced has just been extracted into `#/components/schemas/` by the resolver, so the target is always local. 

## Out of scope (known issues, not introduced by this PR)
1) Reporter of https://github.com/swagger-api/swagger-parser/issues/2109 uses example with a space `admin.user schema `. The spec requires component keys to match `^[a-zA-Z0-9\.\-_]+$.` A space is not in that character class, so admin.user schema is not a valid component key. 

2) `InlineModelResolver.java:179-180` registers `am` (the array) instead of `inner` (the item schema). - such behavior is a non-reported bug

Fixes: https://github.com/swagger-api/swagger-parser/issues/2109

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->