### PR TITLE
fix: prevent StringIndexOutOfBoundsException in uniqueName with leading separators

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/InlineModelResolver.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/util/InlineModelResolver.java
@@ -438,14 +438,18 @@ public class InlineModelResolver {
         int count = 0;
         boolean done = false;
         if (camelCaseFlattenNaming) {
-            String uniqueKey;
             String concatenated = "";
-            for (int i = 0; i < key.split("[-|\\s|_]").length; i++) {
-                uniqueKey = key.split("[-|\\s|_]")[i];
+            for (String uniqueKey : key.split("[-|\\s|_]")) {
+                if (uniqueKey.isEmpty()) {
+                    continue;
+                }
                 uniqueKey = uniqueKey.substring(0, 1).toUpperCase() + uniqueKey.substring(1);
                 concatenated = concatenated.concat(uniqueKey);
             }
             key = concatenated.replaceAll("[^a-z_\\.A-Z0-9 ]", ""); // FIXME: a parameter
+            if (key.isEmpty()) {
+                key = "inline_object";
+            }
         }else {
             key = key.replaceAll("[^a-z_\\.A-Z0-9 ]", ""); // FIXME: a parameter
         }

--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/InlineModelResolverTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/util/InlineModelResolverTest.java
@@ -1709,6 +1709,31 @@ public class InlineModelResolverTest {
         assertNotNull(openAPI.getComponents().getSchemas().get("inline_response_200"));
     }
 
+    @Test(description = "https://github.com/swagger-api/swagger-parser/issues/2386")
+    public void testUniqueNameSkipsEmptyTokensFromLeadingSeparators() {
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.setComponents(new Components());
+        InlineModelResolver resolver = new InlineModelResolver(false, true);
+        resolver.flatten(openAPI);
+
+        assertEquals("MyModel", resolver.uniqueName(" my model"));
+        assertEquals("Foo", resolver.uniqueName("-foo"));
+        assertEquals("Foo", resolver.uniqueName("_foo"));
+        assertEquals("FooBar", resolver.uniqueName("foo--bar"));
+        assertEquals("inline_object", resolver.uniqueName(""));
+        assertEquals("inline_object", resolver.uniqueName("---"));
+    }
+
+    @Test(description = "https://github.com/swagger-api/swagger-parser/issues/2386")
+    public void testFlattenSchemaTitleWithLeadingSeparator() {
+        String title = " my model";
+        OpenAPI openAPI = openAPIWithInlineResponseSchema(title);
+
+        new InlineModelResolver(false, true).flatten(openAPI);
+
+        assertFlattenedResponseSchema(openAPI, "MyModel", "#/components/schemas/MyModel");
+    }
+
     @Test(description = "https://github.com/swagger-api/swagger-parser/issues/1200")
     public void testSchemaPropertiesBeingPassedToFlattenedModel() {
         OpenAPI openAPI = new OpenAPI();


### PR DESCRIPTION
## Summary

- Fix `InlineModelResolver.uniqueName()` to skip empty tokens produced by `String.split()` when `camelCaseFlattenNaming` is enabled, preventing `StringIndexOutOfBoundsException` on titles that start with separators (`-`, `_`, `|`, whitespace) or are empty.
- Fall back to `inline_object` when the sanitized camel-case name would otherwise be blank.
- Add unit tests covering leading separators, consecutive separators, empty title, and an end-to-end flatten scenario.

Fixes #2386

## Test plan

- [x] `mvn test` (Java 17)
- [x] New tests: `testUniqueNameSkipsEmptyTokensFromLeadingSeparators`, `testFlattenSchemaTitleWithLeadingSeparator`