### PR TITLE
chore: update dependency-check-maven to 12.2.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
+    allow:
       - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      # Old Dependency-Check majors can lose compatibility with the NVD API.
+      - dependency-name: "org.owasp:dependency-check-maven"
         update-types: ["version-update:semver-major"]

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>8.1.2</version>
+                        <version>12.2.2</version>
                         <configuration>
                             <skipSystemScope>true</skipSystemScope>
                         </configuration>


### PR DESCRIPTION
# Pull Request

The 8.x line is obsolete and unsupported for current NVD usage; OWASP now requires Dependency-Check 12.1.0 or later.
## Type of Change

<!-- Check all that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [x] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->