### PR TITLE
Fix: resolution of external refs inside path items with templated fragments (#2033)

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -869,7 +869,7 @@ public final class ExternalRefProcessor {
             if (example.get$ref() != null) {
                 RefFormat ref = computeRefFormat(example.get$ref());
                 if (isAnExternalRefFormat(ref)) {
-                    processRefExample(example, $ref);
+                    processRefExample(example, file);
                 } else {
                     processRefToExternalExample(file + example.get$ref(), RefFormat.RELATIVE);
                 }
@@ -916,7 +916,7 @@ public final class ExternalRefProcessor {
             if (header.get$ref() != null) {
                 RefFormat ref = computeRefFormat(header.get$ref());
                 if (isAnExternalRefFormat(ref)) {
-                    processRefHeader(header, $ref);
+                    processRefHeader(header, file);
                 } else {
                     processRefToExternalHeader(file + header.get$ref(), RefFormat.RELATIVE);
                 }
@@ -930,7 +930,7 @@ public final class ExternalRefProcessor {
             if (link.get$ref() != null) {
                 RefFormat ref = computeRefFormat(link.get$ref());
                 if (isAnExternalRefFormat(ref)) {
-                    processRefLink(link, $ref);
+                    processRefLink(link, file);
                 } else {
                     processRefToExternalLink(file + link.get$ref(), RefFormat.RELATIVE);
                 }

--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/processors/ExternalRefProcessor.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -878,22 +880,8 @@ public final class ExternalRefProcessor {
     }
 
     private void processRefExample(Example example, String externalFile) {
-        RefFormat format = computeRefFormat(example.get$ref());
-
-        if (!isAnExternalRefFormat(format)) {
-            example.set$ref(RefType.SCHEMAS.getInternalPrefix()+ processRefToExternalSchema(externalFile + example.get$ref(), RefFormat.RELATIVE));
-            return;
-        }
-        String $ref = example.get$ref();
-        String subRefExternalPath = getExternalPath(example.get$ref())
-                .orElse(null);
-
-        if (format.equals(RefFormat.RELATIVE) && !Objects.equals(subRefExternalPath, externalFile)) {
-            $ref = join(externalFile, example.get$ref());
-            example.set$ref($ref);
-        }else {
-            processRefToExternalExample($ref, format);
-        }
+        processRef(example.get$ref(), externalFile, example::set$ref, this::processRefToExternalExample,
+                ref -> join(externalFile, ref));
     }
 
     private void processRefSchemaObject(Schema schema, String $ref) {
@@ -941,24 +929,9 @@ public final class ExternalRefProcessor {
 
 
     private void processRefSchema(Schema subRef, String externalFile) {
-        RefFormat format = computeRefFormat(subRef.get$ref());
-
-        if (!isAnExternalRefFormat(format)) {
-            subRef.set$ref(RefType.SCHEMAS.getInternalPrefix()+ processRefToExternalSchema(externalFile + subRef.get$ref(), RefFormat.RELATIVE));
-            return;
-        }
-        String $ref = subRef.get$ref();
-        String subRefExternalPath = getExternalPath(subRef.get$ref())
-            .orElse(null);
-
-        if (format.equals(RefFormat.RELATIVE) && !Objects.equals(subRefExternalPath, externalFile)) {
-            $ref = constructRef(subRef, externalFile);
-            subRef.set$ref($ref);
-        }else {
-            processRefToExternalSchema($ref, format);
-        }
+        processRef(subRef.get$ref(), externalFile, subRef::set$ref, this::processRefToExternalSchema,
+                ref -> constructRef(subRef, externalFile));
     }
-
 
     protected String constructRef(Schema refProperty, String rootLocation) {
         String ref = refProperty.get$ref();
@@ -966,40 +939,31 @@ public final class ExternalRefProcessor {
     }
 
     private void processRefHeader(Header subRef, String externalFile) {
-        RefFormat format = computeRefFormat(subRef.get$ref());
-
-        if (!isAnExternalRefFormat(format)) {
-            subRef.set$ref(RefType.SCHEMAS.getInternalPrefix()+ processRefToExternalSchema(externalFile + subRef.get$ref(), RefFormat.RELATIVE));
-            return;
-        }
-        String $ref = subRef.get$ref();
-        String subRefExternalPath = getExternalPath(subRef.get$ref())
-                .orElse(null);
-
-        if (format.equals(RefFormat.RELATIVE) && !Objects.equals(subRefExternalPath, externalFile)) {
-            $ref = join(externalFile, subRef.get$ref());
-            subRef.set$ref($ref);
-        }else {
-            processRefToExternalHeader($ref, format);
-        }
+        processRef(subRef.get$ref(), externalFile, subRef::set$ref, this::processRefToExternalHeader,
+                ref -> join(externalFile, ref));
     }
 
     private void processRefLink(Link subRef, String externalFile) {
-        RefFormat format = computeRefFormat(subRef.get$ref());
+        processRef(subRef.get$ref(), externalFile, subRef::set$ref, this::processRefToExternalLink,
+                ref -> join(externalFile, ref));
+    }
+
+    private void processRef(String ref, String externalFile, Consumer<String> refSetter,
+                            BiConsumer<String, RefFormat> externalRefProcessor,
+                            Function<String, String> relativeRefResolver) {
+        RefFormat format = computeRefFormat(ref);
 
         if (!isAnExternalRefFormat(format)) {
-            subRef.set$ref(RefType.SCHEMAS.getInternalPrefix()+ processRefToExternalSchema(externalFile + subRef.get$ref(), RefFormat.RELATIVE));
+            refSetter.accept(RefType.SCHEMAS.getInternalPrefix()
+                    + processRefToExternalSchema(externalFile + ref, RefFormat.RELATIVE));
             return;
         }
-        String $ref = subRef.get$ref();
-        String subRefExternalPath = getExternalPath(subRef.get$ref())
-                .orElse(null);
+        String subRefExternalPath = getExternalPath(ref).orElse(null);
 
         if (format.equals(RefFormat.RELATIVE) && !Objects.equals(subRefExternalPath, externalFile)) {
-            $ref = join(externalFile, subRef.get$ref());
-            subRef.set$ref($ref);
-        }else {
-            processRefToExternalLink($ref, format);
+            refSetter.accept(relativeRefResolver.apply(ref));
+        } else {
+            externalRefProcessor.accept(ref, format);
         }
     }
 

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue2033Test.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/Issue2033Test.java
@@ -1,0 +1,67 @@
+package io.swagger.v3.parser.test;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.headers.Header;
+import io.swagger.v3.oas.models.links.Link;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class Issue2033Test {
+
+    @Test
+    public void resolvesRelativeComponentRefsFromExternalTemplatedPathItem() {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation(
+                "src/test/resources/issue-2033/main.yaml", null, options);
+
+        assertNotNull(result.getOpenAPI());
+        assertTrue(result.getMessages().isEmpty(), "Unexpected parser messages: " + result.getMessages());
+
+        OpenAPI openAPI = result.getOpenAPI();
+        ApiResponse partialResponse = openAPI.getPaths()
+                .get("/nodes/{uuid}/rights")
+                .getGet()
+                .getResponses()
+                .get("206");
+
+        Header contentRange = partialResponse.getHeaders().get("Content-Range");
+
+        assertNotNull(contentRange);
+        assertEquals(contentRange.get$ref(), "#/components/headers/Content-Range");
+
+        Header resolvedContentRange = openAPI.getComponents().getHeaders().get("Content-Range");
+        assertNotNull(resolvedContentRange);
+        assertNotNull(resolvedContentRange.getSchema());
+        assertEquals(resolvedContentRange.getSchema().getType(), "string");
+        assertEquals(resolvedContentRange.getSchema().getPattern(), "\\d+-\\d+/\\d+");
+
+        Link nextPage = partialResponse.getLinks().get("nextPage");
+        assertNotNull(nextPage);
+        assertEquals(nextPage.get$ref(), "#/components/links/NextPage");
+
+        Link resolvedNextPage = openAPI.getComponents().getLinks().get("NextPage");
+        assertNotNull(resolvedNextPage);
+        assertEquals(resolvedNextPage.getOperationId(), "listNodeRights");
+
+        Example contentRangeExample = partialResponse.getContent()
+                .get("application/json")
+                .getExamples()
+                .get("contentRange");
+        assertNotNull(contentRangeExample);
+        assertEquals(contentRangeExample.get$ref(), "#/components/examples/ContentRangeExample");
+
+        Example resolvedExample = openAPI.getComponents().getExamples().get("ContentRangeExample");
+        assertNotNull(resolvedExample);
+        assertEquals(resolvedExample.getValue(), "items 0-9/42");
+    }
+}

--- a/modules/swagger-parser-v3/src/test/resources/issue-2033/common-spec-openapi.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2033/common-spec-openapi.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: Common components
+  version: 1.0.0
+paths: {}
+components:
+  examples:
+    ContentRangeExample:
+      value: items 0-9/42
+  headers:
+    Content-Range:
+      schema:
+        type: string
+        pattern: '\d+-\d+/\d+'
+  links:
+    NextPage:
+      operationId: listNodeRights

--- a/modules/swagger-parser-v3/src/test/resources/issue-2033/main.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2033/main.yaml
@@ -1,0 +1,7 @@
+openapi: 3.0.3
+info:
+  title: Issue 2033
+  version: 1.0.0
+paths:
+  /nodes/{uuid}/rights:
+    $ref: "traceability/nodes.yaml#/paths/~1nodes~1{uuid}~1rights"

--- a/modules/swagger-parser-v3/src/test/resources/issue-2033/traceability/nodes.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue-2033/traceability/nodes.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.3
+info:
+  title: Nodes
+  version: 1.0.0
+paths:
+  /nodes/{uuid}/rights:
+    get:
+      operationId: listNodeRights
+      responses:
+        "206":
+          description: Partial
+          content:
+            application/json:
+              schema:
+                type: string
+              examples:
+                contentRange:
+                  $ref: "../common-spec-openapi.yaml#/components/examples/ContentRangeExample"
+          headers:
+            Content-Range:
+              $ref: "../common-spec-openapi.yaml#/components/headers/Content-Range"
+          links:
+            nextPage:
+              $ref: "../common-spec-openapi.yaml#/components/links/NextPage"


### PR DESCRIPTION
# Pull Request

## Description
When an external path item is referenced with a URL whose fragment contains an OpenAPI path template (e.g. `traceability/nodes.yaml#/paths/~1nodes~1{uuid}~1rights`), any response headers, links, or examples inside that path item that point to further external files fail to resolve. Instead of the correct component, the reference ends up pointing at the parent path item, which is the wrong type.

## What was broken

`processRefHeaders`, `processRefLinks`, and `processRefExamples` each computed the external file path correctly, 
but then passed the full `$ref` (fragment included) down to the nested processor. Inside `processRefHeader`, the `join` call constructed `new URI(source)` with that string. The raw `{` character is not valid in a URI, so the constructor throwed, the catch block silently returns the original source string, and the header ends up pointing at the parent path item rather than `common-spec-openapi.yaml#/components/headers/Content-Range`.

```java
// Before: header.$ref = "traceability/nodes.yaml#/paths/~1nodes~1{uuid}~1rights"  (wrong)
// After:  header.$ref = "#/components/headers/Content-Range"  ✓
```

The same bug affected links and examples in the same code path.

## What changed

- `ExternalRefProcessor.processRefHeaders` (~line 920): passes `file` instead of `$ref` to `processRefHeader`, so the join operation never sees the raw-brace fragment.
- `ExternalRefProcessor.processRefExamples` (~line 870): same fix for examples.
- `ExternalRefProcessor.processRefLinks` (~line 931): same fix for links.

Also refactores `processRef` into a separate method to avoid duplicating code.f

This mirrors a fix applied to the [schema code path](https://github.com/swagger-api/swagger-parser/pull/1523) which had the same problem.

Fixes: https://github.com/swagger-api/swagger-parser/issues/2033

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->